### PR TITLE
refactor: BusinessException 간소화 작업 및 필드 에러 처리 분리

### DIFF
--- a/src/main/java/com/dduru/gildongmu/common/exception/BusinessException.java
+++ b/src/main/java/com/dduru/gildongmu/common/exception/BusinessException.java
@@ -5,19 +5,14 @@ import lombok.Getter;
 @Getter
 public class BusinessException extends RuntimeException {
     private final ErrorCode errorCode;
-    private final String field;
 
     public BusinessException(ErrorCode errorCode) {
-        this(errorCode, null, null);
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
     }
 
     public BusinessException(ErrorCode errorCode, String message) {
-        this(errorCode, message, null);
-    }
-
-    public BusinessException(ErrorCode errorCode, String message, String field) {
-        super(message);
+        super(message != null ? message : errorCode.getMessage());
         this.errorCode = errorCode;
-        this.field = field;
     }
 }

--- a/src/main/java/com/dduru/gildongmu/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/dduru/gildongmu/common/exception/GlobalExceptionHandler.java
@@ -18,11 +18,7 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponse> handleBusinessException(BusinessException e) {
         log.error("Business Exception: {}", e.getMessage());
         ErrorCode errorCode = e.getErrorCode();
-
-        ErrorResponse response = e.getField() == null
-                ? ErrorResponse.of(errorCode, e.getMessage())
-                : ErrorResponse.ofField(errorCode, e.getField(), e.getMessage());
-
+        ErrorResponse response = ErrorResponse.of(errorCode, e.getMessage());
         return ResponseEntity.status(errorCode.getStatus()).body(response);
     }
 


### PR DESCRIPTION
## 🔎 작업 내용
* `BusinessException` 클래스에서 field 프로퍼티와 관련 생성자를 제거해 예외 구조를 단순화
* `BusinessException`에 대해 `GlobalExceptionHandler`가 항상 ErrorResponse.of를 사용하도록 수정
    * 필드 유효성 등의 문제로 에러 시 분리 작업하기 위함. 
    ex. `MethodArgumentNotValidException`, `ConstraintViolationException` 에러 분리

전반적으로 비즈니스 예외 처리 흐름을 단순화하고 불필요한 복잡도를 줄였습니다.

## ➕ 이슈 링크
* Closed #111 

## 🧑‍💻 예정 작업
- #104 **에러 처리 변경 작업**

## 📝 체크리스트
- [x] 브랜치 이름은 `feature/개발내용` 형식으로 작성했는가?
- [x] 커밋 메시지는 `feat: 커밋 내용` 형식으로 작성했는가?
- [x] 작업 전 Issue를 작성했는가?
- [x] `dev` 브랜치로 병합을 요청했는가?
- [x] 불필요한 주석과 공백은 제거했는가?
- [x] 코드 리뷰어의 피드백을 반영했는가?
- [x] 테스트를 진행했는가?
- [ ] 테스트 코드를 작성했는가?
- 
