### PR TITLE
docs: Swagger UI 문서 전면 개선 - 에러 응답 자동화, 스키마 수정, 204 응답 개선

### DIFF
--- a/src/main/java/com/dduru/gildongmu/S3/controller/S3ApiDocs.java
+++ b/src/main/java/com/dduru/gildongmu/S3/controller/S3ApiDocs.java
@@ -2,7 +2,9 @@ package com.dduru.gildongmu.S3.controller;
 
 import com.dduru.gildongmu.S3.dto.ImageUploadRequest;
 import com.dduru.gildongmu.S3.dto.ImageUploadResponse;
+import com.dduru.gildongmu.common.annotation.ApiErrorResponses;
 import com.dduru.gildongmu.common.dto.ApiResult;
+import com.dduru.gildongmu.common.exception.ErrorCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -19,5 +21,9 @@ public interface S3ApiDocs {
     @ApiResponse(responseCode = "200", description = "Presigned URL 생성 성공",
             content = @Content(mediaType = "application/json",
             schema = @Schema(implementation = ImageUploadResponse.class)))
+    @ApiErrorResponses({
+            ErrorCode.INVALID_INPUT_VALUE,
+            ErrorCode.INVALID_FILE_EXTENSION
+    })
     ResponseEntity<ApiResult<ImageUploadResponse>> prepareUpload(@RequestBody ImageUploadRequest request);
 }

--- a/src/main/java/com/dduru/gildongmu/S3/controller/S3ApiDocs.java
+++ b/src/main/java/com/dduru/gildongmu/S3/controller/S3ApiDocs.java
@@ -6,8 +6,6 @@ import com.dduru.gildongmu.common.annotation.ApiErrorResponses;
 import com.dduru.gildongmu.common.dto.ApiResult;
 import com.dduru.gildongmu.common.exception.ErrorCode;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
@@ -18,9 +16,7 @@ public interface S3ApiDocs {
 
     @Operation(summary = "이미지 업로드를 위한 Presigned URL 생성",
                description = "S3에 이미지를 직접 업로드하기 위한 Presigned URL을 생성합니다.")
-    @ApiResponse(responseCode = "200", description = "Presigned URL 생성 성공",
-            content = @Content(mediaType = "application/json",
-            schema = @Schema(implementation = ImageUploadResponse.class)))
+    @ApiResponse(responseCode = "200", description = "Presigned URL 생성 성공")
     @ApiErrorResponses({
             ErrorCode.INVALID_INPUT_VALUE,
             ErrorCode.INVALID_FILE_EXTENSION

--- a/src/main/java/com/dduru/gildongmu/auth/controller/OauthApiDocs.java
+++ b/src/main/java/com/dduru/gildongmu/auth/controller/OauthApiDocs.java
@@ -8,6 +8,7 @@ import com.dduru.gildongmu.common.dto.ApiResult;
 import com.dduru.gildongmu.common.exception.ErrorCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -42,7 +43,7 @@ public interface OauthApiDocs {
     ResponseEntity<ApiResult<LoginResponse>> refreshAccessToken(@Valid RefreshTokenRequest request);
 
     @Operation(summary = "로그아웃", description = "사용자 로그아웃을 처리합니다.", security = @SecurityRequirement(name = "JWT"))
-    @ApiResponse(responseCode = "204", description = "로그아웃 성공")
+    @ApiResponse(responseCode = "204", description = "로그아웃 성공", content = @Content())
     @ApiErrorResponses({ErrorCode.UNAUTHORIZED, ErrorCode.INVALID_TOKEN, ErrorCode.EXPIRED_TOKEN})
     ResponseEntity<ApiResult<Void>> logout(@Parameter(hidden = true) Long userId);
 }

--- a/src/main/java/com/dduru/gildongmu/auth/controller/OauthApiDocs.java
+++ b/src/main/java/com/dduru/gildongmu/auth/controller/OauthApiDocs.java
@@ -3,11 +3,12 @@ package com.dduru.gildongmu.auth.controller;
 import com.dduru.gildongmu.auth.dto.LoginRequest;
 import com.dduru.gildongmu.auth.dto.LoginResponse;
 import com.dduru.gildongmu.auth.dto.RefreshTokenRequest;
+import com.dduru.gildongmu.common.annotation.ApiErrorResponses;
 import com.dduru.gildongmu.common.dto.ApiResult;
+import com.dduru.gildongmu.common.exception.ErrorCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -18,10 +19,13 @@ import org.springframework.web.bind.annotation.RequestBody;
 public interface OauthApiDocs {
 
     @Operation(summary = "ID Token 로그인 (모바일)", description = "ID Token을 사용한 OAuth 로그인을 처리합니다.")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "로그인 성공"),
-            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
-            @ApiResponse(responseCode = "401", description = "유효하지 않은 ID Token")
+    @ApiResponse(responseCode = "200", description = "로그인 성공")
+    @ApiErrorResponses({
+            ErrorCode.INVALID_INPUT_VALUE,
+            ErrorCode.UNSUPPORTED_SOCIAL_LOGIN,
+            ErrorCode.SOCIAL_LOGIN_FAILED,
+            ErrorCode.INVALID_TOKEN,
+            ErrorCode.DUPLICATE_EMAIL
     })
     ResponseEntity<ApiResult<LoginResponse>> loginWithIdToken(
             @Parameter(description = "OAuth Provider (kakao, google)", example = "kakao") String provider,
@@ -29,16 +33,16 @@ public interface OauthApiDocs {
     );
 
     @Operation(summary = "Access Token 갱신", description = "Refresh Token을 사용하여 Access Token을 갱신합니다.")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "토큰 갱신 성공"),
-            @ApiResponse(responseCode = "400", description = "잘못된 Refresh Token")
+    @ApiResponse(responseCode = "200", description = "토큰 갱신 성공")
+    @ApiErrorResponses({
+            ErrorCode.INVALID_INPUT_VALUE,
+            ErrorCode.INVALID_TOKEN,
+            ErrorCode.EXPIRED_TOKEN
     })
     ResponseEntity<ApiResult<LoginResponse>> refreshAccessToken(@Valid RefreshTokenRequest request);
 
     @Operation(summary = "로그아웃", description = "사용자 로그아웃을 처리합니다.", security = @SecurityRequirement(name = "JWT"))
-    @ApiResponses({
-            @ApiResponse(responseCode = "204", description = "로그아웃 성공"),
-            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자")
-    })
+    @ApiResponse(responseCode = "204", description = "로그아웃 성공")
+    @ApiErrorResponses({ErrorCode.UNAUTHORIZED, ErrorCode.INVALID_TOKEN, ErrorCode.EXPIRED_TOKEN})
     ResponseEntity<ApiResult<Void>> logout(@Parameter(hidden = true) Long userId);
 }

--- a/src/main/java/com/dduru/gildongmu/comment/controller/CommentApiDocs.java
+++ b/src/main/java/com/dduru/gildongmu/comment/controller/CommentApiDocs.java
@@ -3,11 +3,12 @@ package com.dduru.gildongmu.comment.controller;
 import com.dduru.gildongmu.comment.dto.CommentCreateRequest;
 import com.dduru.gildongmu.comment.dto.CommentResponse;
 import com.dduru.gildongmu.comment.dto.CommentUpdateRequest;
+import com.dduru.gildongmu.common.annotation.ApiErrorResponses;
 import com.dduru.gildongmu.common.dto.ApiResult;
+import com.dduru.gildongmu.common.exception.ErrorCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
@@ -17,10 +18,14 @@ import java.util.List;
 @Tag(name = "Comments", description = "댓글 API")
 public interface CommentApiDocs {
     @Operation(summary = "댓글 작성", description = "게시글에 새로운 댓글을 작성합니다.")
-    @ApiResponses({
-            @ApiResponse(responseCode = "201", description = "작성 성공"),
-            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
-            @ApiResponse(responseCode = "404", description = "게시글 또는 부모 댓글을 찾을 수 없음")
+    @ApiResponse(responseCode = "201", description = "작성 성공")
+    @ApiErrorResponses({
+            ErrorCode.INVALID_INPUT_VALUE,
+            ErrorCode.POST_NOT_FOUND,
+            ErrorCode.COMMENT_NOT_FOUND,
+            ErrorCode.INVALID_PARENT_COMMENT,
+            ErrorCode.USER_NOT_FOUND,
+            ErrorCode.UNAUTHORIZED
     })
     ResponseEntity<ApiResult<CommentResponse>> createComment(
             @Parameter(hidden = true) Long userId,
@@ -29,18 +34,20 @@ public interface CommentApiDocs {
     );
 
     @Operation(summary = "게시글 댓글 조회", description = "특정 게시글의 모든 댓글을 조회합니다. 대댓글 포함 계층 구조로 반환됩니다.")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "조회 성공"),
-            @ApiResponse(responseCode = "404", description = "게시글을 찾을 수 없음")
-    })
+    @ApiResponse(responseCode = "200", description = "조회 성공")
+    @ApiErrorResponses({ErrorCode.POST_NOT_FOUND})
     ResponseEntity<ApiResult<List<CommentResponse>>> retrieveComments(
             @Parameter(description = "게시글 ID") Long postId
     );
 
     @Operation(summary = "댓글 삭제", description = "특정 게시글의 댓글을 삭제합니다.")
-    @ApiResponses({
-            @ApiResponse(responseCode = "204", description = "삭제 성공"),
-            @ApiResponse(responseCode = "404", description = "게시글 또는 댓글을 찾을 수 없음")
+    @ApiResponse(responseCode = "204", description = "삭제 성공")
+    @ApiErrorResponses({
+            ErrorCode.POST_NOT_FOUND,
+            ErrorCode.COMMENT_NOT_FOUND,
+            ErrorCode.COMMENT_ACCESS_DENIED,
+            ErrorCode.INVALID_PARENT_COMMENT,
+            ErrorCode.UNAUTHORIZED
     })
     ResponseEntity<ApiResult<Void>> deleteComment(
             @Parameter(hidden = true) Long userId,
@@ -49,9 +56,14 @@ public interface CommentApiDocs {
     );
 
     @Operation(summary = "댓글 수정", description = "특정 게시글의 댓글을 수정합니다.")
-    @ApiResponses({
-            @ApiResponse(responseCode = "204", description = "수정 성공"),
-            @ApiResponse(responseCode = "404", description = "게시글 또는 댓글을 찾을 수 없음")
+    @ApiResponse(responseCode = "204", description = "수정 성공")
+    @ApiErrorResponses({
+            ErrorCode.INVALID_INPUT_VALUE,
+            ErrorCode.POST_NOT_FOUND,
+            ErrorCode.COMMENT_NOT_FOUND,
+            ErrorCode.COMMENT_ACCESS_DENIED,
+            ErrorCode.INVALID_PARENT_COMMENT,
+            ErrorCode.UNAUTHORIZED
     })
     ResponseEntity<ApiResult<Void>> updateComment(
             @Parameter(hidden = true) Long userId,

--- a/src/main/java/com/dduru/gildongmu/comment/controller/CommentApiDocs.java
+++ b/src/main/java/com/dduru/gildongmu/comment/controller/CommentApiDocs.java
@@ -8,6 +8,7 @@ import com.dduru.gildongmu.common.dto.ApiResult;
 import com.dduru.gildongmu.common.exception.ErrorCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -41,7 +42,7 @@ public interface CommentApiDocs {
     );
 
     @Operation(summary = "댓글 삭제", description = "특정 게시글의 댓글을 삭제합니다.")
-    @ApiResponse(responseCode = "204", description = "삭제 성공")
+    @ApiResponse(responseCode = "204", description = "삭제 성공", content = @Content())
     @ApiErrorResponses({
             ErrorCode.POST_NOT_FOUND,
             ErrorCode.COMMENT_NOT_FOUND,
@@ -56,7 +57,7 @@ public interface CommentApiDocs {
     );
 
     @Operation(summary = "댓글 수정", description = "특정 게시글의 댓글을 수정합니다.")
-    @ApiResponse(responseCode = "204", description = "수정 성공")
+    @ApiResponse(responseCode = "204", description = "수정 성공", content = @Content())
     @ApiErrorResponses({
             ErrorCode.INVALID_INPUT_VALUE,
             ErrorCode.POST_NOT_FOUND,

--- a/src/main/java/com/dduru/gildongmu/like/controller/CommentLikeApiDocs.java
+++ b/src/main/java/com/dduru/gildongmu/like/controller/CommentLikeApiDocs.java
@@ -6,6 +6,7 @@ import com.dduru.gildongmu.common.dto.ApiResult;
 import com.dduru.gildongmu.common.exception.ErrorCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
@@ -14,7 +15,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 @Tag(name = "Comments", description = "댓글 좋아요 관련 API")
 public interface CommentLikeApiDocs {
     @Operation(summary = "댓글 좋아요 토글", description = "댓글에 대한 좋아요를 추가하거나 삭제합니다.")
-    @ApiResponse(responseCode = "204", description = "좋아요 토글 성공")
+    @ApiResponse(responseCode = "204", description = "좋아요 토글 성공", content = @Content())
     @ApiErrorResponses({
             ErrorCode.COMMENT_NOT_FOUND,
             ErrorCode.USER_NOT_FOUND,

--- a/src/main/java/com/dduru/gildongmu/like/controller/CommentLikeApiDocs.java
+++ b/src/main/java/com/dduru/gildongmu/like/controller/CommentLikeApiDocs.java
@@ -1,7 +1,9 @@
 package com.dduru.gildongmu.like.controller;
 
+import com.dduru.gildongmu.common.annotation.ApiErrorResponses;
 import com.dduru.gildongmu.common.annotation.CurrentUser;
 import com.dduru.gildongmu.common.dto.ApiResult;
+import com.dduru.gildongmu.common.exception.ErrorCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -13,5 +15,10 @@ import org.springframework.web.bind.annotation.PathVariable;
 public interface CommentLikeApiDocs {
     @Operation(summary = "댓글 좋아요 토글", description = "댓글에 대한 좋아요를 추가하거나 삭제합니다.")
     @ApiResponse(responseCode = "204", description = "좋아요 토글 성공")
+    @ApiErrorResponses({
+            ErrorCode.COMMENT_NOT_FOUND,
+            ErrorCode.USER_NOT_FOUND,
+            ErrorCode.UNAUTHORIZED
+    })
     ResponseEntity<ApiResult<Void>> toggleCommentLike(@Parameter(hidden = true) @CurrentUser Long userId, @PathVariable Long commentId);
 }

--- a/src/main/java/com/dduru/gildongmu/like/controller/PostLikeApiDocs.java
+++ b/src/main/java/com/dduru/gildongmu/like/controller/PostLikeApiDocs.java
@@ -1,7 +1,9 @@
 package com.dduru.gildongmu.like.controller;
 
+import com.dduru.gildongmu.common.annotation.ApiErrorResponses;
 import com.dduru.gildongmu.common.annotation.CurrentUser;
 import com.dduru.gildongmu.common.dto.ApiResult;
+import com.dduru.gildongmu.common.exception.ErrorCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -13,5 +15,10 @@ import org.springframework.web.bind.annotation.PathVariable;
 public interface PostLikeApiDocs {
     @Operation(summary = "게시글 좋아요 토글", description = "게시글에 대한 좋아요를 추가하거나 삭제합니다.")
     @ApiResponse(responseCode = "204", description = "좋아요 토글 성공")
+    @ApiErrorResponses({
+            ErrorCode.POST_NOT_FOUND,
+            ErrorCode.USER_NOT_FOUND,
+            ErrorCode.UNAUTHORIZED
+    })
     ResponseEntity<ApiResult<Void>> togglePostLike(@Parameter(hidden = true) @CurrentUser Long userId, @PathVariable Long postId);
 }

--- a/src/main/java/com/dduru/gildongmu/like/controller/PostLikeApiDocs.java
+++ b/src/main/java/com/dduru/gildongmu/like/controller/PostLikeApiDocs.java
@@ -6,6 +6,7 @@ import com.dduru.gildongmu.common.dto.ApiResult;
 import com.dduru.gildongmu.common.exception.ErrorCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
@@ -14,7 +15,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 @Tag(name = "Posts", description = "게시글 좋아요 관련 API")
 public interface PostLikeApiDocs {
     @Operation(summary = "게시글 좋아요 토글", description = "게시글에 대한 좋아요를 추가하거나 삭제합니다.")
-    @ApiResponse(responseCode = "204", description = "좋아요 토글 성공")
+    @ApiResponse(responseCode = "204", description = "좋아요 토글 성공", content = @Content())
     @ApiErrorResponses({
             ErrorCode.POST_NOT_FOUND,
             ErrorCode.USER_NOT_FOUND,

--- a/src/main/java/com/dduru/gildongmu/participation/controller/ParticipationApiDocs.java
+++ b/src/main/java/com/dduru/gildongmu/participation/controller/ParticipationApiDocs.java
@@ -7,6 +7,7 @@ import com.dduru.gildongmu.participation.dto.ParticipationRequest;
 import com.dduru.gildongmu.participation.dto.ParticipationResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -49,7 +50,7 @@ public interface ParticipationApiDocs {
     );
 
     @Operation(summary = "참여 신청 승인", description = "게시글 참여 신청을 승인합니다.")
-    @ApiResponse(responseCode = "204", description = "참여 신청 승인 성공")
+    @ApiResponse(responseCode = "204", description = "참여 신청 승인 성공", content = @Content())
     @ApiErrorResponses({
             ErrorCode.POST_NOT_FOUND,
             ErrorCode.PARTICIPATION_NOT_FOUND,
@@ -65,7 +66,7 @@ public interface ParticipationApiDocs {
     );
 
     @Operation(summary = "참여 신청 거절", description = "게시글 참여 신청을 거절합니다.")
-    @ApiResponse(responseCode = "204", description = "참여 신청 거절 성공")
+    @ApiResponse(responseCode = "204", description = "참여 신청 거절 성공", content = @Content())
     @ApiErrorResponses({
             ErrorCode.POST_NOT_FOUND,
             ErrorCode.PARTICIPATION_NOT_FOUND,
@@ -80,7 +81,7 @@ public interface ParticipationApiDocs {
     );
 
     @Operation(summary = "참여 취소", description = "게시글 참여를 취소합니다.")
-    @ApiResponse(responseCode = "204", description = "참여 취소 성공")
+    @ApiResponse(responseCode = "204", description = "참여 취소 성공", content = @Content())
     @ApiErrorResponses({
             ErrorCode.POST_NOT_FOUND,
             ErrorCode.PARTICIPATION_NOT_FOUND,

--- a/src/main/java/com/dduru/gildongmu/participation/controller/ParticipationApiDocs.java
+++ b/src/main/java/com/dduru/gildongmu/participation/controller/ParticipationApiDocs.java
@@ -1,12 +1,13 @@
 package com.dduru.gildongmu.participation.controller;
 
+import com.dduru.gildongmu.common.annotation.ApiErrorResponses;
 import com.dduru.gildongmu.common.dto.ApiResult;
+import com.dduru.gildongmu.common.exception.ErrorCode;
 import com.dduru.gildongmu.participation.dto.ParticipationRequest;
 import com.dduru.gildongmu.participation.dto.ParticipationResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -19,8 +20,15 @@ import java.util.List;
 public interface ParticipationApiDocs {
 
     @Operation(summary = "참여 신청", description = "게시글에 참여 신청을 합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "201", description = "참여 신청 성공"),
+    @ApiResponse(responseCode = "201", description = "참여 신청 성공")
+    @ApiErrorResponses({
+            ErrorCode.INVALID_INPUT_VALUE,
+            ErrorCode.POST_NOT_FOUND,
+            ErrorCode.RECRUITMENT_CLOSED,
+            ErrorCode.DUPLICATE_PARTICIPATION,
+            ErrorCode.SELF_PARTICIPATION_NOT_ALLOWED,
+            ErrorCode.USER_NOT_FOUND,
+            ErrorCode.UNAUTHORIZED
     })
     ResponseEntity<ApiResult<ParticipationResponse>> createParticipation(
             @Parameter(description = "게시글 ID") Long postId,
@@ -29,8 +37,11 @@ public interface ParticipationApiDocs {
     );
 
     @Operation(summary = "게시글 참여자 목록 조회", description = "게시글에 참여한 사용자 목록을 조회합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "참여자 목록 조회 성공"),
+    @ApiResponse(responseCode = "200", description = "참여자 목록 조회 성공")
+    @ApiErrorResponses({
+            ErrorCode.POST_NOT_FOUND,
+            ErrorCode.POST_ACCESS_DENIED,
+            ErrorCode.UNAUTHORIZED
     })
     ResponseEntity<ApiResult<List<ParticipationResponse>>> getPostParticipants(
             @Parameter(description = "게시글 ID") Long postId,
@@ -38,8 +49,14 @@ public interface ParticipationApiDocs {
     );
 
     @Operation(summary = "참여 신청 승인", description = "게시글 참여 신청을 승인합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "204", description = "참여 신청 승인 성공"),
+    @ApiResponse(responseCode = "204", description = "참여 신청 승인 성공")
+    @ApiErrorResponses({
+            ErrorCode.POST_NOT_FOUND,
+            ErrorCode.PARTICIPATION_NOT_FOUND,
+            ErrorCode.POST_ACCESS_DENIED,
+            ErrorCode.PARTICIPATION_POST_MISMATCH,
+            ErrorCode.RECRUIT_COUNT_EXCEED_CAPACITY,
+            ErrorCode.UNAUTHORIZED
     })
     ResponseEntity<ApiResult<Void>> approveParticipation(
             @Parameter(description = "게시글 ID") Long postId,
@@ -48,8 +65,13 @@ public interface ParticipationApiDocs {
     );
 
     @Operation(summary = "참여 신청 거절", description = "게시글 참여 신청을 거절합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "204", description = "참여 신청 거절 성공"),
+    @ApiResponse(responseCode = "204", description = "참여 신청 거절 성공")
+    @ApiErrorResponses({
+            ErrorCode.POST_NOT_FOUND,
+            ErrorCode.PARTICIPATION_NOT_FOUND,
+            ErrorCode.POST_ACCESS_DENIED,
+            ErrorCode.PARTICIPATION_POST_MISMATCH,
+            ErrorCode.UNAUTHORIZED
     })
     ResponseEntity<ApiResult<Void>> rejectParticipation(
             @Parameter(description = "게시글 ID") Long postId,
@@ -58,8 +80,14 @@ public interface ParticipationApiDocs {
     );
 
     @Operation(summary = "참여 취소", description = "게시글 참여를 취소합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "204", description = "참여 취소 성공"),
+    @ApiResponse(responseCode = "204", description = "참여 취소 성공")
+    @ApiErrorResponses({
+            ErrorCode.POST_NOT_FOUND,
+            ErrorCode.PARTICIPATION_NOT_FOUND,
+            ErrorCode.POST_ACCESS_DENIED,
+            ErrorCode.PARTICIPATION_POST_MISMATCH,
+            ErrorCode.RECRUIT_COUNT_BELOW_ZERO,
+            ErrorCode.UNAUTHORIZED
     })
     ResponseEntity<ApiResult<Void>> cancelParticipation(
             @Parameter(description = "게시글 ID") Long postId,

--- a/src/main/java/com/dduru/gildongmu/post/controller/PostApiDocs.java
+++ b/src/main/java/com/dduru/gildongmu/post/controller/PostApiDocs.java
@@ -11,6 +11,7 @@ import com.dduru.gildongmu.post.dto.PostStatusUpdateRequest;
 import com.dduru.gildongmu.post.dto.PostUpdateRequest;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -60,7 +61,7 @@ public interface PostApiDocs {
     );
 
     @Operation(summary = "게시글 수정", description = "게시글을 수정합니다.")
-    @ApiResponse(responseCode = "204", description = "수정 성공")
+    @ApiResponse(responseCode = "204", description = "수정 성공", content = @Content())
     @ApiErrorResponses({
             ErrorCode.INVALID_INPUT_VALUE,
             ErrorCode.POST_NOT_FOUND,
@@ -82,7 +83,7 @@ public interface PostApiDocs {
     );
 
     @Operation(summary = "게시글 삭제", description = "게시글을 삭제합니다.")
-    @ApiResponse(responseCode = "204", description = "삭제 성공")
+    @ApiResponse(responseCode = "204", description = "삭제 성공", content = @Content())
     @ApiErrorResponses({
             ErrorCode.POST_NOT_FOUND,
             ErrorCode.POST_ACCESS_DENIED,
@@ -94,7 +95,7 @@ public interface PostApiDocs {
     );
 
     @Operation(summary = "게시글 모집 상태 변경", description = "게시글 모집 상태를 변경합니다. (true: 모집중, false: 모집마감)")
-    @ApiResponse(responseCode = "204", description = "상태 변경 성공")
+    @ApiResponse(responseCode = "204", description = "상태 변경 성공", content = @Content())
     @ApiErrorResponses({
             ErrorCode.INVALID_INPUT_VALUE,
             ErrorCode.POST_NOT_FOUND,

--- a/src/main/java/com/dduru/gildongmu/post/controller/PostApiDocs.java
+++ b/src/main/java/com/dduru/gildongmu/post/controller/PostApiDocs.java
@@ -1,11 +1,17 @@
 package com.dduru.gildongmu.post.controller;
 
+import com.dduru.gildongmu.common.annotation.ApiErrorResponses;
 import com.dduru.gildongmu.common.dto.ApiResult;
-import com.dduru.gildongmu.post.dto.*;
+import com.dduru.gildongmu.common.exception.ErrorCode;
+import com.dduru.gildongmu.post.dto.PostCreateRequest;
+import com.dduru.gildongmu.post.dto.PostCreateResponse;
+import com.dduru.gildongmu.post.dto.PostDetailResponse;
+import com.dduru.gildongmu.post.dto.PostListResponse;
+import com.dduru.gildongmu.post.dto.PostStatusUpdateRequest;
+import com.dduru.gildongmu.post.dto.PostUpdateRequest;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -31,18 +37,22 @@ public interface PostApiDocs {
     );
 
     @Operation(summary = "게시글 상세 조회", description = "게시글 상세 정보를 조회합니다.")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "조회 성공"),
-            @ApiResponse(responseCode = "404", description = "게시글을 찾을 수 없음")
-    })
+    @ApiResponse(responseCode = "200", description = "조회 성공")
+    @ApiErrorResponses({ErrorCode.POST_NOT_FOUND})
     ResponseEntity<ApiResult<PostDetailResponse>> getPostDetail(
             @Parameter(description = "게시글 ID") Long postId
     );
 
     @Operation(summary = "게시글 작성", description = "새로운 게시글을 작성합니다.")
-    @ApiResponses({
-            @ApiResponse(responseCode = "201", description = "작성 성공"),
-            @ApiResponse(responseCode = "400", description = "잘못된 요청")
+    @ApiResponse(responseCode = "201", description = "작성 성공")
+    @ApiErrorResponses({
+            ErrorCode.INVALID_INPUT_VALUE,
+            ErrorCode.INVALID_POST_DATE,
+            ErrorCode.INVALID_BUDGET_RANGE,
+            ErrorCode.INVALID_AGE_RANGE,
+            ErrorCode.DESTINATION_NOT_FOUND,
+            ErrorCode.USER_NOT_FOUND,
+            ErrorCode.UNAUTHORIZED
     })
     ResponseEntity<ApiResult<PostCreateResponse>> createPost(
             @Parameter(hidden = true) Long userId,
@@ -50,10 +60,20 @@ public interface PostApiDocs {
     );
 
     @Operation(summary = "게시글 수정", description = "게시글을 수정합니다.")
-    @ApiResponses({
-            @ApiResponse(responseCode = "204", description = "수정 성공"),
-            @ApiResponse(responseCode = "403", description = "권한 없음"),
-            @ApiResponse(responseCode = "404", description = "게시글을 찾을 수 없음")
+    @ApiResponse(responseCode = "204", description = "수정 성공")
+    @ApiErrorResponses({
+            ErrorCode.INVALID_INPUT_VALUE,
+            ErrorCode.POST_NOT_FOUND,
+            ErrorCode.POST_ACCESS_DENIED,
+            ErrorCode.INVALID_POST_DATE,
+            ErrorCode.INVALID_BUDGET_RANGE,
+            ErrorCode.INVALID_AGE_RANGE,
+            ErrorCode.DESTINATION_NOT_FOUND,
+            ErrorCode.TRAVEL_ALREADY_STARTED,
+            ErrorCode.TRAVEL_ALREADY_ENDED,
+            ErrorCode.INVALID_RECRUIT_CAPACITY,
+            ErrorCode.USER_NOT_FOUND,
+            ErrorCode.UNAUTHORIZED
     })
     ResponseEntity<ApiResult<Void>> updatePost(
             @Parameter(description = "게시글 ID") Long postId,
@@ -62,10 +82,11 @@ public interface PostApiDocs {
     );
 
     @Operation(summary = "게시글 삭제", description = "게시글을 삭제합니다.")
-    @ApiResponses({
-            @ApiResponse(responseCode = "204", description = "삭제 성공"),
-            @ApiResponse(responseCode = "403", description = "권한 없음"),
-            @ApiResponse(responseCode = "404", description = "게시글을 찾을 수 없음")
+    @ApiResponse(responseCode = "204", description = "삭제 성공")
+    @ApiErrorResponses({
+            ErrorCode.POST_NOT_FOUND,
+            ErrorCode.POST_ACCESS_DENIED,
+            ErrorCode.UNAUTHORIZED
     })
     ResponseEntity<ApiResult<Void>> deletePost(
             @Parameter(description = "게시글 ID") Long postId,
@@ -73,11 +94,13 @@ public interface PostApiDocs {
     );
 
     @Operation(summary = "게시글 모집 상태 변경", description = "게시글 모집 상태를 변경합니다. (true: 모집중, false: 모집마감)")
-    @ApiResponses({
-            @ApiResponse(responseCode = "204", description = "상태 변경 성공"),
-            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
-            @ApiResponse(responseCode = "403", description = "권한 없음"),
-            @ApiResponse(responseCode = "404", description = "게시글을 찾을 수 없음")
+    @ApiResponse(responseCode = "204", description = "상태 변경 성공")
+    @ApiErrorResponses({
+            ErrorCode.INVALID_INPUT_VALUE,
+            ErrorCode.POST_NOT_FOUND,
+            ErrorCode.POST_ACCESS_DENIED,
+            ErrorCode.INVALID_POST_STATUS,
+            ErrorCode.UNAUTHORIZED
     })
     ResponseEntity<ApiResult<Void>> updatePostStatus(
             @Parameter(description = "게시글 ID") Long postId,

--- a/src/main/java/com/dduru/gildongmu/profile/controller/ProfileApiDocs.java
+++ b/src/main/java/com/dduru/gildongmu/profile/controller/ProfileApiDocs.java
@@ -10,10 +10,7 @@ import com.dduru.gildongmu.profile.dto.ProfileSetupRequest;
 import com.dduru.gildongmu.profile.validator.ValidNickname;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
@@ -22,14 +19,7 @@ import org.springframework.http.ResponseEntity;
 public interface ProfileApiDocs {
 
     @Operation(summary = "닉네임 수정", description = "사용자의 닉네임을 수정합니다.")
-    @ApiResponses({
-            @ApiResponse(
-                    responseCode = "204",
-                    description = "닉네임 수정 성공",
-                    content = @Content(mediaType = "application/json",
-                            schema = @Schema(implementation = ApiResult.class))
-            )
-    })
+    @ApiResponse(responseCode = "204", description = "닉네임 수정 성공")
     @ApiErrorResponses({
             ErrorCode.NICKNAME_INVALID_LENGTH,
             ErrorCode.NICKNAME_INVALID_CHARACTERS,
@@ -44,12 +34,7 @@ public interface ProfileApiDocs {
     );
 
     @Operation(summary = "닉네임 유효성 확인", description = "닉네임의 사용 가능 여부를 확인합니다. 닉네임 형식 검증 및 중복 여부를 체크합니다.")
-    @ApiResponses({
-            @ApiResponse(
-                    responseCode = "200",
-                    description = "닉네임 유효성 확인 성공(사용가능)"
-            )
-    })
+    @ApiResponse(responseCode = "200", description = "닉네임 유효성 확인 성공(사용가능)")
     @ApiErrorResponses({
             ErrorCode.NICKNAME_INVALID_LENGTH,
             ErrorCode.NICKNAME_INVALID_CHARACTERS,
@@ -65,12 +50,7 @@ public interface ProfileApiDocs {
     );
 
     @Operation(summary = "랜덤 닉네임 생성", description = "랜덤으로 사용 가능한 닉네임을 생성합니다. 형용사와 명사 조합에 랜덤 숫자를 추가하여 고유성을 보장합니다.")
-    @ApiResponses({
-            @ApiResponse(
-                    responseCode = "200",
-                    description = "랜덤 닉네임 생성 성공"
-            )
-    })
+    @ApiResponse(responseCode = "200", description = "랜덤 닉네임 생성 성공")
     @ApiErrorResponses({ErrorCode.UNAUTHORIZED})
     ResponseEntity<ApiResult<NicknameRandomResponse>> generateRandomNickname();
 
@@ -78,14 +58,7 @@ public interface ProfileApiDocs {
             summary = "프로필 초기 설정",
             description = "온보딩 과정에서 사용자의 프로필 정보를 초기 설정합니다. 닉네임, 성별, 전화번호, 생년월일을 저장하며, 비관적 잠금을 사용하여 닉네임 중복을 방지합니다."
     )
-    @ApiResponses({
-            @ApiResponse(
-                    responseCode = "204",
-                    description = "프로필 초기 설정 성공",
-                    content = @Content(mediaType = "application/json",
-                            schema = @Schema(implementation = ApiResult.class))
-            )
-    })
+    @ApiResponse(responseCode = "204", description = "프로필 초기 설정 성공")
     @ApiErrorResponses({
             ErrorCode.INVALID_INPUT_VALUE,
             ErrorCode.NICKNAME_INVALID_LENGTH,

--- a/src/main/java/com/dduru/gildongmu/profile/controller/ProfileApiDocs.java
+++ b/src/main/java/com/dduru/gildongmu/profile/controller/ProfileApiDocs.java
@@ -10,6 +10,7 @@ import com.dduru.gildongmu.profile.dto.ProfileSetupRequest;
 import com.dduru.gildongmu.profile.validator.ValidNickname;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -19,7 +20,7 @@ import org.springframework.http.ResponseEntity;
 public interface ProfileApiDocs {
 
     @Operation(summary = "닉네임 수정", description = "사용자의 닉네임을 수정합니다.")
-    @ApiResponse(responseCode = "204", description = "닉네임 수정 성공")
+    @ApiResponse(responseCode = "204", description = "닉네임 수정 성공", content = @Content())
     @ApiErrorResponses({
             ErrorCode.NICKNAME_INVALID_LENGTH,
             ErrorCode.NICKNAME_INVALID_CHARACTERS,
@@ -58,7 +59,7 @@ public interface ProfileApiDocs {
             summary = "프로필 초기 설정",
             description = "온보딩 과정에서 사용자의 프로필 정보를 초기 설정합니다. 닉네임, 성별, 전화번호, 생년월일을 저장하며, 비관적 잠금을 사용하여 닉네임 중복을 방지합니다."
     )
-    @ApiResponse(responseCode = "204", description = "프로필 초기 설정 성공")
+    @ApiResponse(responseCode = "204", description = "프로필 초기 설정 성공", content = @Content())
     @ApiErrorResponses({
             ErrorCode.INVALID_INPUT_VALUE,
             ErrorCode.NICKNAME_INVALID_LENGTH,

--- a/src/main/java/com/dduru/gildongmu/profile/controller/ProfileApiDocs.java
+++ b/src/main/java/com/dduru/gildongmu/profile/controller/ProfileApiDocs.java
@@ -47,9 +47,7 @@ public interface ProfileApiDocs {
     @ApiResponses({
             @ApiResponse(
                     responseCode = "200",
-                    description = "닉네임 유효성 확인 성공 - 사용 가능한 닉네임임",
-                    content = @Content(mediaType = "application/json",
-                            schema = @Schema(implementation = NicknameValidateResponse.class))
+                    description = "닉네임 유효성 확인 성공(사용가능)"
             )
     })
     @ApiErrorResponses({
@@ -70,9 +68,7 @@ public interface ProfileApiDocs {
     @ApiResponses({
             @ApiResponse(
                     responseCode = "200",
-                    description = "랜덤 닉네임 생성 성공",
-                    content = @Content(mediaType = "application/json",
-                            schema = @Schema(implementation = NicknameRandomResponse.class))
+                    description = "랜덤 닉네임 생성 성공"
             )
     })
     @ApiErrorResponses({ErrorCode.UNAUTHORIZED})

--- a/src/main/java/com/dduru/gildongmu/survey/controller/SurveyApiDocs.java
+++ b/src/main/java/com/dduru/gildongmu/survey/controller/SurveyApiDocs.java
@@ -24,11 +24,7 @@ public interface SurveyApiDocs {
     @ApiResponses({
             @ApiResponse(
                     responseCode = "201",
-                    description = "설문 제출 성공",
-                    content = @Content(
-                            mediaType = "application/json",
-                            schema = @Schema(implementation = SurveyResponse.class)
-                    )
+                    description = "설문 제출 성공"
             ),
             @ApiResponse(
                     responseCode = "400",
@@ -89,11 +85,7 @@ public interface SurveyApiDocs {
     @ApiResponses({
             @ApiResponse(
                     responseCode = "200",
-                    description = "조회 성공",
-                    content = @Content(
-                            mediaType = "application/json",
-                            schema = @Schema(implementation = SurveyResponse.class)
-                    )
+                    description = "조회 성공"
             ),
             @ApiResponse(
                     responseCode = "404",

--- a/src/main/java/com/dduru/gildongmu/survey/controller/SurveyController.java
+++ b/src/main/java/com/dduru/gildongmu/survey/controller/SurveyController.java
@@ -25,7 +25,7 @@ public class SurveyController implements SurveyApiDocs {
             @RequestBody @Valid SurveyRequest request
     ) {
         SurveyResponse response = surveyService.submitSurvey(userId, request);
-        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResult.ok(response));
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResult.created(response));
     }
 
     @Override
@@ -34,6 +34,6 @@ public class SurveyController implements SurveyApiDocs {
             @CurrentUser Long userId
     ) {
         SurveyResponse response = surveyService.getMySurveyResult(userId);
-        return ResponseEntity.status(HttpStatus.OK).body(ApiResult.ok(response));
+        return ResponseEntity.ok(ApiResult.ok(response));
     }
 }

--- a/src/main/java/com/dduru/gildongmu/verification/controller/PhoneVerificationApiDocs.java
+++ b/src/main/java/com/dduru/gildongmu/verification/controller/PhoneVerificationApiDocs.java
@@ -1,18 +1,15 @@
 package com.dduru.gildongmu.verification.controller;
 
+import com.dduru.gildongmu.common.annotation.ApiErrorResponses;
 import com.dduru.gildongmu.common.dto.ApiResult;
-import com.dduru.gildongmu.common.exception.ErrorResponse;
+import com.dduru.gildongmu.common.exception.ErrorCode;
 import com.dduru.gildongmu.verification.dto.VerificationSendRequest;
 import com.dduru.gildongmu.verification.dto.VerificationSendResponse;
 import com.dduru.gildongmu.verification.dto.VerificationVerifyRequest;
 import com.dduru.gildongmu.verification.dto.VerificationVerifyResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.ExampleObject;
-import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
@@ -21,72 +18,13 @@ import org.springframework.http.ResponseEntity;
 public interface PhoneVerificationApiDocs {
 
     @Operation(summary = "인증번호 발송", description = "전화번호로 인증번호를 발송합니다.")
-    @ApiResponses({
-            @ApiResponse(
-                    responseCode = "200",
-                    description = "인증번호 발송 성공",
-                    content = @Content(
-                            mediaType = "application/json",
-                            schema = @Schema(implementation = VerificationSendResponse.class)
-                    )
-            ),
-            @ApiResponse(
-                    responseCode = "409",
-                    description = "이미 가입된 전화번호",
-                    content = @Content(
-                            mediaType = "application/json",
-                            schema = @Schema(implementation = ErrorResponse.class),
-                            examples = @ExampleObject(
-                                    name = "DuplicatePhoneNumber",
-                                    value = """
-                                            {
-                                              "status": 409,
-                                              "data": {
-                                                "errorCode": "DUPLICATE_PHONE_NUMBER",
-                                                "field": null,
-                                                "message": "이미 가입된 전화번호입니다. 로그인해주세요."
-                                              }
-                                            }
-                                            """
-                            )
-                    )
-            ),
-            @ApiResponse(
-                    responseCode = "429",
-                    description = "재발송 제한 또는 일일 발송 한도 초과",
-                    content = @Content(
-                            mediaType = "application/json",
-                            schema = @Schema(implementation = ErrorResponse.class),
-                            examples = {
-                                    @ExampleObject(
-                                            name = "ResendLimitExceeded",
-                                            value = """
-                                                    {
-                                                      "status": 429,
-                                                      "data": {
-                                                        "errorCode": "TOO_MANY_REQUESTS",
-                                                        "field": null,
-                                                        "message": "재발송 제한 시간이 지나지 않았습니다."
-                                                      }
-                                                    }
-                                                    """
-                                    ),
-                                    @ExampleObject(
-                                            name = "DailyLimitExceeded",
-                                            value = """
-                                                    {
-                                                      "status": 429,
-                                                      "data": {
-                                                        "errorCode": "DAILY_SMS_LIMIT_EXCEEDED",
-                                                        "field": null,
-                                                        "message": "일일 SMS 발송 한도를 초과했습니다."
-                                                      }
-                                                    }
-                                                    """
-                                    )
-                            }
-                    )
-            )
+    @ApiResponse(responseCode = "200", description = "인증번호 발송 성공")
+    @ApiErrorResponses({
+            ErrorCode.DUPLICATE_PHONE_NUMBER,
+            ErrorCode.TOO_MANY_REQUESTS,
+            ErrorCode.DAILY_SMS_LIMIT_EXCEEDED,
+            ErrorCode.SMS_SEND_FAILED,
+            ErrorCode.SMS_PROVIDER_ERROR
     })
     ResponseEntity<ApiResult<VerificationSendResponse>> sendVerificationCode(
             @Parameter(hidden = true) Long userId,
@@ -94,93 +32,12 @@ public interface PhoneVerificationApiDocs {
     );
 
     @Operation(summary = "인증번호 검증", description = "발송된 인증번호를 검증하고 인증 토큰을 발급합니다.")
-    @ApiResponses({
-            @ApiResponse(
-                    responseCode = "200",
-                    description = "인증번호 검증 성공",
-                    content = @Content(
-                            mediaType = "application/json",
-                            schema = @Schema(implementation = VerificationVerifyResponse.class)
-                    )
-            ),
-            @ApiResponse(
-                    responseCode = "400",
-                    description = "인증번호 불일치 또는 검증 시도 횟수 초과",
-                    content = @Content(
-                            mediaType = "application/json",
-                            schema = @Schema(implementation = ErrorResponse.class),
-                            examples = {
-                                    @ExampleObject(
-                                            name = "InvalidAuthCode",
-                                            value = """
-                                                    {
-                                                      "status": 400,
-                                                      "data": {
-                                                        "errorCode": "INVALID_AUTH_CODE",
-                                                        "field": null,
-                                                        "message": "인증번호가 일치하지 않습니다."
-                                                      }
-                                                    }
-                                                    """
-                                    ),
-                                    @ExampleObject(
-                                            name = "AttemptsExceeded",
-                                            value = """
-                                                    {
-                                                      "status": 400,
-                                                      "data": {
-                                                        "errorCode": "VERIFICATION_ATTEMPTS_EXCEEDED",
-                                                        "field": null,
-                                                        "message": "검증 시도 횟수를 초과했습니다."
-                                                      }
-                                                    }
-                                                    """
-                                    )
-                            }
-                    )
-            ),
-            @ApiResponse(
-                    responseCode = "404",
-                    description = "인증 정보를 찾을 수 없음 (만료 포함)",
-                    content = @Content(
-                            mediaType = "application/json",
-                            schema = @Schema(implementation = ErrorResponse.class),
-                            examples = @ExampleObject(
-                                    name = "VerificationNotFound",
-                                    value = """
-                                            {
-                                              "status": 404,
-                                              "data": {
-                                                "errorCode": "VERIFICATION_NOT_FOUND",
-                                                "field": null,
-                                                "message": "인증 정보를 찾을 수 없습니다."
-                                              }
-                                            }
-                                            """
-                            )
-                    )
-            ),
-            @ApiResponse(
-                    responseCode = "409",
-                    description = "이미 완료된 인증",
-                    content = @Content(
-                            mediaType = "application/json",
-                            schema = @Schema(implementation = ErrorResponse.class),
-                            examples = @ExampleObject(
-                                    name = "AlreadyVerified",
-                                    value = """
-                                            {
-                                              "status": 409,
-                                              "data": {
-                                                "errorCode": "ALREADY_VERIFIED",
-                                                "field": null,
-                                                "message": "이미 완료된 인증입니다."
-                                              }
-                                            }
-                                            """
-                            )
-                    )
-            )
+    @ApiResponse(responseCode = "200", description = "인증번호 검증 성공")
+    @ApiErrorResponses({
+            ErrorCode.INVALID_AUTH_CODE,
+            ErrorCode.VERIFICATION_ATTEMPTS_EXCEEDED,
+            ErrorCode.VERIFICATION_NOT_FOUND,
+            ErrorCode.ALREADY_VERIFIED
     })
     ResponseEntity<ApiResult<VerificationVerifyResponse>> verifyCode(
             @Parameter(hidden = true) Long userId,


### PR DESCRIPTION
## 🔎 작업 내용
* 모든 ApiDocs에 `@ApiErrorResponses` 어노테이션 추가하여 실제 에러 처리와 일치하도록 개선
* 잘못 정의된 응답 스키마 수정 (S3ApiDocs, SurveyApiDocs, ProfileApiDocs, PhoneVerificationApiDocs)
* 204 No Content 응답에 대해 Swagger UI에서 body 예시가 표시되지 않도록 `content = @Content()` 추가
* 성공 응답 상태코드와 실제 응답 검토 및 일치 여부 확인

## ➕ 이슈 링크
* Closed #131 

## 📸 스크린샷
<!-- Swagger UI 변경 전후 스크린샷이 있다면 추가해주세요 -->
#### 성공 응답
* 200 OK
<img width="429" height="349" alt="image" src="https://github.com/user-attachments/assets/09a379fe-8885-4149-ac31-053e6071f9fe" />

* 204 NO CONTENT
<img width="204" height="76" alt="image" src="https://github.com/user-attachments/assets/f5b9b371-8621-4e2b-8d9e-cb2730bcfe24" />

* 에러 응답 예시
<img width="1384" height="781" alt="image" src="https://github.com/user-attachments/assets/0c224478-692c-48d0-9788-b3a8726a5416" />

## 😎 리뷰 요구사항
<!--
리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?-->
> 
- 모든 에러 응답이 `@ApiErrorResponses`를 통해 자동으로 생성되도록 통일했습니다.
- 204 응답의 경우 프론트 개발자가 혼동하지 않도록 body 예시가 표시되지 않도록 수정했습니다.
- 실제 컨트롤러 구현과 Swagger 문서가 일치하는지 전체적으로 검토했습니다.

## 🧑‍💻 예정 작업
- issue 추가 후 수정할 예정

## 📝 체크리스트
- [x] 브랜치 이름은 `feature/개발내용` 형식으로 작성했는가?
- [x] 커밋 메시지는 `feat: 커밋 내용` 형식으로 작성했는가?
- [x] 작업 전 Issue를 작성했는가?
- [x] `dev` 브랜치로 병합을 요청했는가?
- [x] 불필요한 주석과 공백은 제거했는가?
- [x] 코드 리뷰어의 피드백을 반영했는가?
- [x] 테스트를 진행했는가?
- [x] 테스트 코드를 작성했는가?
