### PR TITLE
feat: CoolSMS를 이용한 휴대폰 인증 API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,8 @@ dependencies {
 	//S3
 	implementation 'software.amazon.awssdk:s3:2.20.26'
 	implementation 'software.amazon.awssdk:auth:2.20.26'
+	//CoolSMS
+	implementation 'net.nurigo:sdk:4.3.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/dduru/gildongmu/S3/controller/S3Controller.java
+++ b/src/main/java/com/dduru/gildongmu/S3/controller/S3Controller.java
@@ -5,6 +5,7 @@ import com.dduru.gildongmu.S3.dto.ImageUploadResponse;
 import com.dduru.gildongmu.S3.service.S3Service;
 import com.dduru.gildongmu.common.dto.ApiResult;
 import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -14,6 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/images")
+@ConditionalOnProperty(prefix = "aws.s3", name = "enabled", havingValue = "true", matchIfMissing = true)
 public class S3Controller implements S3ApiDocs {
     private final S3Service s3Service;
 

--- a/src/main/java/com/dduru/gildongmu/S3/service/S3Service.java
+++ b/src/main/java/com/dduru/gildongmu/S3/service/S3Service.java
@@ -6,6 +6,7 @@ import com.dduru.gildongmu.S3.exception.InvalidFileExtensionException;
 import java.time.Duration;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
@@ -18,6 +19,7 @@ import java.util.UUID;
 
 @Slf4j
 @Service
+@ConditionalOnProperty(prefix = "aws.s3", name = "enabled", havingValue = "true", matchIfMissing = true)
 @RequiredArgsConstructor
 public class S3Service {
 

--- a/src/main/java/com/dduru/gildongmu/common/annotation/CommonApiResponses.java
+++ b/src/main/java/com/dduru/gildongmu/common/annotation/CommonApiResponses.java
@@ -1,0 +1,104 @@
+package com.dduru.gildongmu.common.annotation;
+
+import com.dduru.gildongmu.common.exception.ErrorResponse;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@ApiResponses({
+        @ApiResponse(
+                responseCode = "400",
+                description = "잘못된 요청",
+                content = @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(implementation = ErrorResponse.class),
+                        examples = @ExampleObject(
+                                name = "InvalidInput",
+                                value = """
+                                        {
+                                          "status": 400,
+                                          "data": {
+                                            "errorCode": "INVALID_INPUT_VALUE",
+                                            "field": null,
+                                            "message": "잘못된 입력 값입니다."
+                                          }
+                                        }
+                                        """
+                        )
+                )
+        ),
+        @ApiResponse(
+                responseCode = "401",
+                description = "인증 실패",
+                content = @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(implementation = ErrorResponse.class),
+                        examples = @ExampleObject(
+                                name = "Unauthorized",
+                                value = """
+                                        {
+                                          "status": 401,
+                                          "data": {
+                                            "errorCode": "UNAUTHORIZED",
+                                            "field": null,
+                                            "message": "인증되지 않은 사용자입니다."
+                                          }
+                                        }
+                                        """
+                        )
+                )
+        ),
+        @ApiResponse(
+                responseCode = "404",
+                description = "리소스를 찾을 수 없음",
+                content = @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(implementation = ErrorResponse.class),
+                        examples = @ExampleObject(
+                                name = "NotFound",
+                                value = """
+                                        {
+                                          "status": 404,
+                                          "data": {
+                                            "errorCode": "NOT_FOUND",
+                                            "field": null,
+                                            "message": "요청한 리소스를 찾을 수 없습니다."
+                                          }
+                                        }
+                                        """
+                        )
+                )
+        ),
+        @ApiResponse(
+                responseCode = "500",
+                description = "서버 오류",
+                content = @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(implementation = ErrorResponse.class),
+                        examples = @ExampleObject(
+                                name = "InternalServerError",
+                                value = """
+                                        {
+                                          "status": 500,
+                                          "data": {
+                                            "errorCode": "INTERNAL_SERVER_ERROR",
+                                            "field": null,
+                                            "message": "서버 오류가 발생했습니다."
+                                          }
+                                        }
+                                        """
+                        )
+                )
+        )
+})
+public @interface CommonApiResponses {
+}

--- a/src/main/java/com/dduru/gildongmu/common/exception/ErrorCode.java
+++ b/src/main/java/com/dduru/gildongmu/common/exception/ErrorCode.java
@@ -63,6 +63,19 @@ public enum ErrorCode {
     // 설문 (SURVEY)
     UNKNOWN_SURVEY_ANSWER_CODE(HttpStatus.BAD_REQUEST, "알 수 없는 설문조사 답변 코드입니다."),
 
+    // 휴대폰 인증 (VERIFICATION)
+    SMS_SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "SMS 발송에 실패했습니다."),
+    INVALID_AUTH_CODE(HttpStatus.BAD_REQUEST, "인증번호가 일치하지 않습니다."),
+    VERIFICATION_EXPIRED(HttpStatus.BAD_REQUEST, "인증번호가 만료되었습니다."),
+    TOO_MANY_REQUESTS(HttpStatus.TOO_MANY_REQUESTS, "재발송 제한 시간이 지나지 않았습니다."),
+    VERIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "인증 정보를 찾을 수 없습니다."),
+    VERIFICATION_ATTEMPTS_EXCEEDED(HttpStatus.BAD_REQUEST, "검증 시도 횟수를 초과했습니다."),
+    ALREADY_VERIFIED(HttpStatus.CONFLICT, "이미 완료된 인증입니다."),
+    PHONE_NUMBER_MISMATCH(HttpStatus.BAD_REQUEST, "인증 요청한 번호와 검증하려는 번호가 일치하지 않습니다."),
+    DAILY_SMS_LIMIT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "일일 SMS 발송 한도를 초과했습니다."),
+    DUPLICATE_PHONE_NUMBER(HttpStatus.CONFLICT, "이미 가입된 전화번호입니다."),
+    SMS_PROVIDER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "SMS 서비스에 일시적인 오류가 발생했습니다."),
+
     // 공통 (COMMON)
     INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "잘못된 입력 값입니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류가 발생했습니다."),

--- a/src/main/java/com/dduru/gildongmu/common/exception/ErrorCode.java
+++ b/src/main/java/com/dduru/gildongmu/common/exception/ErrorCode.java
@@ -66,12 +66,10 @@ public enum ErrorCode {
     // 휴대폰 인증 (VERIFICATION)
     SMS_SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "SMS 발송에 실패했습니다."),
     INVALID_AUTH_CODE(HttpStatus.BAD_REQUEST, "인증번호가 일치하지 않습니다."),
-    VERIFICATION_EXPIRED(HttpStatus.BAD_REQUEST, "인증번호가 만료되었습니다."),
     TOO_MANY_REQUESTS(HttpStatus.TOO_MANY_REQUESTS, "재발송 제한 시간이 지나지 않았습니다."),
     VERIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "인증 정보를 찾을 수 없습니다."),
     VERIFICATION_ATTEMPTS_EXCEEDED(HttpStatus.BAD_REQUEST, "검증 시도 횟수를 초과했습니다."),
     ALREADY_VERIFIED(HttpStatus.CONFLICT, "이미 완료된 인증입니다."),
-    PHONE_NUMBER_MISMATCH(HttpStatus.BAD_REQUEST, "인증 요청한 번호와 검증하려는 번호가 일치하지 않습니다."),
     DAILY_SMS_LIMIT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "일일 SMS 발송 한도를 초과했습니다."),
     DUPLICATE_PHONE_NUMBER(HttpStatus.CONFLICT, "이미 가입된 전화번호입니다."),
     SMS_PROVIDER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "SMS 서비스에 일시적인 오류가 발생했습니다."),

--- a/src/main/java/com/dduru/gildongmu/common/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/dduru/gildongmu/common/jwt/JwtTokenProvider.java
@@ -108,7 +108,7 @@ public class JwtTokenProvider {
     }
 
     public String createVerificationToken(String phoneNumber) {
-        Date expiryDate = new Date(System.currentTimeMillis() + jwtExpirationMs); // Access Token과 동일한 만료 시간 사용
+        Date expiryDate = new Date(System.currentTimeMillis() + jwtExpirationMs);
 
         return Jwts.builder()
                 .setSubject(phoneNumber)

--- a/src/main/java/com/dduru/gildongmu/common/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/dduru/gildongmu/common/jwt/JwtTokenProvider.java
@@ -107,6 +107,18 @@ public class JwtTokenProvider {
         }
     }
 
+    public String createVerificationToken(String phoneNumber) {
+        Date expiryDate = new Date(System.currentTimeMillis() + jwtExpirationMs); // Access Token과 동일한 만료 시간 사용
+
+        return Jwts.builder()
+                .setSubject(phoneNumber)
+                .claim("type", "verification")
+                .setIssuedAt(new Date())
+                .setExpiration(expiryDate)
+                .signWith(SignatureAlgorithm.HS512, jwtSecret)
+                .compact();
+    }
+
     private Claims getClaims(String token) {
         return Jwts.parser()
                 .setSigningKey(jwtSecret)

--- a/src/main/java/com/dduru/gildongmu/common/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/dduru/gildongmu/common/jwt/JwtTokenProvider.java
@@ -107,12 +107,15 @@ public class JwtTokenProvider {
         }
     }
 
-    public String createVerificationToken(String phoneNumber) {
+    public String createVerificationToken(Long userId, String phoneNumber) {
         Date expiryDate = new Date(System.currentTimeMillis() + jwtExpirationMs);
 
+        String subject = userId != null ? userId.toString() : phoneNumber;
+
         return Jwts.builder()
-                .setSubject(phoneNumber)
+                .setSubject(subject)
                 .claim("type", "verification")
+                .claim("phone_number", phoneNumber)
                 .setIssuedAt(new Date())
                 .setExpiration(expiryDate)
                 .signWith(SignatureAlgorithm.HS512, jwtSecret)

--- a/src/main/java/com/dduru/gildongmu/config/S3Config.java
+++ b/src/main/java/com/dduru/gildongmu/config/S3Config.java
@@ -1,6 +1,7 @@
 package com.dduru.gildongmu.config;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -17,6 +18,7 @@ public class S3Config {
     private final S3Properties s3Properties;
 
     @Bean
+    @ConditionalOnProperty(prefix = "aws.s3", name = "enabled", havingValue = "true", matchIfMissing = true)
     public S3Presigner s3Presigner() {
         AwsBasicCredentials credentials = AwsBasicCredentials.create(s3Properties.getAccessKey(), s3Properties.getSecretKey());
         return S3Presigner.builder()

--- a/src/main/java/com/dduru/gildongmu/config/SecurityConfig.java
+++ b/src/main/java/com/dduru/gildongmu/config/SecurityConfig.java
@@ -35,6 +35,7 @@ public class SecurityConfig {
                         /* API 권한 설정 */
                         .requestMatchers("/api/v1/auth/logout").authenticated()
                         .requestMatchers("/api/v1/auth/**").permitAll()
+                        .requestMatchers("/api/v1/verifications/**").permitAll()
                         .requestMatchers("/login/page", "/test/login/oauth2/code/**").permitAll()
 
                         /* Swagger, 정적 리소스, Actuator 권한 설정 */

--- a/src/main/java/com/dduru/gildongmu/user/repository/UserRepository.java
+++ b/src/main/java/com/dduru/gildongmu/user/repository/UserRepository.java
@@ -20,4 +20,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
     }
 
     boolean existsByNickname(String nickname);
+    boolean existsByPhoneNumber(String phoneNumber);
 }

--- a/src/main/java/com/dduru/gildongmu/verification/controller/PhoneVerificationApiDocs.java
+++ b/src/main/java/com/dduru/gildongmu/verification/controller/PhoneVerificationApiDocs.java
@@ -1,0 +1,41 @@
+package com.dduru.gildongmu.verification.controller;
+
+import com.dduru.gildongmu.common.dto.ApiResult;
+import com.dduru.gildongmu.verification.dto.VerificationSendRequest;
+import com.dduru.gildongmu.verification.dto.VerificationSendResponse;
+import com.dduru.gildongmu.verification.dto.VerificationVerifyRequest;
+import com.dduru.gildongmu.verification.dto.VerificationVerifyResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "Phone Verification", description = "휴대폰 인증 API")
+public interface PhoneVerificationApiDocs {
+
+    @Operation(summary = "인증번호 발송", description = "전화번호로 인증번호를 발송합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "인증번호 발송 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 전화번호 형식"),
+            @ApiResponse(responseCode = "409", description = "이미 가입된 전화번호"),
+            @ApiResponse(responseCode = "429", description = "재발송 제한 또는 일일 발송 한도 초과"),
+            @ApiResponse(responseCode = "500", description = "SMS 발송 실패")
+    })
+    ResponseEntity<ApiResult<VerificationSendResponse>> sendVerificationCode(
+            @Valid @RequestBody VerificationSendRequest request
+    );
+
+    @Operation(summary = "인증번호 검증", description = "발송된 인증번호를 검증하고 인증 토큰을 발급합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "인증번호 검증 성공"),
+            @ApiResponse(responseCode = "400", description = "인증번호 불일치 또는 검증 시도 횟수 초과"),
+            @ApiResponse(responseCode = "404", description = "인증 정보를 찾을 수 없음"),
+            @ApiResponse(responseCode = "409", description = "이미 완료된 인증")
+    })
+    ResponseEntity<ApiResult<VerificationVerifyResponse>> verifyCode(
+            @Valid @RequestBody VerificationVerifyRequest request
+    );
+}

--- a/src/main/java/com/dduru/gildongmu/verification/controller/PhoneVerificationApiDocs.java
+++ b/src/main/java/com/dduru/gildongmu/verification/controller/PhoneVerificationApiDocs.java
@@ -1,5 +1,6 @@
 package com.dduru.gildongmu.verification.controller;
 
+import com.dduru.gildongmu.common.annotation.CommonApiResponses;
 import com.dduru.gildongmu.common.dto.ApiResult;
 import com.dduru.gildongmu.common.exception.ErrorResponse;
 import com.dduru.gildongmu.verification.dto.VerificationSendRequest;
@@ -21,6 +22,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 public interface PhoneVerificationApiDocs {
 
     @Operation(summary = "인증번호 발송", description = "전화번호로 인증번호를 발송합니다.")
+    @CommonApiResponses
     @ApiResponses({
             @ApiResponse(
                     responseCode = "200",
@@ -28,27 +30,6 @@ public interface PhoneVerificationApiDocs {
                     content = @Content(
                             mediaType = "application/json",
                             schema = @Schema(implementation = VerificationSendResponse.class)
-                    )
-            ),
-            @ApiResponse(
-                    responseCode = "400",
-                    description = "잘못된 전화번호 형식",
-                    content = @Content(
-                            mediaType = "application/json",
-                            schema = @Schema(implementation = ErrorResponse.class),
-                            examples = @ExampleObject(
-                                    name = "InvalidPhoneNumber",
-                                    value = """
-                                            {
-                                              "status": 400,
-                                              "data": {
-                                                "code": "INVALID_INPUT_VALUE",
-                                                "field": "phoneNumber",
-                                                "message": "전화번호 형식이 올바르지 않습니다."
-                                              }
-                                            }
-                                            """
-                            )
                     )
             ),
             @ApiResponse(
@@ -63,7 +44,7 @@ public interface PhoneVerificationApiDocs {
                                             {
                                               "status": 409,
                                               "data": {
-                                                "code": "DUPLICATE_PHONE_NUMBER",
+                                                "errorCode": "DUPLICATE_PHONE_NUMBER",
                                                 "field": null,
                                                 "message": "이미 가입된 전화번호입니다. 로그인해주세요."
                                               }
@@ -85,7 +66,7 @@ public interface PhoneVerificationApiDocs {
                                                     {
                                                       "status": 429,
                                                       "data": {
-                                                        "code": "TOO_MANY_REQUESTS",
+                                                        "errorCode": "TOO_MANY_REQUESTS",
                                                         "field": null,
                                                         "message": "재발송 제한 시간이 지나지 않았습니다."
                                                       }
@@ -98,7 +79,7 @@ public interface PhoneVerificationApiDocs {
                                                     {
                                                       "status": 429,
                                                       "data": {
-                                                        "code": "DAILY_SMS_LIMIT_EXCEEDED",
+                                                        "errorCode": "DAILY_SMS_LIMIT_EXCEEDED",
                                                         "field": null,
                                                         "message": "일일 SMS 발송 한도를 초과했습니다."
                                                       }
@@ -107,27 +88,6 @@ public interface PhoneVerificationApiDocs {
                                     )
                             }
                     )
-            ),
-            @ApiResponse(
-                    responseCode = "500",
-                    description = "SMS 발송 실패",
-                    content = @Content(
-                            mediaType = "application/json",
-                            schema = @Schema(implementation = ErrorResponse.class),
-                            examples = @ExampleObject(
-                                    name = "SmsProviderError",
-                                    value = """
-                                            {
-                                              "status": 500,
-                                              "data": {
-                                                "code": "SMS_PROVIDER_ERROR",
-                                                "field": null,
-                                                "message": "SMS 서비스에 일시적인 오류가 발생했습니다."
-                                              }
-                                            }
-                                            """
-                            )
-                    )
             )
     })
     ResponseEntity<ApiResult<VerificationSendResponse>> sendVerificationCode(
@@ -135,6 +95,7 @@ public interface PhoneVerificationApiDocs {
     );
 
     @Operation(summary = "인증번호 검증", description = "발송된 인증번호를 검증하고 인증 토큰을 발급합니다.")
+    @CommonApiResponses
     @ApiResponses({
             @ApiResponse(
                     responseCode = "200",
@@ -157,7 +118,7 @@ public interface PhoneVerificationApiDocs {
                                                     {
                                                       "status": 400,
                                                       "data": {
-                                                        "code": "INVALID_AUTH_CODE",
+                                                        "errorCode": "INVALID_AUTH_CODE",
                                                         "field": null,
                                                         "message": "인증번호가 일치하지 않습니다."
                                                       }
@@ -170,7 +131,7 @@ public interface PhoneVerificationApiDocs {
                                                     {
                                                       "status": 400,
                                                       "data": {
-                                                        "code": "VERIFICATION_ATTEMPTS_EXCEEDED",
+                                                        "errorCode": "VERIFICATION_ATTEMPTS_EXCEEDED",
                                                         "field": null,
                                                         "message": "검증 시도 횟수를 초과했습니다."
                                                       }
@@ -192,7 +153,7 @@ public interface PhoneVerificationApiDocs {
                                             {
                                               "status": 404,
                                               "data": {
-                                                "code": "VERIFICATION_NOT_FOUND",
+                                                "errorCode": "VERIFICATION_NOT_FOUND",
                                                 "field": null,
                                                 "message": "인증 정보를 찾을 수 없습니다."
                                               }
@@ -213,7 +174,7 @@ public interface PhoneVerificationApiDocs {
                                             {
                                               "status": 409,
                                               "data": {
-                                                "code": "ALREADY_VERIFIED",
+                                                "errorCode": "ALREADY_VERIFIED",
                                                 "field": null,
                                                 "message": "이미 완료된 인증입니다."
                                               }

--- a/src/main/java/com/dduru/gildongmu/verification/controller/PhoneVerificationApiDocs.java
+++ b/src/main/java/com/dduru/gildongmu/verification/controller/PhoneVerificationApiDocs.java
@@ -1,11 +1,15 @@
 package com.dduru.gildongmu.verification.controller;
 
 import com.dduru.gildongmu.common.dto.ApiResult;
+import com.dduru.gildongmu.common.exception.ErrorResponse;
 import com.dduru.gildongmu.verification.dto.VerificationSendRequest;
 import com.dduru.gildongmu.verification.dto.VerificationSendResponse;
 import com.dduru.gildongmu.verification.dto.VerificationVerifyRequest;
 import com.dduru.gildongmu.verification.dto.VerificationVerifyResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -18,11 +22,113 @@ public interface PhoneVerificationApiDocs {
 
     @Operation(summary = "인증번호 발송", description = "전화번호로 인증번호를 발송합니다.")
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "인증번호 발송 성공"),
-            @ApiResponse(responseCode = "400", description = "잘못된 전화번호 형식"),
-            @ApiResponse(responseCode = "409", description = "이미 가입된 전화번호"),
-            @ApiResponse(responseCode = "429", description = "재발송 제한 또는 일일 발송 한도 초과"),
-            @ApiResponse(responseCode = "500", description = "SMS 발송 실패")
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "인증번호 발송 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = VerificationSendResponse.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 전화번호 형식",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(
+                                    name = "InvalidPhoneNumber",
+                                    value = """
+                                            {
+                                              "status": 400,
+                                              "data": {
+                                                "code": "INVALID_INPUT_VALUE",
+                                                "field": "phoneNumber",
+                                                "message": "전화번호 형식이 올바르지 않습니다."
+                                              }
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "409",
+                    description = "이미 가입된 전화번호",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(
+                                    name = "DuplicatePhoneNumber",
+                                    value = """
+                                            {
+                                              "status": 409,
+                                              "data": {
+                                                "code": "DUPLICATE_PHONE_NUMBER",
+                                                "field": null,
+                                                "message": "이미 가입된 전화번호입니다. 로그인해주세요."
+                                              }
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "429",
+                    description = "재발송 제한 또는 일일 발송 한도 초과",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(
+                                            name = "ResendLimitExceeded",
+                                            value = """
+                                                    {
+                                                      "status": 429,
+                                                      "data": {
+                                                        "code": "TOO_MANY_REQUESTS",
+                                                        "field": null,
+                                                        "message": "재발송 제한 시간이 지나지 않았습니다."
+                                                      }
+                                                    }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "DailyLimitExceeded",
+                                            value = """
+                                                    {
+                                                      "status": 429,
+                                                      "data": {
+                                                        "code": "DAILY_SMS_LIMIT_EXCEEDED",
+                                                        "field": null,
+                                                        "message": "일일 SMS 발송 한도를 초과했습니다."
+                                                      }
+                                                    }
+                                                    """
+                                    )
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = "SMS 발송 실패",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(
+                                    name = "SmsProviderError",
+                                    value = """
+                                            {
+                                              "status": 500,
+                                              "data": {
+                                                "code": "SMS_PROVIDER_ERROR",
+                                                "field": null,
+                                                "message": "SMS 서비스에 일시적인 오류가 발생했습니다."
+                                              }
+                                            }
+                                            """
+                            )
+                    )
+            )
     })
     ResponseEntity<ApiResult<VerificationSendResponse>> sendVerificationCode(
             @Valid @RequestBody VerificationSendRequest request
@@ -30,10 +136,92 @@ public interface PhoneVerificationApiDocs {
 
     @Operation(summary = "인증번호 검증", description = "발송된 인증번호를 검증하고 인증 토큰을 발급합니다.")
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "인증번호 검증 성공"),
-            @ApiResponse(responseCode = "400", description = "인증번호 불일치 또는 검증 시도 횟수 초과"),
-            @ApiResponse(responseCode = "404", description = "인증 정보를 찾을 수 없음"),
-            @ApiResponse(responseCode = "409", description = "이미 완료된 인증")
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "인증번호 검증 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = VerificationVerifyResponse.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "인증번호 불일치 또는 검증 시도 횟수 초과",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(
+                                            name = "InvalidAuthCode",
+                                            value = """
+                                                    {
+                                                      "status": 400,
+                                                      "data": {
+                                                        "code": "INVALID_AUTH_CODE",
+                                                        "field": null,
+                                                        "message": "인증번호가 일치하지 않습니다."
+                                                      }
+                                                    }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "AttemptsExceeded",
+                                            value = """
+                                                    {
+                                                      "status": 400,
+                                                      "data": {
+                                                        "code": "VERIFICATION_ATTEMPTS_EXCEEDED",
+                                                        "field": null,
+                                                        "message": "검증 시도 횟수를 초과했습니다."
+                                                      }
+                                                    }
+                                                    """
+                                    )
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "인증 정보를 찾을 수 없음 (만료 포함)",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(
+                                    name = "VerificationNotFound",
+                                    value = """
+                                            {
+                                              "status": 404,
+                                              "data": {
+                                                "code": "VERIFICATION_NOT_FOUND",
+                                                "field": null,
+                                                "message": "인증 정보를 찾을 수 없습니다."
+                                              }
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "409",
+                    description = "이미 완료된 인증",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(
+                                    name = "AlreadyVerified",
+                                    value = """
+                                            {
+                                              "status": 409,
+                                              "data": {
+                                                "code": "ALREADY_VERIFIED",
+                                                "field": null,
+                                                "message": "이미 완료된 인증입니다."
+                                              }
+                                            }
+                                            """
+                            )
+                    )
+            )
     })
     ResponseEntity<ApiResult<VerificationVerifyResponse>> verifyCode(
             @Valid @RequestBody VerificationVerifyRequest request

--- a/src/main/java/com/dduru/gildongmu/verification/controller/PhoneVerificationController.java
+++ b/src/main/java/com/dduru/gildongmu/verification/controller/PhoneVerificationController.java
@@ -1,0 +1,39 @@
+package com.dduru.gildongmu.verification.controller;
+
+import com.dduru.gildongmu.common.dto.ApiResult;
+import com.dduru.gildongmu.verification.dto.VerificationSendRequest;
+import com.dduru.gildongmu.verification.dto.VerificationSendResponse;
+import com.dduru.gildongmu.verification.dto.VerificationVerifyRequest;
+import com.dduru.gildongmu.verification.dto.VerificationVerifyResponse;
+import com.dduru.gildongmu.verification.service.PhoneVerificationService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RequestMapping("/api/v1/verifications")
+@RequiredArgsConstructor
+@RestController
+public class PhoneVerificationController implements PhoneVerificationApiDocs {
+
+    private final PhoneVerificationService phoneVerificationService;
+
+    @Override
+    @PostMapping
+    public ResponseEntity<ApiResult<VerificationSendResponse>> sendVerificationCode(
+            @Valid @RequestBody VerificationSendRequest request) {
+        VerificationSendResponse response = phoneVerificationService.sendVerificationCode(request.phoneNumber());
+        return ResponseEntity.ok(ApiResult.ok(response));
+    }
+
+    @Override
+    @PatchMapping
+    public ResponseEntity<ApiResult<VerificationVerifyResponse>> verifyCode(
+            @Valid @RequestBody VerificationVerifyRequest request) {
+        VerificationVerifyResponse response = phoneVerificationService.verifyCode(
+                request.phoneNumber(),
+                request.code()
+        );
+        return ResponseEntity.ok(ApiResult.ok(response));
+    }
+}

--- a/src/main/java/com/dduru/gildongmu/verification/dto/VerificationData.java
+++ b/src/main/java/com/dduru/gildongmu/verification/dto/VerificationData.java
@@ -1,0 +1,14 @@
+package com.dduru.gildongmu.verification.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+
+@Builder
+public record VerificationData(
+        String code,
+        String phone,
+        @JsonProperty("count")
+        Integer count,
+        String status
+) {
+}

--- a/src/main/java/com/dduru/gildongmu/verification/dto/VerificationSendRequest.java
+++ b/src/main/java/com/dduru/gildongmu/verification/dto/VerificationSendRequest.java
@@ -1,0 +1,11 @@
+package com.dduru.gildongmu.verification.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record VerificationSendRequest(
+        @NotBlank(message = "전화번호는 필수입니다.")
+        @Pattern(regexp = "^010\\d{8}$", message = "전화번호는 010으로 시작하는 11자리 숫자여야 합니다.")
+        String phoneNumber
+) {
+}

--- a/src/main/java/com/dduru/gildongmu/verification/dto/VerificationSendResponse.java
+++ b/src/main/java/com/dduru/gildongmu/verification/dto/VerificationSendResponse.java
@@ -1,0 +1,10 @@
+package com.dduru.gildongmu.verification.dto;
+
+import lombok.Builder;
+import java.time.LocalDateTime;
+
+@Builder
+public record VerificationSendResponse(
+        LocalDateTime expiresAt
+) {
+}

--- a/src/main/java/com/dduru/gildongmu/verification/dto/VerificationVerifyRequest.java
+++ b/src/main/java/com/dduru/gildongmu/verification/dto/VerificationVerifyRequest.java
@@ -1,0 +1,15 @@
+package com.dduru.gildongmu.verification.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record VerificationVerifyRequest(
+        @NotBlank(message = "전화번호는 필수입니다.")
+        @Pattern(regexp = "^010\\d{8}$", message = "전화번호는 010으로 시작하는 11자리 숫자여야 합니다.")
+        String phoneNumber,
+
+        @NotBlank(message = "인증번호는 필수입니다.")
+        @Pattern(regexp = "^\\d{6}$", message = "인증번호는 6자리 숫자여야 합니다.")
+        String code
+) {
+}

--- a/src/main/java/com/dduru/gildongmu/verification/dto/VerificationVerifyResponse.java
+++ b/src/main/java/com/dduru/gildongmu/verification/dto/VerificationVerifyResponse.java
@@ -1,0 +1,16 @@
+package com.dduru.gildongmu.verification.dto;
+
+import lombok.Builder;
+
+@Builder
+public record VerificationVerifyResponse(
+        String status,
+        String token
+) {
+    public static VerificationVerifyResponse verified(String token) {
+        return VerificationVerifyResponse.builder()
+                .status("VERIFIED")
+                .token(token)
+                .build();
+    }
+}

--- a/src/main/java/com/dduru/gildongmu/verification/exception/AlreadyVerifiedException.java
+++ b/src/main/java/com/dduru/gildongmu/verification/exception/AlreadyVerifiedException.java
@@ -1,0 +1,14 @@
+package com.dduru.gildongmu.verification.exception;
+
+import com.dduru.gildongmu.common.exception.BusinessException;
+import com.dduru.gildongmu.common.exception.ErrorCode;
+
+public class AlreadyVerifiedException extends BusinessException {
+    public AlreadyVerifiedException() {
+        super(ErrorCode.ALREADY_VERIFIED, "이미 완료된 인증입니다.");
+    }
+
+    public AlreadyVerifiedException(String message) {
+        super(ErrorCode.ALREADY_VERIFIED, message);
+    }
+}

--- a/src/main/java/com/dduru/gildongmu/verification/exception/DailySmsLimitExceededException.java
+++ b/src/main/java/com/dduru/gildongmu/verification/exception/DailySmsLimitExceededException.java
@@ -1,0 +1,14 @@
+package com.dduru.gildongmu.verification.exception;
+
+import com.dduru.gildongmu.common.exception.BusinessException;
+import com.dduru.gildongmu.common.exception.ErrorCode;
+
+public class DailySmsLimitExceededException extends BusinessException {
+    public DailySmsLimitExceededException() {
+        super(ErrorCode.DAILY_SMS_LIMIT_EXCEEDED, "일일 발송 한도를 초과했습니다.");
+    }
+
+    public DailySmsLimitExceededException(String message) {
+        super(ErrorCode.DAILY_SMS_LIMIT_EXCEEDED, message);
+    }
+}

--- a/src/main/java/com/dduru/gildongmu/verification/exception/DuplicatePhoneNumberException.java
+++ b/src/main/java/com/dduru/gildongmu/verification/exception/DuplicatePhoneNumberException.java
@@ -1,0 +1,14 @@
+package com.dduru.gildongmu.verification.exception;
+
+import com.dduru.gildongmu.common.exception.BusinessException;
+import com.dduru.gildongmu.common.exception.ErrorCode;
+
+public class DuplicatePhoneNumberException extends BusinessException {
+    public DuplicatePhoneNumberException() {
+        super(ErrorCode.DUPLICATE_PHONE_NUMBER, "이미 가입된 전화번호입니다.");
+    }
+
+    public DuplicatePhoneNumberException(String message) {
+        super(ErrorCode.DUPLICATE_PHONE_NUMBER, message);
+    }
+}

--- a/src/main/java/com/dduru/gildongmu/verification/exception/InvalidVerificationCodeException.java
+++ b/src/main/java/com/dduru/gildongmu/verification/exception/InvalidVerificationCodeException.java
@@ -1,0 +1,14 @@
+package com.dduru.gildongmu.verification.exception;
+
+import com.dduru.gildongmu.common.exception.BusinessException;
+import com.dduru.gildongmu.common.exception.ErrorCode;
+
+public class InvalidVerificationCodeException extends BusinessException {
+    public InvalidVerificationCodeException() {
+        super(ErrorCode.INVALID_AUTH_CODE, "인증번호가 일치하지 않습니다.");
+    }
+
+    public InvalidVerificationCodeException(String message) {
+        super(ErrorCode.INVALID_AUTH_CODE, message);
+    }
+}

--- a/src/main/java/com/dduru/gildongmu/verification/exception/ResendLimitExceededException.java
+++ b/src/main/java/com/dduru/gildongmu/verification/exception/ResendLimitExceededException.java
@@ -1,0 +1,14 @@
+package com.dduru.gildongmu.verification.exception;
+
+import com.dduru.gildongmu.common.exception.BusinessException;
+import com.dduru.gildongmu.common.exception.ErrorCode;
+
+public class ResendLimitExceededException extends BusinessException {
+    public ResendLimitExceededException() {
+        super(ErrorCode.TOO_MANY_REQUESTS, "재발송 제한 시간이 지나지 않았습니다.");
+    }
+
+    public ResendLimitExceededException(String message) {
+        super(ErrorCode.TOO_MANY_REQUESTS, message);
+    }
+}

--- a/src/main/java/com/dduru/gildongmu/verification/exception/SmsProviderException.java
+++ b/src/main/java/com/dduru/gildongmu/verification/exception/SmsProviderException.java
@@ -1,0 +1,14 @@
+package com.dduru.gildongmu.verification.exception;
+
+import com.dduru.gildongmu.common.exception.BusinessException;
+import com.dduru.gildongmu.common.exception.ErrorCode;
+
+public class SmsProviderException extends BusinessException {
+    public SmsProviderException() {
+        super(ErrorCode.SMS_PROVIDER_ERROR, "SMS 발송 서비스에 일시적인 오류가 발생했습니다.");
+    }
+
+    public SmsProviderException(String message) {
+        super(ErrorCode.SMS_PROVIDER_ERROR, message);
+    }
+}

--- a/src/main/java/com/dduru/gildongmu/verification/exception/SmsSendFailedException.java
+++ b/src/main/java/com/dduru/gildongmu/verification/exception/SmsSendFailedException.java
@@ -1,0 +1,14 @@
+package com.dduru.gildongmu.verification.exception;
+
+import com.dduru.gildongmu.common.exception.BusinessException;
+import com.dduru.gildongmu.common.exception.ErrorCode;
+
+public class SmsSendFailedException extends BusinessException {
+    public SmsSendFailedException() {
+        super(ErrorCode.SMS_SEND_FAILED, "SMS 발송에 실패했습니다.");
+    }
+
+    public SmsSendFailedException(String message) {
+        super(ErrorCode.SMS_SEND_FAILED, message);
+    }
+}

--- a/src/main/java/com/dduru/gildongmu/verification/exception/VerificationAttemptsExceededException.java
+++ b/src/main/java/com/dduru/gildongmu/verification/exception/VerificationAttemptsExceededException.java
@@ -1,0 +1,14 @@
+package com.dduru.gildongmu.verification.exception;
+
+import com.dduru.gildongmu.common.exception.BusinessException;
+import com.dduru.gildongmu.common.exception.ErrorCode;
+
+public class VerificationAttemptsExceededException extends BusinessException {
+    public VerificationAttemptsExceededException() {
+        super(ErrorCode.VERIFICATION_ATTEMPTS_EXCEEDED, "검증 시도 횟수를 초과했습니다.");
+    }
+
+    public VerificationAttemptsExceededException(String message) {
+        super(ErrorCode.VERIFICATION_ATTEMPTS_EXCEEDED, message);
+    }
+}

--- a/src/main/java/com/dduru/gildongmu/verification/exception/VerificationCreationException.java
+++ b/src/main/java/com/dduru/gildongmu/verification/exception/VerificationCreationException.java
@@ -1,0 +1,14 @@
+package com.dduru.gildongmu.verification.exception;
+
+import com.dduru.gildongmu.common.exception.BusinessException;
+import com.dduru.gildongmu.common.exception.ErrorCode;
+
+public class VerificationCreationException extends BusinessException {
+    public VerificationCreationException() {
+        super(ErrorCode.INTERNAL_SERVER_ERROR, "인증 정보 생성에 실패했습니다.");
+    }
+
+    public VerificationCreationException(String message) {
+        super(ErrorCode.INTERNAL_SERVER_ERROR, message);
+    }
+}

--- a/src/main/java/com/dduru/gildongmu/verification/exception/VerificationNotFoundException.java
+++ b/src/main/java/com/dduru/gildongmu/verification/exception/VerificationNotFoundException.java
@@ -1,0 +1,14 @@
+package com.dduru.gildongmu.verification.exception;
+
+import com.dduru.gildongmu.common.exception.BusinessException;
+import com.dduru.gildongmu.common.exception.ErrorCode;
+
+public class VerificationNotFoundException extends BusinessException {
+    public VerificationNotFoundException() {
+        super(ErrorCode.VERIFICATION_NOT_FOUND, "인증 정보를 찾을 수 없습니다.");
+    }
+
+    public VerificationNotFoundException(String message) {
+        super(ErrorCode.VERIFICATION_NOT_FOUND, message);
+    }
+}

--- a/src/main/java/com/dduru/gildongmu/verification/service/PhoneVerificationService.java
+++ b/src/main/java/com/dduru/gildongmu/verification/service/PhoneVerificationService.java
@@ -26,7 +26,13 @@ public class PhoneVerificationService {
         VerificationCodeService.VerificationCreateResult result = 
                 verificationCodeService.createVerification(phoneNumber);
 
-        sendVerificationSms(phoneNumber, result.code());
+        try {
+            sendVerificationSms(phoneNumber, result.code());
+            verificationCodeService.setResendLimit(phoneNumber);
+        } catch (Exception e) {
+            verificationCodeService.rollbackVerificationCreation(phoneNumber);
+            throw e;
+        }
 
         return VerificationSendResponse.builder()
                 .expiresAt(result.expiresAt())
@@ -59,5 +65,4 @@ public class PhoneVerificationService {
     private String createVerificationMessage(String code) {
         return String.format("[뚜르] 인증번호는 [%s]입니다. 3분 내에 입력해주세요.", code);
     }
-
 }

--- a/src/main/java/com/dduru/gildongmu/verification/service/PhoneVerificationService.java
+++ b/src/main/java/com/dduru/gildongmu/verification/service/PhoneVerificationService.java
@@ -43,7 +43,7 @@ public class PhoneVerificationService {
 
     public VerificationVerifyResponse verifyCode(String phoneNumber, String code) {
         verificationCodeService.verifyCode(phoneNumber, code);
-        String token = jwtTokenProvider.createVerificationToken(phoneNumber);
+        String token = jwtTokenProvider.createVerificationToken(null, phoneNumber);
         return VerificationVerifyResponse.verified(token);
     }
 

--- a/src/main/java/com/dduru/gildongmu/verification/service/PhoneVerificationService.java
+++ b/src/main/java/com/dduru/gildongmu/verification/service/PhoneVerificationService.java
@@ -1,0 +1,77 @@
+package com.dduru.gildongmu.verification.service;
+
+import com.dduru.gildongmu.common.jwt.JwtTokenProvider;
+import com.dduru.gildongmu.user.repository.UserRepository;
+import com.dduru.gildongmu.verification.dto.VerificationSendResponse;
+import com.dduru.gildongmu.verification.dto.VerificationVerifyResponse;
+import com.dduru.gildongmu.verification.exception.DuplicatePhoneNumberException;
+import com.dduru.gildongmu.verification.exception.SmsProviderException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PhoneVerificationService {
+
+    private final SmsService smsService;
+    private final VerificationCodeService verificationCodeService;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final UserRepository userRepository;
+
+    /**
+     * 인증번호 발송
+     * @param phoneNumber 전화번호
+     * @return verificationId와 만료 시간
+     */
+    public VerificationSendResponse sendVerificationCode(String phoneNumber) {
+        // 이미 가입된 번호인지 확인 (기획에 따라 다를 수 있음)
+        if (userRepository.existsByPhoneNumber(phoneNumber)) {
+            throw new DuplicatePhoneNumberException("이미 가입된 전화번호입니다. 로그인해주세요.");
+        }
+
+        try {
+            // 인증번호 생성 및 저장
+            VerificationCodeService.VerificationCreateResult result = 
+                    verificationCodeService.createVerification(phoneNumber);
+
+            // SMS 발송
+            String code = verificationCodeService.getCode(phoneNumber);
+            String message = String.format("[뚜르] 인증번호는 [%s]입니다. 3분 내에 입력해주세요.", code);
+            
+            try {
+                smsService.sendSms(phoneNumber, message);
+            } catch (Exception e) {
+                log.error("SMS 발송 실패: phoneNumber={}", phoneNumber, e);
+                throw new SmsProviderException("SMS 발송 서비스에 일시적인 오류가 발생했습니다.");
+            }
+
+            return VerificationSendResponse.builder()
+                    .expiresAt(result.expiresAt())
+                    .build();
+
+        } catch (DuplicatePhoneNumberException | SmsProviderException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("인증번호 발송 중 오류 발생: phoneNumber={}", phoneNumber, e);
+            throw new SmsProviderException("인증번호 발송에 실패했습니다.");
+        }
+    }
+
+    /**
+     * 인증번호 검증 및 토큰 발급
+     * @param phoneNumber 전화번호
+     * @param code 인증번호
+     * @return 검증 결과 및 토큰
+     */
+    public VerificationVerifyResponse verifyCode(String phoneNumber, String code) {
+        // 인증번호 검증
+        verificationCodeService.verifyCode(phoneNumber, code);
+
+        // 검증 성공 시 토큰 발급 (임시 토큰 또는 인증 토큰)
+        String token = jwtTokenProvider.createVerificationToken(phoneNumber);
+
+        return VerificationVerifyResponse.verified(token);
+    }
+}

--- a/src/main/java/com/dduru/gildongmu/verification/service/PhoneVerificationService.java
+++ b/src/main/java/com/dduru/gildongmu/verification/service/PhoneVerificationService.java
@@ -6,6 +6,7 @@ import com.dduru.gildongmu.verification.dto.VerificationSendResponse;
 import com.dduru.gildongmu.verification.dto.VerificationVerifyResponse;
 import com.dduru.gildongmu.verification.exception.DuplicatePhoneNumberException;
 import com.dduru.gildongmu.verification.exception.SmsProviderException;
+import com.dduru.gildongmu.verification.exception.SmsSendFailedException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -23,7 +24,7 @@ public class PhoneVerificationService {
     /**
      * 인증번호 발송
      * @param phoneNumber 전화번호
-     * @return verificationId와 만료 시간
+     * @return 만료 시간
      */
     public VerificationSendResponse sendVerificationCode(String phoneNumber) {
         // 이미 가입된 번호인지 확인 (기획에 따라 다를 수 있음)
@@ -31,32 +32,27 @@ public class PhoneVerificationService {
             throw new DuplicatePhoneNumberException("이미 가입된 전화번호입니다. 로그인해주세요.");
         }
 
+        // 인증번호 생성 및 저장
+        VerificationCodeService.VerificationCreateResult result = 
+                verificationCodeService.createVerification(phoneNumber);
+
+        // SMS 발송
+        String code = verificationCodeService.getCode(phoneNumber);
+        String message = String.format("[뚜르] 인증번호는 [%s]입니다. 3분 내에 입력해주세요.", code);
+        
         try {
-            // 인증번호 생성 및 저장
-            VerificationCodeService.VerificationCreateResult result = 
-                    verificationCodeService.createVerification(phoneNumber);
-
-            // SMS 발송
-            String code = verificationCodeService.getCode(phoneNumber);
-            String message = String.format("[뚜르] 인증번호는 [%s]입니다. 3분 내에 입력해주세요.", code);
-            
-            try {
-                smsService.sendSms(phoneNumber, message);
-            } catch (Exception e) {
-                log.error("SMS 발송 실패: phoneNumber={}", phoneNumber, e);
-                throw new SmsProviderException("SMS 발송 서비스에 일시적인 오류가 발생했습니다.");
-            }
-
-            return VerificationSendResponse.builder()
-                    .expiresAt(result.expiresAt())
-                    .build();
-
-        } catch (DuplicatePhoneNumberException | SmsProviderException e) {
-            throw e;
+            smsService.sendSms(phoneNumber, message);
+        } catch (SmsSendFailedException e) {
+            log.error("SMS 발송 실패: phoneNumber={}", phoneNumber, e);
+            throw new SmsProviderException("SMS 발송 서비스에 일시적인 오류가 발생했습니다.");
         } catch (Exception e) {
-            log.error("인증번호 발송 중 오류 발생: phoneNumber={}", phoneNumber, e);
-            throw new SmsProviderException("인증번호 발송에 실패했습니다.");
+            log.error("SMS 발송 중 예상치 못한 오류 발생: phoneNumber={}", phoneNumber, e);
+            throw new SmsProviderException("SMS 발송 서비스에 일시적인 오류가 발생했습니다.");
         }
+
+        return VerificationSendResponse.builder()
+                .expiresAt(result.expiresAt())
+                .build();
     }
 
     /**

--- a/src/main/java/com/dduru/gildongmu/verification/service/PhoneVerificationService.java
+++ b/src/main/java/com/dduru/gildongmu/verification/service/PhoneVerificationService.java
@@ -37,8 +37,7 @@ public class PhoneVerificationService {
                 verificationCodeService.createVerification(phoneNumber);
 
         // SMS 발송
-        String code = verificationCodeService.getCode(phoneNumber);
-        String message = String.format("[뚜르] 인증번호는 [%s]입니다. 3분 내에 입력해주세요.", code);
+        String message = String.format("[뚜르] 인증번호는 [%s]입니다. 3분 내에 입력해주세요.", result.code());
         
         try {
             smsService.sendSms(phoneNumber, message);

--- a/src/main/java/com/dduru/gildongmu/verification/service/PhoneVerificationService.java
+++ b/src/main/java/com/dduru/gildongmu/verification/service/PhoneVerificationService.java
@@ -6,6 +6,7 @@ import com.dduru.gildongmu.verification.dto.VerificationSendResponse;
 import com.dduru.gildongmu.verification.dto.VerificationVerifyResponse;
 import com.dduru.gildongmu.verification.exception.DuplicatePhoneNumberException;
 import com.dduru.gildongmu.verification.exception.SmsProviderException;
+import com.dduru.gildongmu.verification.exception.SmsSendFailedException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -31,7 +32,8 @@ public class PhoneVerificationService {
             verificationCodeService.setResendLimit(phoneNumber);
         } catch (Exception e) {
             verificationCodeService.rollbackVerificationCreation(phoneNumber);
-            throw e;
+            log.error("Verification code 메서드 처리 실패", e);
+            throw new SmsSendFailedException("SMS 발송 실패 등 서비스 처리 중 문제 발생");
         }
 
         return VerificationSendResponse.builder()

--- a/src/main/java/com/dduru/gildongmu/verification/service/PhoneVerificationService.java
+++ b/src/main/java/com/dduru/gildongmu/verification/service/PhoneVerificationService.java
@@ -6,7 +6,6 @@ import com.dduru.gildongmu.verification.dto.VerificationSendResponse;
 import com.dduru.gildongmu.verification.dto.VerificationVerifyResponse;
 import com.dduru.gildongmu.verification.exception.DuplicatePhoneNumberException;
 import com.dduru.gildongmu.verification.exception.SmsProviderException;
-import com.dduru.gildongmu.verification.exception.SmsSendFailedException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -21,52 +20,44 @@ public class PhoneVerificationService {
     private final JwtTokenProvider jwtTokenProvider;
     private final UserRepository userRepository;
 
-    /**
-     * 인증번호 발송
-     * @param phoneNumber 전화번호
-     * @return 만료 시간
-     */
     public VerificationSendResponse sendVerificationCode(String phoneNumber) {
-        // 이미 가입된 번호인지 확인 (기획에 따라 다를 수 있음)
-        if (userRepository.existsByPhoneNumber(phoneNumber)) {
-            throw new DuplicatePhoneNumberException("이미 가입된 전화번호입니다. 로그인해주세요.");
-        }
+        validatePhoneNumber(phoneNumber);
 
-        // 인증번호 생성 및 저장
         VerificationCodeService.VerificationCreateResult result = 
                 verificationCodeService.createVerification(phoneNumber);
 
-        // SMS 발송
-        String message = String.format("[뚜르] 인증번호는 [%s]입니다. 3분 내에 입력해주세요.", result.code());
-        
-        try {
-            smsService.sendSms(phoneNumber, message);
-        } catch (SmsSendFailedException e) {
-            log.error("SMS 발송 실패: phoneNumber={}", phoneNumber, e);
-            throw new SmsProviderException("SMS 발송 서비스에 일시적인 오류가 발생했습니다.");
-        } catch (Exception e) {
-            log.error("SMS 발송 중 예상치 못한 오류 발생: phoneNumber={}", phoneNumber, e);
-            throw new SmsProviderException("SMS 발송 서비스에 일시적인 오류가 발생했습니다.");
-        }
+        sendVerificationSms(phoneNumber, result.code());
 
         return VerificationSendResponse.builder()
                 .expiresAt(result.expiresAt())
                 .build();
     }
 
-    /**
-     * 인증번호 검증 및 토큰 발급
-     * @param phoneNumber 전화번호
-     * @param code 인증번호
-     * @return 검증 결과 및 토큰
-     */
     public VerificationVerifyResponse verifyCode(String phoneNumber, String code) {
-        // 인증번호 검증
         verificationCodeService.verifyCode(phoneNumber, code);
-
-        // 검증 성공 시 토큰 발급 (임시 토큰 또는 인증 토큰)
         String token = jwtTokenProvider.createVerificationToken(phoneNumber);
-
         return VerificationVerifyResponse.verified(token);
     }
+
+    private void validatePhoneNumber(String phoneNumber) {
+        if (userRepository.existsByPhoneNumber(phoneNumber)) {
+            throw new DuplicatePhoneNumberException("이미 가입된 전화번호입니다. 로그인해주세요.");
+        }
+    }
+
+    private void sendVerificationSms(String phoneNumber, String code) {
+        String message = createVerificationMessage(code);
+        
+        try {
+            smsService.sendSms(phoneNumber, message);
+        } catch (Exception e) {
+            log.error("SMS 발송 실패: phoneNumber={}", phoneNumber, e);
+            throw new SmsProviderException("SMS 발송 서비스에 일시적인 오류가 발생했습니다.");
+        }
+    }
+
+    private String createVerificationMessage(String code) {
+        return String.format("[뚜르] 인증번호는 [%s]입니다. 3분 내에 입력해주세요.", code);
+    }
+
 }

--- a/src/main/java/com/dduru/gildongmu/verification/service/SmsService.java
+++ b/src/main/java/com/dduru/gildongmu/verification/service/SmsService.java
@@ -1,0 +1,73 @@
+package com.dduru.gildongmu.verification.service;
+
+import com.dduru.gildongmu.verification.exception.SmsSendFailedException;
+import lombok.extern.slf4j.Slf4j;
+import net.nurigo.sdk.NurigoApp;
+import net.nurigo.sdk.message.model.Message;
+import net.nurigo.sdk.message.request.SingleMessageSendingRequest;
+import net.nurigo.sdk.message.response.SingleMessageSentResponse;
+import net.nurigo.sdk.message.service.DefaultMessageService;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import jakarta.annotation.PostConstruct;
+
+@Slf4j
+@Service
+public class SmsService {
+
+    @Value("${coolsms.api-key}")
+    private String apiKey;
+
+    @Value("${coolsms.api-secret}")
+    private String apiSecret;
+
+    @Value("${coolsms.from-number}")
+    private String fromNumber;
+
+    private DefaultMessageService messageService;
+
+    @PostConstruct
+    public void init() {
+        this.messageService = NurigoApp.INSTANCE.initialize(apiKey, apiSecret, "https://api.coolsms.co.kr");
+    }
+
+    /**
+     * SMS 발송 (CoolSMS SDK)
+     * @param phoneNumber 수신자 전화번호
+     * @param messageText 발송할 메시지
+     */
+    public void sendSms(String phoneNumber, String messageText) {
+        try {
+            Message message = new Message();
+            message.setFrom(fromNumber);
+            message.setTo(phoneNumber);
+            message.setText(messageText);
+
+            SingleMessageSendingRequest request = new SingleMessageSendingRequest(message);
+            SingleMessageSentResponse response = this.messageService.sendOne(request);
+
+            if (response == null) {
+                log.error("CoolSMS 발송 실패: 응답이 null입니다. phoneNumber={}", phoneNumber);
+                throw new SmsSendFailedException("SMS 발송에 실패했습니다.");
+            }
+
+            // SDK는 성공 시 statusCode가 null이거나 특정 값일 수 있으므로 에러 메시지 확인
+            String statusCode = response.getStatusCode();
+            if (statusCode != null && !statusCode.equals("2000")) {
+                String statusMessage = response.getStatusMessage();
+                log.error("CoolSMS 발송 실패: statusCode={}, statusMessage={}, phoneNumber={}", 
+                        statusCode, statusMessage, phoneNumber);
+                throw new SmsSendFailedException("SMS 발송에 실패했습니다: " + statusMessage);
+            }
+
+            log.info("CoolSMS 발송 성공: phoneNumber={}, messageId={}, statusCode={}", 
+                    phoneNumber, response.getMessageId(), statusCode);
+        } catch (SmsSendFailedException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("CoolSMS 발송 중 오류 발생: phoneNumber={}", phoneNumber, e);
+            throw new SmsSendFailedException("SMS 발송 중 오류가 발생했습니다: " + e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/dduru/gildongmu/verification/service/SmsService.java
+++ b/src/main/java/com/dduru/gildongmu/verification/service/SmsService.java
@@ -66,7 +66,7 @@ public class SmsService {
         } catch (SmsSendFailedException e) {
             throw e;
         } catch (Exception e) {
-            log.error("CoolSMS 발송 중 오류 발생: phoneNumber={}", phoneNumber, e);
+            log.error("CoolSMS 발송 중 예상치 못한 오류 발생: phoneNumber={}", phoneNumber, e);
             throw new SmsSendFailedException("SMS 발송 중 오류가 발생했습니다: " + e.getMessage());
         }
     }

--- a/src/main/java/com/dduru/gildongmu/verification/service/SmsService.java
+++ b/src/main/java/com/dduru/gildongmu/verification/service/SmsService.java
@@ -32,42 +32,51 @@ public class SmsService {
         this.messageService = NurigoApp.INSTANCE.initialize(apiKey, apiSecret, "https://api.coolsms.co.kr");
     }
 
-    /**
-     * SMS 발송 (CoolSMS SDK)
-     * @param phoneNumber 수신자 전화번호
-     * @param messageText 발송할 메시지
-     */
     public void sendSms(String phoneNumber, String messageText) {
         try {
-            Message message = new Message();
-            message.setFrom(fromNumber);
-            message.setTo(phoneNumber);
-            message.setText(messageText);
+            Message message = createMessage(phoneNumber, messageText);
+            SingleMessageSentResponse response = sendMessage(message);
 
-            SingleMessageSendingRequest request = new SingleMessageSendingRequest(message);
-            SingleMessageSentResponse response = this.messageService.sendOne(request);
-
-            if (response == null) {
-                log.error("CoolSMS 발송 실패: 응답이 null입니다. phoneNumber={}", phoneNumber);
-                throw new SmsSendFailedException("SMS 발송에 실패했습니다.");
-            }
-
-            // SDK는 성공 시 statusCode가 null이거나 특정 값일 수 있으므로 에러 메시지 확인
-            String statusCode = response.getStatusCode();
-            if (statusCode != null && !statusCode.equals("2000")) {
-                String statusMessage = response.getStatusMessage();
-                log.error("CoolSMS 발송 실패: statusCode={}, statusMessage={}, phoneNumber={}", 
-                        statusCode, statusMessage, phoneNumber);
-                throw new SmsSendFailedException("SMS 발송에 실패했습니다: " + statusMessage);
-            }
-
-            log.info("CoolSMS 발송 성공: phoneNumber={}, messageId={}, statusCode={}", 
-                    phoneNumber, response.getMessageId(), statusCode);
+            validateResponse(response, phoneNumber);
+            logSuccess(response, phoneNumber);
         } catch (SmsSendFailedException e) {
             throw e;
         } catch (Exception e) {
             log.error("CoolSMS 발송 중 예상치 못한 오류 발생: phoneNumber={}", phoneNumber, e);
             throw new SmsSendFailedException("SMS 발송 중 오류가 발생했습니다: " + e.getMessage());
         }
+    }
+
+    private Message createMessage(String phoneNumber, String messageText) {
+        Message message = new Message();
+        message.setFrom(fromNumber);
+        message.setTo(phoneNumber);
+        message.setText(messageText);
+        return message;
+    }
+
+    private SingleMessageSentResponse sendMessage(Message message) {
+        SingleMessageSendingRequest request = new SingleMessageSendingRequest(message);
+        return this.messageService.sendOne(request);
+    }
+
+    private void validateResponse(SingleMessageSentResponse response, String phoneNumber) {
+        if (response == null) {
+            log.error("CoolSMS 발송 실패: 응답이 null입니다. phoneNumber={}", phoneNumber);
+            throw new SmsSendFailedException("SMS 발송에 실패했습니다.");
+        }
+
+        String statusCode = response.getStatusCode();
+        if (!statusCode.equals("2000")) {
+            String statusMessage = response.getStatusMessage();
+            log.error("CoolSMS 발송 실패: statusCode={}, statusMessage={}, phoneNumber={}", 
+                    statusCode, statusMessage, phoneNumber);
+            throw new SmsSendFailedException("SMS 발송에 실패했습니다: " + statusMessage);
+        }
+    }
+
+    private void logSuccess(SingleMessageSentResponse response, String phoneNumber) {
+        log.info("CoolSMS 발송 성공: phoneNumber={}, messageId={}, statusCode={}", 
+                phoneNumber, response.getMessageId(), response.getStatusCode());
     }
 }

--- a/src/main/java/com/dduru/gildongmu/verification/service/SmsService.java
+++ b/src/main/java/com/dduru/gildongmu/verification/service/SmsService.java
@@ -39,11 +39,9 @@ public class SmsService {
 
             validateResponse(response, phoneNumber);
             logSuccess(response, phoneNumber);
-        } catch (SmsSendFailedException e) {
-            throw e;
         } catch (Exception e) {
             log.error("CoolSMS 발송 중 예상치 못한 오류 발생: phoneNumber={}", phoneNumber, e);
-            throw new SmsSendFailedException("SMS 발송 중 오류가 발생했습니다: " + e.getMessage());
+            throw new SmsSendFailedException("SMS 발송 처리 중 오류가 발생했습니다.");
         }
     }
 

--- a/src/main/java/com/dduru/gildongmu/verification/service/VerificationCodeService.java
+++ b/src/main/java/com/dduru/gildongmu/verification/service/VerificationCodeService.java
@@ -42,6 +42,13 @@ public class VerificationCodeService {
     
     private DefaultRedisScript<Long> dailyLimitScript;
 
+    /**
+     * 일별 발송 제한 카운터를 관리하는 Redis Lua Script
+     * KEYS[1]: Redis Key
+     * ARGV[1]: 최대 시도 횟수
+     * - count 증가 후 제한 초과 시: -1 반환
+     * - 정상 경우: 증가된 count 반환
+     */
     @PostConstruct
     public void init() {
         String script = 

--- a/src/main/java/com/dduru/gildongmu/verification/service/VerificationCodeService.java
+++ b/src/main/java/com/dduru/gildongmu/verification/service/VerificationCodeService.java
@@ -7,11 +7,15 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
 import org.springframework.stereotype.Service;
 
+import jakarta.annotation.PostConstruct;
 import java.security.SecureRandom;
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 @Slf4j
@@ -34,6 +38,26 @@ public class VerificationCodeService {
     private static final String STATUS_PENDING = "PENDING";
     private static final String STATUS_VERIFIED = "VERIFIED";
     private static final SecureRandom random = new SecureRandom();
+    
+    private DefaultRedisScript<Long> dailyLimitScript;
+
+    @PostConstruct
+    public void init() {
+        String script = 
+            "local count = redis.call('INCR', KEYS[1])\n" +
+            "if count == 1 then\n" +
+            "    redis.call('EXPIRE', KEYS[1], ARGV[2])\n" +
+            "end\n" +
+            "if count > tonumber(ARGV[1]) then\n" +
+            "    redis.call('DECR', KEYS[1])\n" +
+            "    return -1\n" +
+            "end\n" +
+            "return count";
+        
+        dailyLimitScript = new DefaultRedisScript<>();
+        dailyLimitScript.setScriptText(script);
+        dailyLimitScript.setResultType(Long.class);
+    }
 
     public VerificationCreateResult createVerification(String phoneNumber) {
         if (!canResend(phoneNumber)) {
@@ -175,21 +199,15 @@ public class VerificationCodeService {
         redisTemplate.opsForValue().set(redisKey, "1", RESEND_LIMIT_MINUTES, TimeUnit.MINUTES);
     }
 
-    /**
-     * 일일 발송 한도 확인 및 증가 (atomic operation)
-     * Redis INCR을 사용하여 race condition 방지
-     */
     private void checkAndIncrementDailyLimit(String phoneNumber) {
         String redisKey = DAILY_LIMIT_KEY_PREFIX + phoneNumber;
         
-        Long count = redisTemplate.opsForValue().increment(redisKey);
+        List<String> keys = Collections.singletonList(redisKey);
+        Long result = redisTemplate.execute(dailyLimitScript, keys, 
+            String.valueOf(DAILY_SMS_LIMIT), 
+            String.valueOf(24 * 60 * 60));
         
-        if (count == 1) {
-            redisTemplate.expire(redisKey, 24, TimeUnit.HOURS);
-        }
-        
-        if (count > DAILY_SMS_LIMIT) {
-            redisTemplate.opsForValue().decrement(redisKey);
+        if (result < 0) {
             throw new DailySmsLimitExceededException("일일 발송 한도를 초과했습니다.");
         }
     }

--- a/src/main/java/com/dduru/gildongmu/verification/service/VerificationCodeService.java
+++ b/src/main/java/com/dduru/gildongmu/verification/service/VerificationCodeService.java
@@ -1,0 +1,244 @@
+package com.dduru.gildongmu.verification.service;
+
+import com.dduru.gildongmu.verification.dto.VerificationData;
+import com.dduru.gildongmu.verification.exception.*;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.security.SecureRandom;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class VerificationCodeService {
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private final ObjectMapper objectMapper;
+    
+    private static final String REDIS_KEY_PREFIX = "sms:auth:";
+    private static final String DAILY_LIMIT_KEY_PREFIX = "sms:daily:";
+    private static final String RESEND_LIMIT_KEY_PREFIX = "sms:resend:";
+    private static final int CODE_LENGTH = 6;
+    private static final int EXPIRATION_MINUTES = 3;
+    private static final int MAX_VERIFICATION_ATTEMPTS = 5;
+    private static final int DAILY_SMS_LIMIT = 5;
+    private static final int RESEND_LIMIT_MINUTES = 1;
+    private static final SecureRandom random = new SecureRandom();
+
+    /**
+     * 인증번호 생성 및 Redis에 저장
+     * @param phoneNumber 전화번호 (Redis Key로 사용)
+     * @return 만료 시간
+     */
+    public VerificationCreateResult createVerification(String phoneNumber) {
+        // 1분 내 재요청 차단
+        if (!canResend(phoneNumber)) {
+            throw new ResendLimitExceededException("잠시 후 다시 시도해주세요.");
+        }
+
+        // 일일 발송 한도 확인
+        checkDailyLimit(phoneNumber);
+
+        // 인증번호 생성
+        String code = generateCode();
+        
+        // Redis에 저장 (phoneNumber를 key로 사용)
+        VerificationData data = VerificationData.builder()
+                .code(code)
+                .phone(phoneNumber)
+                .count(0)
+                .status("PENDING")
+                .build();
+
+        String redisKey = REDIS_KEY_PREFIX + phoneNumber;
+        try {
+            String jsonData = objectMapper.writeValueAsString(data);
+            redisTemplate.opsForValue().set(
+                    redisKey,
+                    jsonData,
+                    Duration.ofMinutes(EXPIRATION_MINUTES)
+            );
+        } catch (JsonProcessingException e) {
+            log.error("인증 데이터 저장 실패: phoneNumber={}", phoneNumber, e);
+            throw new VerificationCreationException("인증 정보 저장에 실패했습니다.");
+        }
+
+        // 재발송 제한 설정
+        setResendLimit(phoneNumber);
+        
+        // 일일 발송 횟수 증가
+        incrementDailyCount(phoneNumber);
+
+        LocalDateTime expiresAt = LocalDateTime.now().plusMinutes(EXPIRATION_MINUTES);
+        log.info("인증번호 생성 및 저장 완료: phoneNumber={}", phoneNumber);
+        
+        return new VerificationCreateResult(expiresAt);
+    }
+
+    /**
+     * 인증번호 검증
+     * @param phoneNumber 전화번호 (Redis Key)
+     * @param inputCode 입력받은 인증번호
+     * @return 검증 성공 여부
+     */
+    public boolean verifyCode(String phoneNumber, String inputCode) {
+        String redisKey = REDIS_KEY_PREFIX + phoneNumber;
+        String jsonData = redisTemplate.opsForValue().get(redisKey);
+
+        if (jsonData == null) {
+            throw new VerificationNotFoundException("인증 정보를 찾을 수 없습니다.");
+        }
+
+        try {
+            VerificationData data = objectMapper.readValue(jsonData, VerificationData.class);
+
+            // 이미 완료된 인증인지 확인
+            if ("VERIFIED".equals(data.status())) {
+                throw new AlreadyVerifiedException("이미 완료된 인증입니다.");
+            }
+
+            // 검증 시도 횟수 확인
+            if (data.count() >= MAX_VERIFICATION_ATTEMPTS) {
+                // 시도 횟수 초과 시 세션 삭제
+                redisTemplate.delete(redisKey);
+                throw new VerificationAttemptsExceededException("검증 시도 횟수를 초과했습니다.");
+            }
+
+            // 인증번호 불일치
+            if (!data.code().equals(inputCode)) {
+                // 시도 횟수 증가
+                VerificationData updatedData = VerificationData.builder()
+                        .code(data.code())
+                        .phone(data.phone())
+                        .count(data.count() + 1)
+                        .status(data.status())
+                        .build();
+                
+                try {
+                    String updatedJson = objectMapper.writeValueAsString(updatedData);
+                    redisTemplate.opsForValue().set(redisKey, updatedJson, Duration.ofMinutes(EXPIRATION_MINUTES));
+                } catch (JsonProcessingException e) {
+                    log.error("인증 데이터 업데이트 실패: phoneNumber={}", phoneNumber, e);
+                }
+                
+                throw new InvalidVerificationCodeException("인증번호가 일치하지 않습니다.");
+            }
+
+            // 인증 성공 - 상태를 VERIFIED로 변경
+            VerificationData verifiedData = VerificationData.builder()
+                    .code(data.code())
+                    .phone(data.phone())
+                    .count(data.count())
+                    .status("VERIFIED")
+                    .build();
+
+            try {
+                String verifiedJson = objectMapper.writeValueAsString(verifiedData);
+                // 인증 완료 후 10분간 유지 (토큰 발급을 위해)
+                redisTemplate.opsForValue().set(redisKey, verifiedJson, Duration.ofMinutes(10));
+            } catch (JsonProcessingException e) {
+                log.error("인증 데이터 업데이트 실패: phoneNumber={}", phoneNumber, e);
+            }
+
+            log.info("인증번호 검증 성공: phoneNumber={}", phoneNumber);
+            return true;
+
+        } catch (JsonProcessingException e) {
+            log.error("인증 데이터 파싱 실패: phoneNumber={}", phoneNumber, e);
+            throw new VerificationNotFoundException("인증 정보를 찾을 수 없습니다.");
+        }
+    }
+
+    /**
+     * 인증 데이터 조회
+     */
+    public VerificationData getVerificationData(String phoneNumber) {
+        String redisKey = REDIS_KEY_PREFIX + phoneNumber;
+        String jsonData = redisTemplate.opsForValue().get(redisKey);
+
+        if (jsonData == null) {
+            throw new VerificationNotFoundException("인증 정보를 찾을 수 없습니다.");
+        }
+
+        try {
+            return objectMapper.readValue(jsonData, VerificationData.class);
+        } catch (JsonProcessingException e) {
+            log.error("인증 데이터 파싱 실패: phoneNumber={}", phoneNumber, e);
+            throw new VerificationNotFoundException("인증 정보를 찾을 수 없습니다.");
+        }
+    }
+
+    /**
+     * 인증번호 조회 (SMS 발송용)
+     */
+    public String getCode(String phoneNumber) {
+        VerificationData data = getVerificationData(phoneNumber);
+        return data.code();
+    }
+
+    /**
+     * 인증번호 생성 (6자리 숫자)
+     */
+    private String generateCode() {
+        int min = (int) Math.pow(10, CODE_LENGTH - 1);
+        int max = (int) Math.pow(10, CODE_LENGTH) - 1;
+        int code = random.nextInt(max - min + 1) + min;
+        return String.valueOf(code);
+    }
+
+    /**
+     * 재발송 가능 여부 확인 (1분 이내 재발송 방지)
+     */
+    private boolean canResend(String phoneNumber) {
+        String redisKey = RESEND_LIMIT_KEY_PREFIX + phoneNumber;
+        String value = redisTemplate.opsForValue().get(redisKey);
+        return value == null;
+    }
+
+    /**
+     * 재발송 제한 시간 설정 (1분)
+     */
+    private void setResendLimit(String phoneNumber) {
+        String redisKey = RESEND_LIMIT_KEY_PREFIX + phoneNumber;
+        redisTemplate.opsForValue().set(redisKey, "1", RESEND_LIMIT_MINUTES, TimeUnit.MINUTES);
+    }
+
+    /**
+     * 일일 발송 한도 확인
+     */
+    private void checkDailyLimit(String phoneNumber) {
+        String redisKey = DAILY_LIMIT_KEY_PREFIX + phoneNumber;
+        String countStr = redisTemplate.opsForValue().get(redisKey);
+        
+        if (countStr != null) {
+            int count = Integer.parseInt(countStr);
+            if (count >= DAILY_SMS_LIMIT) {
+                throw new DailySmsLimitExceededException("일일 발송 한도를 초과했습니다.");
+            }
+        }
+    }
+
+    /**
+     * 일일 발송 횟수 증가
+     */
+    private void incrementDailyCount(String phoneNumber) {
+        String redisKey = DAILY_LIMIT_KEY_PREFIX + phoneNumber;
+        String countStr = redisTemplate.opsForValue().get(redisKey);
+        
+        int count = countStr != null ? Integer.parseInt(countStr) : 0;
+        count++;
+        
+        // 자정까지 남은 시간 계산 (대략 24시간)
+        redisTemplate.opsForValue().set(redisKey, String.valueOf(count), 24, TimeUnit.HOURS);
+    }
+
+    public record VerificationCreateResult(LocalDateTime expiresAt) {
+    }
+}

--- a/src/main/java/com/dduru/gildongmu/verification/service/VerificationCodeService.java
+++ b/src/main/java/com/dduru/gildongmu/verification/service/VerificationCodeService.java
@@ -27,7 +27,7 @@ public class VerificationCodeService {
     private static final String RESEND_LIMIT_KEY_PREFIX = "sms:resend:";
     private static final int CODE_LENGTH = 6;
     private static final int EXPIRATION_MINUTES = 3;
-    private static final int VERIFIED_EXPIRATION_MINUTES = 10; // 인증 완료 후 토큰 발급을 위한 유지 시간
+    private static final int VERIFIED_EXPIRATION_MINUTES = 10;
     private static final int MAX_VERIFICATION_ATTEMPTS = 5;
     private static final int DAILY_SMS_LIMIT = 5;
     private static final int RESEND_LIMIT_MINUTES = 1;
@@ -35,31 +35,49 @@ public class VerificationCodeService {
     private static final String STATUS_VERIFIED = "VERIFIED";
     private static final SecureRandom random = new SecureRandom();
 
-    /**
-     * 인증번호 생성 및 Redis에 저장
-     * @param phoneNumber 전화번호 (Redis Key로 사용)
-     * @return 인증번호와 만료 시간
-     */
     public VerificationCreateResult createVerification(String phoneNumber) {
-        // 1분 내 재요청 차단
         if (!canResend(phoneNumber)) {
             throw new ResendLimitExceededException("잠시 후 다시 시도해주세요.");
         }
 
-        // 일일 발송 한도 확인
-        checkDailyLimit(phoneNumber);
+        checkAndIncrementDailyLimit(phoneNumber);
 
-        // 인증번호 생성
         String code = generateCode();
+        VerificationData data = createVerificationData(phoneNumber, code);
+        saveVerificationData(phoneNumber, data);
+
+        setResendLimit(phoneNumber);
+
+        LocalDateTime expiresAt = LocalDateTime.now().plusMinutes(EXPIRATION_MINUTES);
+        log.info("인증번호 생성 및 저장 완료: phoneNumber={}", phoneNumber);
         
-        // Redis에 저장 (phoneNumber를 key로 사용)
-        VerificationData data = VerificationData.builder()
+        return new VerificationCreateResult(code, expiresAt);
+    }
+
+    public void verifyCode(String phoneNumber, String inputCode) {
+        String redisKey = REDIS_KEY_PREFIX + phoneNumber;
+        VerificationData data = getVerificationDataFromRedis(redisKey);
+
+        validateVerificationStatus(data);
+
+        if (!data.code().equals(inputCode)) {
+            handleInvalidCode(redisKey, data);
+        }
+
+        markAsVerified(redisKey, data, phoneNumber);
+        log.info("인증번호 검증 성공: phoneNumber={}", phoneNumber);
+    }
+
+    private VerificationData createVerificationData(String phoneNumber, String code) {
+        return VerificationData.builder()
                 .code(code)
                 .phone(phoneNumber)
                 .count(0)
                 .status(STATUS_PENDING)
                 .build();
+    }
 
+    private void saveVerificationData(String phoneNumber, VerificationData data) {
         String redisKey = REDIS_KEY_PREFIX + phoneNumber;
         try {
             String jsonData = objectMapper.writeValueAsString(data);
@@ -72,87 +90,10 @@ public class VerificationCodeService {
             log.error("인증 데이터 저장 실패: phoneNumber={}", phoneNumber, e);
             throw new VerificationCreationException("인증 정보 저장에 실패했습니다.");
         }
-
-        // 재발송 제한 설정
-        setResendLimit(phoneNumber);
-        
-        // 일일 발송 횟수 증가
-        incrementDailyCount(phoneNumber);
-
-        LocalDateTime expiresAt = LocalDateTime.now().plusMinutes(EXPIRATION_MINUTES);
-        log.info("인증번호 생성 및 저장 완료: phoneNumber={}", phoneNumber);
-        
-        return new VerificationCreateResult(code, expiresAt);
     }
 
-    /**
-     * 인증번호 검증
-     * @param phoneNumber 전화번호 (Redis Key)
-     * @param inputCode 입력받은 인증번호
-     * @return 검증 성공 여부
-     */
-    public boolean verifyCode(String phoneNumber, String inputCode) {
-        String redisKey = REDIS_KEY_PREFIX + phoneNumber;
+    private VerificationData getVerificationDataFromRedis(String redisKey) {
         String jsonData = redisTemplate.opsForValue().get(redisKey);
-
-        if (jsonData == null) {
-            throw new VerificationNotFoundException("인증 정보를 찾을 수 없습니다.");
-        }
-
-        try {
-            VerificationData data = objectMapper.readValue(jsonData, VerificationData.class);
-
-            // 이미 완료된 인증인지 확인
-            if (STATUS_VERIFIED.equals(data.status())) {
-                throw new AlreadyVerifiedException("이미 완료된 인증입니다.");
-            }
-
-            // 검증 시도 횟수 확인
-            if (data.count() >= MAX_VERIFICATION_ATTEMPTS) {
-                // 시도 횟수 초과 시 세션 삭제
-                redisTemplate.delete(redisKey);
-                throw new VerificationAttemptsExceededException("검증 시도 횟수를 초과했습니다.");
-            }
-
-            // 인증번호 불일치
-            if (!data.code().equals(inputCode)) {
-                // 시도 횟수 증가
-                incrementAttemptCount(redisKey, data);
-                throw new InvalidVerificationCodeException("인증번호가 일치하지 않습니다.");
-            }
-
-            // 인증 성공 - 상태를 VERIFIED로 변경
-            VerificationData verifiedData = VerificationData.builder()
-                    .code(data.code())
-                    .phone(data.phone())
-                    .count(data.count())
-                    .status(STATUS_VERIFIED)
-                    .build();
-
-            try {
-                String verifiedJson = objectMapper.writeValueAsString(verifiedData);
-                // 인증 완료 후 일정 시간 유지 (토큰 발급을 위해)
-                redisTemplate.opsForValue().set(redisKey, verifiedJson, Duration.ofMinutes(VERIFIED_EXPIRATION_MINUTES));
-            } catch (JsonProcessingException e) {
-                log.error("인증 데이터 업데이트 실패: phoneNumber={}", phoneNumber, e);
-            }
-
-            log.info("인증번호 검증 성공: phoneNumber={}", phoneNumber);
-            return true;
-
-        } catch (JsonProcessingException e) {
-            log.error("인증 데이터 파싱 실패: phoneNumber={}", phoneNumber, e);
-            throw new VerificationNotFoundException("인증 정보를 찾을 수 없습니다.");
-        }
-    }
-
-    /**
-     * 인증 데이터 조회
-     */
-    public VerificationData getVerificationData(String phoneNumber) {
-        String redisKey = REDIS_KEY_PREFIX + phoneNumber;
-        String jsonData = redisTemplate.opsForValue().get(redisKey);
-
         if (jsonData == null) {
             throw new VerificationNotFoundException("인증 정보를 찾을 수 없습니다.");
         }
@@ -160,22 +101,46 @@ public class VerificationCodeService {
         try {
             return objectMapper.readValue(jsonData, VerificationData.class);
         } catch (JsonProcessingException e) {
-            log.error("인증 데이터 파싱 실패: phoneNumber={}", phoneNumber, e);
+            log.error("인증 데이터 파싱 실패: redisKey={}", redisKey, e);
             throw new VerificationNotFoundException("인증 정보를 찾을 수 없습니다.");
         }
     }
 
-    /**
-     * 인증번호 조회 (SMS 발송용)
-     */
-    public String getCode(String phoneNumber) {
-        VerificationData data = getVerificationData(phoneNumber);
-        return data.code();
+    private void validateVerificationStatus(VerificationData data) {
+        if (STATUS_VERIFIED.equals(data.status())) {
+            throw new AlreadyVerifiedException("이미 완료된 인증입니다.");
+        }
     }
 
-    /**
-     * 검증 시도 횟수 증가
-     */
+    private void handleInvalidCode(String redisKey, VerificationData data) {
+        int newCount = data.count() + 1;
+        
+        if (newCount > MAX_VERIFICATION_ATTEMPTS) {
+            redisTemplate.delete(redisKey);
+            throw new VerificationAttemptsExceededException("검증 시도 횟수를 초과했습니다.");
+        }
+        
+        incrementAttemptCount(redisKey, data);
+        throw new InvalidVerificationCodeException("인증번호가 일치하지 않습니다.");
+    }
+
+    private void markAsVerified(String redisKey, VerificationData data, String phoneNumber) {
+        VerificationData verifiedData = VerificationData.builder()
+                .code(data.code())
+                .phone(data.phone())
+                .count(data.count())
+                .status(STATUS_VERIFIED)
+                .build();
+
+        try {
+            String verifiedJson = objectMapper.writeValueAsString(verifiedData);
+            redisTemplate.opsForValue().set(redisKey, verifiedJson, Duration.ofMinutes(VERIFIED_EXPIRATION_MINUTES));
+        } catch (JsonProcessingException e) {
+            log.error("인증 데이터 업데이트 실패: phoneNumber={}", phoneNumber, e);
+            throw new VerificationCreationException("인증 상태 저장에 실패했습니다.");
+        }
+    }
+
     private void incrementAttemptCount(String redisKey, VerificationData data) {
         VerificationData updatedData = VerificationData.builder()
                 .code(data.code())
@@ -192,9 +157,6 @@ public class VerificationCodeService {
         }
     }
 
-    /**
-     * 인증번호 생성 (6자리 숫자)
-     */
     private String generateCode() {
         int min = (int) Math.pow(10, CODE_LENGTH - 1);
         int max = (int) Math.pow(10, CODE_LENGTH) - 1;
@@ -202,50 +164,34 @@ public class VerificationCodeService {
         return String.valueOf(code);
     }
 
-    /**
-     * 재발송 가능 여부 확인 (1분 이내 재발송 방지)
-     */
     private boolean canResend(String phoneNumber) {
         String redisKey = RESEND_LIMIT_KEY_PREFIX + phoneNumber;
         String value = redisTemplate.opsForValue().get(redisKey);
         return value == null;
     }
 
-    /**
-     * 재발송 제한 시간 설정 (1분)
-     */
     private void setResendLimit(String phoneNumber) {
         String redisKey = RESEND_LIMIT_KEY_PREFIX + phoneNumber;
         redisTemplate.opsForValue().set(redisKey, "1", RESEND_LIMIT_MINUTES, TimeUnit.MINUTES);
     }
 
     /**
-     * 일일 발송 한도 확인
+     * 일일 발송 한도 확인 및 증가 (atomic operation)
+     * Redis INCR을 사용하여 race condition 방지
      */
-    private void checkDailyLimit(String phoneNumber) {
+    private void checkAndIncrementDailyLimit(String phoneNumber) {
         String redisKey = DAILY_LIMIT_KEY_PREFIX + phoneNumber;
-        String countStr = redisTemplate.opsForValue().get(redisKey);
         
-        if (countStr != null) {
-            int count = Integer.parseInt(countStr);
-            if (count >= DAILY_SMS_LIMIT) {
-                throw new DailySmsLimitExceededException("일일 발송 한도를 초과했습니다.");
-            }
+        Long count = redisTemplate.opsForValue().increment(redisKey);
+        
+        if (count == 1) {
+            redisTemplate.expire(redisKey, 24, TimeUnit.HOURS);
         }
-    }
-
-    /**
-     * 일일 발송 횟수 증가
-     */
-    private void incrementDailyCount(String phoneNumber) {
-        String redisKey = DAILY_LIMIT_KEY_PREFIX + phoneNumber;
-        String countStr = redisTemplate.opsForValue().get(redisKey);
         
-        int count = countStr != null ? Integer.parseInt(countStr) : 0;
-        count++;
-        
-        // 자정까지 남은 시간 계산 (대략 24시간)
-        redisTemplate.opsForValue().set(redisKey, String.valueOf(count), 24, TimeUnit.HOURS);
+        if (count > DAILY_SMS_LIMIT) {
+            redisTemplate.opsForValue().decrement(redisKey);
+            throw new DailySmsLimitExceededException("일일 발송 한도를 초과했습니다.");
+        }
     }
 
     public record VerificationCreateResult(String code, LocalDateTime expiresAt) {

--- a/src/main/java/com/dduru/gildongmu/verification/service/VerificationCodeService.java
+++ b/src/main/java/com/dduru/gildongmu/verification/service/VerificationCodeService.java
@@ -27,15 +27,18 @@ public class VerificationCodeService {
     private static final String RESEND_LIMIT_KEY_PREFIX = "sms:resend:";
     private static final int CODE_LENGTH = 6;
     private static final int EXPIRATION_MINUTES = 3;
+    private static final int VERIFIED_EXPIRATION_MINUTES = 10; // 인증 완료 후 토큰 발급을 위한 유지 시간
     private static final int MAX_VERIFICATION_ATTEMPTS = 5;
     private static final int DAILY_SMS_LIMIT = 5;
     private static final int RESEND_LIMIT_MINUTES = 1;
+    private static final String STATUS_PENDING = "PENDING";
+    private static final String STATUS_VERIFIED = "VERIFIED";
     private static final SecureRandom random = new SecureRandom();
 
     /**
      * 인증번호 생성 및 Redis에 저장
      * @param phoneNumber 전화번호 (Redis Key로 사용)
-     * @return 만료 시간
+     * @return 인증번호와 만료 시간
      */
     public VerificationCreateResult createVerification(String phoneNumber) {
         // 1분 내 재요청 차단
@@ -54,7 +57,7 @@ public class VerificationCodeService {
                 .code(code)
                 .phone(phoneNumber)
                 .count(0)
-                .status("PENDING")
+                .status(STATUS_PENDING)
                 .build();
 
         String redisKey = REDIS_KEY_PREFIX + phoneNumber;
@@ -79,7 +82,7 @@ public class VerificationCodeService {
         LocalDateTime expiresAt = LocalDateTime.now().plusMinutes(EXPIRATION_MINUTES);
         log.info("인증번호 생성 및 저장 완료: phoneNumber={}", phoneNumber);
         
-        return new VerificationCreateResult(expiresAt);
+        return new VerificationCreateResult(code, expiresAt);
     }
 
     /**
@@ -100,7 +103,7 @@ public class VerificationCodeService {
             VerificationData data = objectMapper.readValue(jsonData, VerificationData.class);
 
             // 이미 완료된 인증인지 확인
-            if ("VERIFIED".equals(data.status())) {
+            if (STATUS_VERIFIED.equals(data.status())) {
                 throw new AlreadyVerifiedException("이미 완료된 인증입니다.");
             }
 
@@ -114,20 +117,7 @@ public class VerificationCodeService {
             // 인증번호 불일치
             if (!data.code().equals(inputCode)) {
                 // 시도 횟수 증가
-                VerificationData updatedData = VerificationData.builder()
-                        .code(data.code())
-                        .phone(data.phone())
-                        .count(data.count() + 1)
-                        .status(data.status())
-                        .build();
-                
-                try {
-                    String updatedJson = objectMapper.writeValueAsString(updatedData);
-                    redisTemplate.opsForValue().set(redisKey, updatedJson, Duration.ofMinutes(EXPIRATION_MINUTES));
-                } catch (JsonProcessingException e) {
-                    log.error("인증 데이터 업데이트 실패: phoneNumber={}", phoneNumber, e);
-                }
-                
+                incrementAttemptCount(redisKey, data);
                 throw new InvalidVerificationCodeException("인증번호가 일치하지 않습니다.");
             }
 
@@ -136,13 +126,13 @@ public class VerificationCodeService {
                     .code(data.code())
                     .phone(data.phone())
                     .count(data.count())
-                    .status("VERIFIED")
+                    .status(STATUS_VERIFIED)
                     .build();
 
             try {
                 String verifiedJson = objectMapper.writeValueAsString(verifiedData);
-                // 인증 완료 후 10분간 유지 (토큰 발급을 위해)
-                redisTemplate.opsForValue().set(redisKey, verifiedJson, Duration.ofMinutes(10));
+                // 인증 완료 후 일정 시간 유지 (토큰 발급을 위해)
+                redisTemplate.opsForValue().set(redisKey, verifiedJson, Duration.ofMinutes(VERIFIED_EXPIRATION_MINUTES));
             } catch (JsonProcessingException e) {
                 log.error("인증 데이터 업데이트 실패: phoneNumber={}", phoneNumber, e);
             }
@@ -181,6 +171,25 @@ public class VerificationCodeService {
     public String getCode(String phoneNumber) {
         VerificationData data = getVerificationData(phoneNumber);
         return data.code();
+    }
+
+    /**
+     * 검증 시도 횟수 증가
+     */
+    private void incrementAttemptCount(String redisKey, VerificationData data) {
+        VerificationData updatedData = VerificationData.builder()
+                .code(data.code())
+                .phone(data.phone())
+                .count(data.count() + 1)
+                .status(data.status())
+                .build();
+        
+        try {
+            String updatedJson = objectMapper.writeValueAsString(updatedData);
+            redisTemplate.opsForValue().set(redisKey, updatedJson, Duration.ofMinutes(EXPIRATION_MINUTES));
+        } catch (JsonProcessingException e) {
+            log.error("인증 데이터 업데이트 실패: redisKey={}", redisKey, e);
+        }
     }
 
     /**
@@ -239,6 +248,6 @@ public class VerificationCodeService {
         redisTemplate.opsForValue().set(redisKey, String.valueOf(count), 24, TimeUnit.HOURS);
     }
 
-    public record VerificationCreateResult(LocalDateTime expiresAt) {
+    public record VerificationCreateResult(String code, LocalDateTime expiresAt) {
     }
 }

--- a/src/main/java/com/dduru/gildongmu/verification/service/VerificationCodeService.java
+++ b/src/main/java/com/dduru/gildongmu/verification/service/VerificationCodeService.java
@@ -35,6 +35,7 @@ public class VerificationCodeService {
     private static final int MAX_VERIFICATION_ATTEMPTS = 5;
     private static final int DAILY_SMS_LIMIT = 5;
     private static final int RESEND_LIMIT_MINUTES = 1;
+    private static final int DAILY_LIMIT_TTL_SECONDS = 24 * 60 * 60;
     private static final String STATUS_PENDING = "PENDING";
     private static final String STATUS_VERIFIED = "VERIFIED";
     private static final SecureRandom random = new SecureRandom();
@@ -60,17 +61,16 @@ public class VerificationCodeService {
     }
 
     public VerificationCreateResult createVerification(String phoneNumber) {
+        checkAndIncrementDailyLimit(phoneNumber);
+
         if (!canResend(phoneNumber)) {
+            rollbackDailyLimit(phoneNumber);
             throw new ResendLimitExceededException("잠시 후 다시 시도해주세요.");
         }
-
-        checkAndIncrementDailyLimit(phoneNumber);
 
         String code = generateCode();
         VerificationData data = createVerificationData(phoneNumber, code);
         saveVerificationData(phoneNumber, data);
-
-        setResendLimit(phoneNumber);
 
         LocalDateTime expiresAt = LocalDateTime.now().plusMinutes(EXPIRATION_MINUTES);
         log.info("인증번호 생성 및 저장 완료: phoneNumber={}", phoneNumber);
@@ -90,6 +90,21 @@ public class VerificationCodeService {
 
         markAsVerified(redisKey, data, phoneNumber);
         log.info("인증번호 검증 성공: phoneNumber={}", phoneNumber);
+    }
+
+    public void rollbackVerificationCreation(String phoneNumber) {
+        String authKey = REDIS_KEY_PREFIX + phoneNumber;
+        String dailyLimitKey = DAILY_LIMIT_KEY_PREFIX + phoneNumber;
+        
+        redisTemplate.delete(authKey);
+        redisTemplate.opsForValue().decrement(dailyLimitKey);
+        
+        log.info("인증 생성 롤백 완료: phoneNumber={}", phoneNumber);
+    }
+
+    public void setResendLimit(String phoneNumber) {
+        String redisKey = RESEND_LIMIT_KEY_PREFIX + phoneNumber;
+        redisTemplate.opsForValue().set(redisKey, "1", RESEND_LIMIT_MINUTES, TimeUnit.MINUTES);
     }
 
     private VerificationData createVerificationData(String phoneNumber, String code) {
@@ -178,6 +193,7 @@ public class VerificationCodeService {
             redisTemplate.opsForValue().set(redisKey, updatedJson, Duration.ofMinutes(EXPIRATION_MINUTES));
         } catch (JsonProcessingException e) {
             log.error("인증 데이터 업데이트 실패: redisKey={}", redisKey, e);
+            throw new VerificationCreationException("인증 시도 횟수 업데이트에 실패했습니다.");
         }
     }
 
@@ -194,22 +210,23 @@ public class VerificationCodeService {
         return value == null;
     }
 
-    private void setResendLimit(String phoneNumber) {
-        String redisKey = RESEND_LIMIT_KEY_PREFIX + phoneNumber;
-        redisTemplate.opsForValue().set(redisKey, "1", RESEND_LIMIT_MINUTES, TimeUnit.MINUTES);
-    }
-
     private void checkAndIncrementDailyLimit(String phoneNumber) {
         String redisKey = DAILY_LIMIT_KEY_PREFIX + phoneNumber;
         
         List<String> keys = Collections.singletonList(redisKey);
         Long result = redisTemplate.execute(dailyLimitScript, keys, 
             String.valueOf(DAILY_SMS_LIMIT), 
-            String.valueOf(24 * 60 * 60));
-        
+            String.valueOf(DAILY_LIMIT_TTL_SECONDS));
+
         if (result < 0) {
             throw new DailySmsLimitExceededException("일일 발송 한도를 초과했습니다.");
         }
+    }
+
+    private void rollbackDailyLimit(String phoneNumber) {
+        String dailyLimitKey = DAILY_LIMIT_KEY_PREFIX + phoneNumber;
+        redisTemplate.opsForValue().decrement(dailyLimitKey);
+        log.debug("일일 한도 롤백 완료: phoneNumber={}", phoneNumber);
     }
 
     public record VerificationCreateResult(String code, LocalDateTime expiresAt) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -38,6 +38,11 @@ aws:
         access-key: ${AWS_S3_ACCESS_KEY}
         secret-key: ${AWS_S3_SECRET_KEY}
 
+coolsms:
+    api-key: ${COOLSMS_API_KEY}
+    api-secret: ${COOLSMS_API_SECRET}
+    from-number: ${COOLSMS_FROM_NUMBER}
+
 springdoc:
   api-docs:
     path: /v3/api-docs

--- a/src/test/java/com/dduru/gildongmu/common/jwt/JwtTokenProviderTest.java
+++ b/src/test/java/com/dduru/gildongmu/common/jwt/JwtTokenProviderTest.java
@@ -1,0 +1,61 @@
+package com.dduru.gildongmu.common.jwt;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Date;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class JwtTokenProviderTest {
+
+    private static final String SECRET = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==";
+
+    private JwtTokenProvider createProvider() {
+        JwtTokenProvider provider = new JwtTokenProvider();
+        ReflectionTestUtils.setField(provider, "jwtSecret", SECRET);
+        ReflectionTestUtils.setField(provider, "jwtExpirationMs", 60_000);
+        return provider;
+    }
+
+    @Test
+    void 인증토큰_주체는_userId_클레임은_전화번호() {
+        // given
+        JwtTokenProvider provider = createProvider();
+
+        // when
+        String token = provider.createVerificationToken(42L, "01012345678");
+
+        // then
+        Claims claims = Jwts.parser()
+                .setSigningKey(SECRET)
+                .parseClaimsJws(token)
+                .getBody();
+
+        assertThat(claims.getSubject()).isEqualTo("42");
+        assertThat(claims.get("phone_number", String.class)).isEqualTo("01012345678");
+        assertThat(claims.get("type", String.class)).isEqualTo("verification");
+        assertThat(claims.getExpiration()).isAfter(new Date());
+    }
+
+    @Test
+    void 인증토큰_userId없으면_subject를_전화번호로_대체() {
+        // given
+        JwtTokenProvider provider = createProvider();
+
+        // when
+        String token = provider.createVerificationToken(null, "01099998888");
+
+        // then
+        Claims claims = Jwts.parser()
+                .setSigningKey(SECRET)
+                .parseClaimsJws(token)
+                .getBody();
+
+        assertThat(claims.getSubject()).isEqualTo("01099998888");
+        assertThat(claims.get("phone_number", String.class)).isEqualTo("01099998888");
+        assertThat(claims.get("type", String.class)).isEqualTo("verification");
+    }
+}

--- a/src/test/java/com/dduru/gildongmu/verification/service/PhoneVerificationServiceTest.java
+++ b/src/test/java/com/dduru/gildongmu/verification/service/PhoneVerificationServiceTest.java
@@ -1,0 +1,75 @@
+package com.dduru.gildongmu.verification.service;
+
+import com.dduru.gildongmu.common.jwt.JwtTokenProvider;
+import com.dduru.gildongmu.user.repository.UserRepository;
+import com.dduru.gildongmu.verification.dto.VerificationVerifyResponse;
+import com.dduru.gildongmu.verification.exception.DuplicatePhoneNumberException;
+import com.dduru.gildongmu.verification.exception.SmsSendFailedException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class PhoneVerificationServiceTest {
+
+    @Mock
+    private SmsService smsService;
+    @Mock
+    private VerificationCodeService verificationCodeService;
+    @Mock
+    private JwtTokenProvider jwtTokenProvider;
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private PhoneVerificationService phoneVerificationService;
+
+    @Test
+    void 인증번호발송_가입된번호면_예외발생() {
+        // given
+        when(userRepository.existsByPhoneNumber("01012345678")).thenReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> phoneVerificationService.sendVerificationCode("01012345678"))
+                .isInstanceOf(DuplicatePhoneNumberException.class);
+
+        verify(verificationCodeService, never()).createVerification(anyString());
+    }
+
+    @Test
+    void 인증번호발송_SMS실패시_롤백후_예외발생() {
+        // given
+        when(userRepository.existsByPhoneNumber(anyString())).thenReturn(false);
+        VerificationCodeService.VerificationCreateResult result =
+                new VerificationCodeService.VerificationCreateResult("999999", java.time.LocalDateTime.now().plusMinutes(3));
+        when(verificationCodeService.createVerification("01022223333")).thenReturn(result);
+        doThrow(new RuntimeException("sms fail")).when(smsService).sendSms(anyString(), anyString());
+
+        // when & then
+        assertThatThrownBy(() -> phoneVerificationService.sendVerificationCode("01022223333"))
+                .isInstanceOf(SmsSendFailedException.class);
+
+        verify(verificationCodeService).rollbackVerificationCreation("01022223333");
+        verify(verificationCodeService, never()).setResendLimit(anyString());
+    }
+
+    @Test
+    void 인증검증_위임및_토큰반환() {
+        // given
+        when(jwtTokenProvider.createVerificationToken(null, "01033334444")).thenReturn("token");
+
+        // when
+        VerificationVerifyResponse response = phoneVerificationService.verifyCode("01033334444", "123456");
+
+        // then
+        verify(verificationCodeService).verifyCode("01033334444", "123456");
+        verify(jwtTokenProvider).createVerificationToken(null, "01033334444");
+        org.assertj.core.api.Assertions.assertThat(response.token()).isEqualTo("token");
+    }
+}

--- a/src/test/java/com/dduru/gildongmu/verification/service/VerificationCodeServiceTest.java
+++ b/src/test/java/com/dduru/gildongmu/verification/service/VerificationCodeServiceTest.java
@@ -1,0 +1,98 @@
+package com.dduru.gildongmu.verification.service;
+
+import com.dduru.gildongmu.verification.dto.VerificationData;
+import com.dduru.gildongmu.verification.exception.*;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+import java.time.Duration;
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class VerificationCodeServiceTest {
+
+    @Mock
+    private RedisTemplate<String, String> redisTemplate;
+    @Mock
+    private ValueOperations<String, String> valueOperations;
+    @Spy
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    @InjectMocks
+    private VerificationCodeService verificationCodeService;
+
+    @BeforeEach
+    void setUp() {
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        verificationCodeService.init();
+    }
+
+    @Test
+    void 인증생성_재발송제한이면_예외발생하고_일일한도롤백() {
+        // given : 일일 한도는 통과하지만 재발송 키가 존재
+        when(redisTemplate.execute(any(), eq(Collections.singletonList("sms:daily:01011112222")), any(), any()))
+                .thenReturn(1L);
+        when(valueOperations.get("sms:resend:01011112222")).thenReturn("1");
+
+        // when & then
+        assertThatThrownBy(() -> verificationCodeService.createVerification("01011112222"))
+                .isInstanceOf(ResendLimitExceededException.class);
+        verify(valueOperations).decrement("sms:daily:01011112222"); // rollback
+    }
+
+    @Test
+    void 인증검증_코드불일치면_예외발생하고_횟수증가() throws Exception {
+        // given
+        String phone = "01022223333";
+        VerificationData data = VerificationData.builder()
+                .code("123456")
+                .phone(phone)
+                .count(0)
+                .status("PENDING")
+                .build();
+        String json = objectMapper.writeValueAsString(data);
+        when(valueOperations.get("sms:auth:" + phone)).thenReturn(json);
+
+        // when & then
+        assertThatThrownBy(() -> verificationCodeService.verifyCode(phone, "000000"))
+                .isInstanceOf(InvalidVerificationCodeException.class);
+
+        verify(valueOperations).set(eq("sms:auth:" + phone), contains("\"count\":1"), any(Duration.class));
+    }
+
+    @Test
+    void 인증검증_코드일치면_VERIFIED로_저장() throws Exception {
+        // given
+        String phone = "01033334444";
+        VerificationData data = VerificationData.builder()
+                .code("999999")
+                .phone(phone)
+                .count(2)
+                .status("PENDING")
+                .build();
+        String json = objectMapper.writeValueAsString(data);
+        when(valueOperations.get("sms:auth:" + phone)).thenReturn(json);
+
+        // when
+        verificationCodeService.verifyCode(phone, "999999");
+
+        // then
+        ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        verify(valueOperations).set(eq("sms:auth:" + phone), captor.capture(), eq(Duration.ofMinutes(10)));
+        String savedJson = captor.getValue();
+        verify(valueOperations, never()).decrement(anyString());
+        VerificationData saved = objectMapper.readValue(savedJson, VerificationData.class);
+        org.assertj.core.api.Assertions.assertThat(saved.status()).isEqualTo("VERIFIED");
+        org.assertj.core.api.Assertions.assertThat(saved.count()).isEqualTo(2);
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -26,10 +26,33 @@ spring:
 
 jwt:
   expiration: -1
+  secret: test-secret-key-for-jwt
+  refresh-expiration: 3600000
 
 aws:
   s3:
     enabled: false
+    region: ap-northeast-2
+    bucket: dummy-bucket
+    access-key: dummy
+    secret-key: dummy
+
+oauth:
+  kakao:
+    rest-client-id: dummy
+    client-id: dummy
+    client-secret: dummy
+    redirect-uri: http://localhost
+  google:
+    android-client-id: dummy
+    client-id: dummy
+    client-secret: dummy
+    redirect-uri: http://localhost
+
+coolsms:
+  api-key: dummy
+  api-secret: dummy
+  from-number: 01000000000
 
 logging:
   level:

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -27,6 +27,10 @@ spring:
 jwt:
   expiration: -1
 
+aws:
+  s3:
+    enabled: false
+
 logging:
   level:
     com.dduru.gildongmu: debug


### PR DESCRIPTION
## 🔎 작업 내용
*  CoolSMS 공식 Java SDK를 도입하여 휴대폰 인증번호 발송 및 검증 기능을 구현
*  Redis 기반 인증번호 생성/검증 서비스
 -인증번호 생성 (6자리)
 -Redis 저장 (만료: 3분)
 -재발송 제한 (1분)
 -일일 발송 한도 (5건)
 -검증 시도 횟수 제한 (5회)
* 메시지 형식: `[뚜르] 인증번호는 [320509]입니다. 3분 내에 입력해주세요.`
* 휴대폰 인증 테스트 코드 추가
* test.yml에 aws 더미값 추가
* s3config,controller,service 테스트에서는 안돌아가게 설정
## ➕ 이슈 링크
* #106 

## 📸 스크린샷(선택)


## 😎 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 
<!--ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?-->
## 🧑‍💻 예정 작업
- #

## 📝 체크리스트
- [x] 브랜치 이름은 `feature/개발내용` 형식으로 작성했는가?
- [x] 커밋 메시지는 `feat: 커밋 내용` 형식으로 작성했는가?
- [x] 작업 전 Issue를 작성했는가?
- [x] `dev` 브랜치로 병합을 요청했는가?
- [x] 불필요한 주석과 공백은 제거했는가?
- [x] 코드 리뷰어의 피드백을 반영했는가?
- [x] 테스트를 진행했는가?
- [x] 테스트 코드를 작성했는가?
- 
