### PR TITLE
feat: 댓글 대댓글 삭제 API 

### DIFF
--- a/src/main/java/com/dduru/gildongmu/comment/controller/CommentApiDocs.java
+++ b/src/main/java/com/dduru/gildongmu/comment/controller/CommentApiDocs.java
@@ -41,6 +41,7 @@ public interface CommentApiDocs {
             @ApiResponse(responseCode = "404", description = "댓글을 찾을 수 없음")
     })
     ResponseEntity<Void> deleteComment(
+            @Parameter(hidden = true) Long userId,
             @Parameter(description = "댓글 ID") Long commentId
     );
 }

--- a/src/main/java/com/dduru/gildongmu/comment/controller/CommentApiDocs.java
+++ b/src/main/java/com/dduru/gildongmu/comment/controller/CommentApiDocs.java
@@ -34,4 +34,13 @@ public interface CommentApiDocs {
     ResponseEntity<List<CommentResponse>> retrieveComments(
             @Parameter(description = "게시글 ID") Long postId
     );
+
+    @Operation(summary = "댓글 삭제", description = "댓글을 삭제합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "삭제 성공"),
+            @ApiResponse(responseCode = "404", description = "댓글을 찾을 수 없음")
+    })
+    ResponseEntity<Void> deleteComment(
+            @Parameter(description = "댓글 ID") Long commentId
+    );
 }

--- a/src/main/java/com/dduru/gildongmu/comment/controller/CommentController.java
+++ b/src/main/java/com/dduru/gildongmu/comment/controller/CommentController.java
@@ -34,4 +34,11 @@ public class CommentController implements CommentApiDocs {
         List<CommentResponse> comments = commentQueryService.retrieve(postId);
         return ResponseEntity.ok(comments);
     }
+
+    @Override
+    @DeleteMapping("/comments/{commentId}")
+    public ResponseEntity<Void> deleteComment(@PathVariable Long commentId) {
+        commentService.delete(commentId);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/dduru/gildongmu/comment/controller/CommentController.java
+++ b/src/main/java/com/dduru/gildongmu/comment/controller/CommentController.java
@@ -37,8 +37,8 @@ public class CommentController implements CommentApiDocs {
 
     @Override
     @DeleteMapping("/comments/{commentId}")
-    public ResponseEntity<Void> deleteComment(@PathVariable Long commentId) {
-        commentService.delete(commentId);
+    public ResponseEntity<Void> deleteComment(@CurrentUser Long userId, @PathVariable Long commentId) {
+        commentService.delete(userId, commentId);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/dduru/gildongmu/comment/domain/Comment.java
+++ b/src/main/java/com/dduru/gildongmu/comment/domain/Comment.java
@@ -9,6 +9,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -40,6 +41,12 @@ public class Comment extends BaseTimeEntity {
     @OneToMany(mappedBy = "parent", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     private List<Comment> children = new ArrayList<>();
 
+    @Column(nullable = false)
+    private boolean deleted = false;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
     @Builder
     public Comment(String content, User user, Post post, Comment parent) {
         this.content = content;
@@ -49,6 +56,11 @@ public class Comment extends BaseTimeEntity {
             this.parent = parent;
             parent.addChildComment(this);
         }
+    }
+
+    public void softdelete() {
+        this.deleted = true;
+        this.deletedAt = LocalDateTime.now();
     }
 
     public static Comment createComment(String content, User user, Post post, Comment parent) {

--- a/src/main/java/com/dduru/gildongmu/comment/dto/CommentResponse.java
+++ b/src/main/java/com/dduru/gildongmu/comment/dto/CommentResponse.java
@@ -23,8 +23,12 @@ public record CommentResponse(
         String author;
         String authorProfileImage;
 
-        if (comment.isDeleted() || comment.getUser() == null) {
+        if (comment.isDeleted()) {
             content = "작성자에 의해 삭제된 댓글입니다.";
+            author = "알 수 없음";
+            authorProfileImage = null;
+        } else if (comment.getUser() == null) {
+            content = "작성자 정보가 없습니다.";
             author = "알 수 없음";
             authorProfileImage = null;
         } else {

--- a/src/main/java/com/dduru/gildongmu/comment/dto/CommentResponse.java
+++ b/src/main/java/com/dduru/gildongmu/comment/dto/CommentResponse.java
@@ -20,17 +20,24 @@ public record CommentResponse(
                 .collect(Collectors.toList());
 
         String content;
-        if (comment.isDeleted()) {
+        String author;
+        String authorProfileImage;
+
+        if (comment.isDeleted() || comment.getUser() == null) {
             content = "작성자에 의해 삭제된 댓글입니다.";
+            author = "알 수 없음";
+            authorProfileImage = null;
         } else {
             content = comment.getContent();
+            author = comment.getUser().getNickname();
+            authorProfileImage = comment.getUser().getProfileImage();
         }
 
         return new CommentResponse(
                 comment.getId(),
                 content,
-                comment.getUser().getNickname(),
-                comment.getUser().getProfileImage(),
+                author,
+                authorProfileImage,
                 comment.getCreatedAt(),
                 childrenResponses
         );

--- a/src/main/java/com/dduru/gildongmu/comment/dto/CommentResponse.java
+++ b/src/main/java/com/dduru/gildongmu/comment/dto/CommentResponse.java
@@ -19,15 +19,18 @@ public record CommentResponse(
                 .map(CommentResponse::from)
                 .collect(Collectors.toList());
 
-        String author = comment.getUser().getNickname();
-        String profileImage = comment.getUser().getProfileImage();
-        String content = comment.getContent();
+        String content;
+        if (comment.isDeleted()) {
+            content = "작성자에 의해 삭제된 댓글입니다.";
+        } else {
+            content = comment.getContent();
+        }
 
         return new CommentResponse(
                 comment.getId(),
                 content,
-                author,
-                profileImage,
+                comment.getUser().getNickname(),
+                comment.getUser().getProfileImage(),
                 comment.getCreatedAt(),
                 childrenResponses
         );

--- a/src/main/java/com/dduru/gildongmu/comment/exception/CommentAccessDeniedException.java
+++ b/src/main/java/com/dduru/gildongmu/comment/exception/CommentAccessDeniedException.java
@@ -1,0 +1,20 @@
+package com.dduru.gildongmu.comment.exception;
+
+import com.dduru.gildongmu.common.exception.BusinessException;
+import com.dduru.gildongmu.common.exception.ErrorCode;
+
+public class CommentAccessDeniedException extends BusinessException {
+    public CommentAccessDeniedException() {
+        super(ErrorCode.COMMENT_ACCESS_DENIED, "댓글에 대한 접근 권한이 없습니다");
+    }
+
+    public CommentAccessDeniedException(String message) {
+        super(ErrorCode.COMMENT_ACCESS_DENIED, message);
+    }
+
+    public static CommentAccessDeniedException ownerOnly() {
+        return new CommentAccessDeniedException("댓글 작성자만 접근할 수 있습니다");
+    }
+}
+
+

--- a/src/main/java/com/dduru/gildongmu/comment/repository/CommentRepository.java
+++ b/src/main/java/com/dduru/gildongmu/comment/repository/CommentRepository.java
@@ -3,5 +3,8 @@ package com.dduru.gildongmu.comment.repository;
 import com.dduru.gildongmu.comment.domain.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface CommentRepository extends JpaRepository<Comment, Long>, CommentRepositoryCustom {
+    Optional<Comment> findByIdAndDeletedFalse(Long id);
 }

--- a/src/main/java/com/dduru/gildongmu/comment/service/CommentQueryService.java
+++ b/src/main/java/com/dduru/gildongmu/comment/service/CommentQueryService.java
@@ -38,6 +38,7 @@ public class CommentQueryService {
         }
 
         return rootComments.stream()
+                .filter(comment -> !comment.isDeleted() || !comment.getChildren().isEmpty())
                 .map(CommentResponse::from)
                 .toList();
     }

--- a/src/main/java/com/dduru/gildongmu/comment/service/CommentService.java
+++ b/src/main/java/com/dduru/gildongmu/comment/service/CommentService.java
@@ -35,6 +35,14 @@ public class CommentService {
         return CommentResponse.from(savedComment);
     }
 
+    @Transactional
+    public void delete(Long commentId) {
+        Comment comment = commentRepository.findByIdAndDeletedFalse(commentId)
+                .orElseThrow(() -> CommentNotFoundException.of(commentId));
+
+        comment.softdelete();
+    }
+
     private Comment getValidParentComment(Long parentId, Long postId) {
         if (parentId == null || parentId == 0L) {
             return null;

--- a/src/main/java/com/dduru/gildongmu/comment/service/CommentService.java
+++ b/src/main/java/com/dduru/gildongmu/comment/service/CommentService.java
@@ -3,6 +3,7 @@ package com.dduru.gildongmu.comment.service;
 import com.dduru.gildongmu.comment.domain.Comment;
 import com.dduru.gildongmu.comment.dto.CommentCreateRequest;
 import com.dduru.gildongmu.comment.dto.CommentResponse;
+import com.dduru.gildongmu.comment.exception.CommentAccessDeniedException;
 import com.dduru.gildongmu.comment.exception.CommentNotFoundException;
 import com.dduru.gildongmu.comment.exception.InvalidParentCommentException;
 import com.dduru.gildongmu.comment.repository.CommentRepository;
@@ -11,11 +12,12 @@ import com.dduru.gildongmu.post.repository.PostRepository;
 import com.dduru.gildongmu.user.domain.User;
 import com.dduru.gildongmu.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Objects;
-
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class CommentService {
@@ -36,11 +38,19 @@ public class CommentService {
     }
 
     @Transactional
-    public void delete(Long commentId) {
+    public void delete(Long userId, Long commentId) {
         Comment comment = commentRepository.findByIdAndDeletedFalse(commentId)
                 .orElseThrow(() -> CommentNotFoundException.of(commentId));
 
+        validatePermission(comment, userId);
         comment.softdelete();
+    }
+
+    private void validatePermission(Comment comment, Long userId) {
+        if (!comment.getUser().getId().equals(userId)) {
+            log.warn("댓글 권한 없음 - commentId: {}, userId: {}, ownerId: {}", comment.getId(), userId, comment.getUser().getId());
+            throw CommentAccessDeniedException.ownerOnly();
+        }
     }
 
     private Comment getValidParentComment(Long parentId, Long postId) {

--- a/src/main/java/com/dduru/gildongmu/common/exception/ErrorCode.java
+++ b/src/main/java/com/dduru/gildongmu/common/exception/ErrorCode.java
@@ -34,7 +34,7 @@ public enum ErrorCode {
     // 댓글 관련
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMENT_001", "댓글을 찾을 수 없습니다."),
     INVALID_PARENT_COMMENT(HttpStatus.BAD_REQUEST, "COMMENT_002", "부모 댓글이 현재 게시글에 속해있지 않습니다."),
-    COMMENT_ACCESS_DENIED(HttpStatus.FORBIDDEN, "COMMENT_003", "댓글에 대한 접근 권한이 없습니다"),
+    COMMENT_ACCESS_DENIED(HttpStatus.FORBIDDEN, "COMMENT_003", "댓글에 대한 접근 권한이 없습니다."),
 
     // 여행지 관련
     DESTINATION_NOT_FOUND(HttpStatus.NOT_FOUND, "DEST_001", "여행지를 찾을 수 없습니다"),

--- a/src/main/java/com/dduru/gildongmu/common/exception/ErrorCode.java
+++ b/src/main/java/com/dduru/gildongmu/common/exception/ErrorCode.java
@@ -34,6 +34,7 @@ public enum ErrorCode {
     // 댓글 관련
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMENT_001", "댓글을 찾을 수 없습니다."),
     INVALID_PARENT_COMMENT(HttpStatus.BAD_REQUEST, "COMMENT_002", "부모 댓글이 현재 게시글에 속해있지 않습니다."),
+    COMMENT_ACCESS_DENIED(HttpStatus.FORBIDDEN, "COMMENT_003", "댓글에 대한 접근 권한이 없습니다"),
 
     // 여행지 관련
     DESTINATION_NOT_FOUND(HttpStatus.NOT_FOUND, "DEST_001", "여행지를 찾을 수 없습니다"),


### PR DESCRIPTION
## 🔎 작업 내용
* soft delete를 이용해서 댓글 삭제하는 API 추가
* 작성자 본인이 삭제할수 있게 권한 확인
* 대댓글이 있는 댓글을 삭제할경우 "작성자가 삭제한 메시지입니다" 메시지 보여줌
## ➕ 이슈 링크
* #93 

## 📸 스크린샷(선택)


## 😎 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 
<!--ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?-->
## 🧑‍💻 예정 작업
- #94 

## 📝 체크리스트
- [x] 브랜치 이름은 `feature/개발내용` 형식으로 작성했는가?
- [x] 커밋 메시지는 `feat: 커밋 내용` 형식으로 작성했는가?
- [x] 작업 전 Issue를 작성했는가?
- [x] `dev` 브랜치로 병합을 요청했는가?
- [x] 불필요한 주석과 공백은 제거했는가?
- [ ] 코드 리뷰어의 피드백을 반영했는가?
- [x] 테스트를 진행했는가?
- [ ] 테스트 코드를 작성했는가?
- 
