### PR TITLE
feat: 초기 세팅(도메인 작업, DB 작업)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+services:
+  mysql:
+    image: mysql:8
+    container_name: ddu-ru-db
+    restart: always
+    ports:
+      - "3311:3306"
+    volumes:
+      - ddu-ru-db-data:/var/lib/mysql
+      - ./db/mysql/init:/docker-entrypoint-initdb.d
+    environment:
+      MYSQL_ROOT_PASSWORD: 1234
+      MYSQL_DATABASE: dduru
+      TZ: Asia/Seoul
+
+volumes:
+  ddu-ru-db-data:

--- a/src/main/java/com/dduru/gildongmu/GildongmuApplication.java
+++ b/src/main/java/com/dduru/gildongmu/GildongmuApplication.java
@@ -2,8 +2,10 @@ package com.dduru.gildongmu;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class GildongmuApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/dduru/gildongmu/auth/domain/User.java
+++ b/src/main/java/com/dduru/gildongmu/auth/domain/User.java
@@ -1,0 +1,61 @@
+package com.dduru.gildongmu.auth.domain;
+
+import com.dduru.gildongmu.auth.enums.AgeGroup;
+import com.dduru.gildongmu.auth.enums.Gender;
+import com.dduru.gildongmu.auth.enums.OauthType;
+import com.dduru.gildongmu.common.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "users")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class User extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(unique = true, nullable = false, length = 255)
+    private String email;
+
+    @Column(nullable = false, length = 50)
+    private String name;
+
+    @Column(name = "profile_image", nullable = false, length = 500)
+    private String profileImage;
+
+    @Column(name = "oauth_id", nullable = false, length = 100)
+    private String oauthId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "oauth_type", nullable = false)
+    private OauthType oauthType;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Gender gender;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "age_group", nullable = false)
+    private AgeGroup ageGroup;
+
+    @Column(name = "phone_number", length = 20)
+    private String phoneNumber;
+
+    @Builder
+    public User(String email, String name, String profileImage, String oauthId,
+                OauthType oauthType, Gender gender, AgeGroup ageGroup, String phoneNumber) {
+        this.email = email;
+        this.name = name;
+        this.profileImage = profileImage;
+        this.oauthId = oauthId;
+        this.oauthType = oauthType;
+        this.gender = gender;
+        this.ageGroup = ageGroup;
+        this.phoneNumber = phoneNumber;
+    }
+}

--- a/src/main/java/com/dduru/gildongmu/auth/enums/AgeGroup.java
+++ b/src/main/java/com/dduru/gildongmu/auth/enums/AgeGroup.java
@@ -1,0 +1,19 @@
+package com.dduru.gildongmu.auth.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum AgeGroup {
+    AGE_10s("10s", "10대"),
+    AGE_20s("20s", "20대"),
+    AGE_30s("30s", "30대"),
+    AGE_40s("40s", "40대"),
+    AGE_50s("50s", "50대"),
+    AGE_60s("60s", "60대"),
+    UNKNOWN("Unknown", "알 수 없음");
+
+    private final String value;
+    private final String description;
+}

--- a/src/main/java/com/dduru/gildongmu/auth/enums/Gender.java
+++ b/src/main/java/com/dduru/gildongmu/auth/enums/Gender.java
@@ -1,0 +1,15 @@
+package com.dduru.gildongmu.auth.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Gender {
+    M("Male", "남성"),
+    F("Female", "여성"),
+    U("Unknown", "알 수 없음");
+
+    private final String englishName;
+    private final String koreanName;
+}

--- a/src/main/java/com/dduru/gildongmu/auth/enums/OauthType.java
+++ b/src/main/java/com/dduru/gildongmu/auth/enums/OauthType.java
@@ -1,0 +1,22 @@
+package com.dduru.gildongmu.auth.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum OauthType {
+    KAKAO("kakao"),
+    GOOGLE("google");
+
+    private final String value;
+
+    public static OauthType fromValue(String value) {
+        for (OauthType type : values()) {
+            if (type.value.equals(value)) {
+                return type;
+            }
+        }
+        throw new IllegalArgumentException("Unknown oauth type: " + value);
+    }
+}

--- a/src/main/java/com/dduru/gildongmu/common/entity/BaseTimeEntity.java
+++ b/src/main/java/com/dduru/gildongmu/common/entity/BaseTimeEntity.java
@@ -1,0 +1,28 @@
+package com.dduru.gildongmu.common.entity;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import jakarta.persistence.*;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
+    @Temporal(TemporalType.TIMESTAMP)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
+    @Temporal(TemporalType.TIMESTAMP)
+    private LocalDateTime modifiedAt;
+}

--- a/src/main/java/com/dduru/gildongmu/post/domain/Post.java
+++ b/src/main/java/com/dduru/gildongmu/post/domain/Post.java
@@ -1,0 +1,101 @@
+package com.dduru.gildongmu.post.domain;
+
+import com.dduru.gildongmu.auth.domain.User;
+import com.dduru.gildongmu.auth.enums.AgeGroup;
+import com.dduru.gildongmu.auth.enums.Gender;
+import com.dduru.gildongmu.common.entity.BaseTimeEntity;
+import com.dduru.gildongmu.post.enums.Destination;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
+
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "posts")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Post extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "destination_id", nullable = false)
+    private Destination destination;
+
+    @Column(nullable = false, length = 100)
+    private String title;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @Column(name = "start_date", nullable = false)
+    private LocalDate startDate;
+
+    @Column(name = "end_date", nullable = false)
+    private LocalDate endDate;
+
+    @Column(name = "recruit_capacity", nullable = false)
+    @ColumnDefault("1")
+    private Integer recruitCapacity = 1;
+
+    @Column(name = "recruit_deadline", nullable = false)
+    private LocalDate recruitDeadline;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "preferred_gender", nullable = false)
+    @ColumnDefault("'U'")
+    private Gender preferredGender = Gender.U;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "preferred_age", nullable = false)
+    @ColumnDefault("'UNKNOWN'")
+    private AgeGroup preferredAge = AgeGroup.UNKNOWN;
+
+    @Column(name = "budget_min")
+    private Integer budgetMin;
+
+    @Column(name = "budget_max")
+    private Integer budgetMax;
+
+    @Column(name = "photo_urls", columnDefinition = "JSON")
+    private String photoUrls;
+
+    @Column(columnDefinition = "JSON")
+    private String tags;
+
+    @Column(name = "view_count", nullable = false)
+    @ColumnDefault("0")
+    private Integer viewCount = 0;
+
+    @Builder
+    public Post(User user, Destination destination, String title, String content,
+                LocalDate startDate, LocalDate endDate, Integer recruitCapacity,
+                LocalDate recruitDeadline, Gender preferredGender, AgeGroup preferredAge,
+                Integer budgetMin, Integer budgetMax, String photoUrls, String tags) {
+        this.user = user;
+        this.destination = destination;
+        this.title = title;
+        this.content = content;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.recruitCapacity = recruitCapacity != null ? recruitCapacity : 1;
+        this.recruitDeadline = recruitDeadline;
+        this.preferredGender = preferredGender != null ? preferredGender : Gender.U;
+        this.preferredAge = preferredAge != null ? preferredAge : AgeGroup.UNKNOWN;
+        this.budgetMin = budgetMin;
+        this.budgetMax = budgetMax;
+        this.photoUrls = photoUrls;
+        this.tags = tags;
+        this.viewCount = 0;
+    }
+}

--- a/src/main/java/com/dduru/gildongmu/post/enums/Destination.java
+++ b/src/main/java/com/dduru/gildongmu/post/enums/Destination.java
@@ -1,0 +1,43 @@
+package com.dduru.gildongmu.post.enums;
+
+import com.dduru.gildongmu.post.domain.Post;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "destinations")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Destination {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "country_code", nullable = false, length = 2)
+    private String countryCode;
+
+    @Column(name = "country_name", nullable = false, length = 100)
+    private String countryName;
+
+    @Column(length = 100)
+    private String region;
+
+    @Column(nullable = false, length = 100)
+    private String city;
+
+    @Column(length = 500)
+    private String image;
+
+    @Builder
+    public Destination(String countryCode, String countryName, String region, String city, String image) {
+        this.countryCode = countryCode;
+        this.countryName = countryName;
+        this.region = region;
+        this.city = city;
+        this.image = image;
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=gildongmu

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,15 @@
+spring:
+  datasource:
+    url: jdbc:mysql://localhost:3306/dduru
+    username: root
+    password: root
+    driver-class-name: com.mysql.cj.jdbc.Driver
+  jpa:
+    database: mysql
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+        use_sql_comments: true


### PR DESCRIPTION
## 🔎 작업 내용
- 공통 엔티티 생성일/수정일 관리 기능 추가
    - BaseTimeEntity 추상 클래스 작성
    - JPA Auditing 기능 적용 (`@CreatedDate`, `@LastModifiedDate`, `AuditingEntityListener`)
- DB 및 JPA 설정 작업
    - `application.yml`에서 MySQL 연결 정보 및 JPA 관련 설정 구성 
- Docker Container 설정
    - `docker-compose.yml` 생성 및 설정

## ➕ 이슈 링크
- #1 
- #2 
- #3 
- #4
