### PR TITLE
feat: 신규 유저 구분 및 닉네임 처리 변경

### DIFF
--- a/src/main/java/com/dduru/gildongmu/auth/dto/LoginResponse.java
+++ b/src/main/java/com/dduru/gildongmu/auth/dto/LoginResponse.java
@@ -5,12 +5,14 @@ import lombok.Builder;
 @Builder
 public record LoginResponse(
         String accessToken,
-        String refreshToken
+        String refreshToken,
+        Boolean isNewUser
 ) {
-    public static LoginResponse of(String accessToken, String refreshToken) {
+    public static LoginResponse of(String accessToken, String refreshToken, Boolean isNewUser) {
         return new LoginResponse(
                 accessToken,
-                refreshToken
+                refreshToken,
+                isNewUser
         );
     }
 }

--- a/src/main/java/com/dduru/gildongmu/auth/service/OauthAuthService.java
+++ b/src/main/java/com/dduru/gildongmu/auth/service/OauthAuthService.java
@@ -10,6 +10,7 @@ import com.dduru.gildongmu.auth.exception.UserNotFoundException;
 import com.dduru.gildongmu.common.jwt.JwtTokenProvider;
 import com.dduru.gildongmu.user.domain.User;
 import com.dduru.gildongmu.user.enums.OauthType;
+import com.dduru.gildongmu.user.enums.Role;
 import com.dduru.gildongmu.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -145,6 +146,7 @@ public class OauthAuthService {
                 .profileImage(oauthUserInfo.profileImage())
                 .oauthId(oauthUserInfo.oauthId())
                 .oauthType(oauthUserInfo.loginType())
+                .role(Role.USER)
                 .gender(null)
                 .phoneNumber(null)
                 .birthday(null)

--- a/src/main/java/com/dduru/gildongmu/auth/service/OauthAuthService.java
+++ b/src/main/java/com/dduru/gildongmu/auth/service/OauthAuthService.java
@@ -36,12 +36,15 @@ public class OauthAuthService {
     }
 
     private LoginResponse createLoginResponse(OauthUserInfo oauthUserInfo) {
-        User user = findOrCreateUser(oauthUserInfo);
+        UserCreationResult result = findOrCreateUser(oauthUserInfo);
+        User user = result.user();
+        boolean isNewUser = result.isNewUser();
+        
         String jwtToken = jwtTokenProvider.createToken(user.getId());
         String refreshToken = jwtTokenProvider.createRefreshToken(user.getId());
 
         refreshTokenService.saveRefreshToken(user.getId(), refreshToken);
-        return LoginResponse.of(jwtToken, refreshToken);
+        return LoginResponse.of(jwtToken, refreshToken, isNewUser);
     }
 
     public LoginResponse refreshAccessToken(String refreshToken) {
@@ -76,7 +79,7 @@ public class OauthAuthService {
 
         extendTokenExpirationSafely(userId);
 
-        return LoginResponse.of(newAccessToken, refreshToken);
+        return LoginResponse.of(newAccessToken, refreshToken, false);
     }
 
     public void logout(Long userId) {
@@ -109,14 +112,14 @@ public class OauthAuthService {
         }
     }
 
-    private User findOrCreateUser(OauthUserInfo oauthUserInfo) {
+    private UserCreationResult findOrCreateUser(OauthUserInfo oauthUserInfo) {
         Optional<User> existingUser = userRepository.findByOauthIdAndOauthType(
                 oauthUserInfo.oauthId(),
                 oauthUserInfo.loginType()
         );
 
         if (existingUser.isPresent()) {
-            return existingUser.get();
+            return new UserCreationResult(existingUser.get(), false);
         }
 
         if (userRepository.existsByEmail(oauthUserInfo.email())) {
@@ -124,16 +127,21 @@ public class OauthAuthService {
             throw new IllegalArgumentException("이미 다른 소셜 계정으로 가입된 이메일입니다: " + oauthUserInfo.email());
         }
 
-        return createNewUser(oauthUserInfo);
+        User newUser = createNewUser(oauthUserInfo);
+        return new UserCreationResult(newUser, true);
+    }
+
+    private record UserCreationResult(User user, boolean isNewUser) {
     }
 
     private User createNewUser(OauthUserInfo oauthUserInfo) {
         // 추가 정보는 회원가입 이후 별도 입력으로 변경
+        // 닉네임은 온보딩에서 설정하므로 null로 초기화
 
         User newUser = User.builder()
                 .email(oauthUserInfo.email())
                 .name(oauthUserInfo.name())
-                .nickname(oauthUserInfo.name())
+                .nickname(null)
                 .profileImage(oauthUserInfo.profileImage())
                 .oauthId(oauthUserInfo.oauthId())
                 .oauthType(oauthUserInfo.loginType())

--- a/src/main/java/com/dduru/gildongmu/user/domain/User.java
+++ b/src/main/java/com/dduru/gildongmu/user/domain/User.java
@@ -2,6 +2,7 @@ package com.dduru.gildongmu.user.domain;
 
 import com.dduru.gildongmu.user.enums.Gender;
 import com.dduru.gildongmu.user.enums.OauthType;
+import com.dduru.gildongmu.user.enums.Role;
 import com.dduru.gildongmu.common.entity.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -40,6 +41,10 @@ public class User extends BaseTimeEntity {
     private OauthType oauthType;
 
     @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Role role = Role.USER;
+
+    @Enumerated(EnumType.STRING)
     private Gender gender;
 
     // AgeRange는 사용하지 않으므로 주석 처리
@@ -55,13 +60,14 @@ public class User extends BaseTimeEntity {
 
     @Builder
     public User(String email, String name, String nickname, String profileImage, String oauthId,
-                OauthType oauthType, Gender gender, /* AgeRange ageRange, */ String phoneNumber, LocalDate birthday) {
+                OauthType oauthType, Role role, Gender gender, /* AgeRange ageRange, */ String phoneNumber, LocalDate birthday) {
         this.email = email;
         this.name = name;
         this.nickname = nickname;
         this.profileImage = profileImage;
         this.oauthId = oauthId;
         this.oauthType = oauthType;
+        this.role = role != null ? role : Role.USER;
         this.gender = gender;
         // this.ageRange = ageRange;
         this.phoneNumber = phoneNumber;

--- a/src/main/java/com/dduru/gildongmu/user/enums/Role.java
+++ b/src/main/java/com/dduru/gildongmu/user/enums/Role.java
@@ -1,0 +1,10 @@
+package com.dduru.gildongmu.user.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Role {
+    USER, ADMIN;
+}


### PR DESCRIPTION
## 🔎 작업 내용
* 신규 유저 구분 불가-> LoginResponse에 isNewUser 필드 추가(boolean)
```json
{ 
	"accessToken": "<JWT 토큰>", 
	"refreshToken": "",
	"isNewUser": true  // 추가
}
```
* 소셜 회원가입 시 `nickname` 필드는 DB에 `null`로 저장(이후 온보딩 과정에서 받아올 예정)
* role 추가 (USER,ADMIN) : 기본적으로 USER 값으로 저장, ADMIN 역할은 초기 DB에서 직접 수정하는 방향 고려

## ➕ 이슈 링크
* Closed #114 

## 📸 스크린샷(선택)


## 😎 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 
<!--ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?-->
## 🧑‍💻 예정 작업
- #

## 📝 체크리스트
- [x] 브랜치 이름은 `feature/개발내용` 형식으로 작성했는가?
- [x] 커밋 메시지는 `feat: 커밋 내용` 형식으로 작성했는가?
- [x] 작업 전 Issue를 작성했는가?
- [x] `dev` 브랜치로 병합을 요청했는가?
- [x] 불필요한 주석과 공백은 제거했는가?
- [x] 코드 리뷰어의 피드백을 반영했는가?
- [x] 테스트를 진행했는가?
- [ ] 테스트 코드를 작성했는가?
- 
