### PR TITLE
feat: 여행글 생성 API 수정 

### DIFF
--- a/src/main/java/com/dduru/gildongmu/destination/controller/DestinationApiDocs.java
+++ b/src/main/java/com/dduru/gildongmu/destination/controller/DestinationApiDocs.java
@@ -15,14 +15,14 @@ public interface DestinationApiDocs {
 
     @Operation(
             summary = "인기 여행지 목록 조회",
-            description = "게시글 작성 1단계 등에서 노출하는 인기 여행지 5건을 반환합니다. (제주도, 부산, 강릉, 후쿠오카, 오사카)"
+            description = "최근 30일 기준 여행글 등록 수 + 조회수 + 좋아요 수를 합산해 상위 10개 여행지를 반환합니다. 집계 데이터가 없으면 추천 여행지 10개(제주도, 부산, 강릉, 후쿠오카, 오사카, 서울, 도쿄, 교토, 방콕, 다낭)를 반환합니다."
     )
     @ApiResponse(responseCode = "200", description = "조회 성공")
     ResponseEntity<ApiResult<List<DestinationInfo>>> getPopularDestinations();
 
     @Operation(
             summary = "여행지 검색",
-            description = "도시/국가명으로 여행지를 검색합니다. keyword가 없거나 비어 있으면 인기여행지를 반환합니다. 최대 20건."
+            description = "도시/국가명으로 여행지를 검색합니다. keyword가 없거나 비어 있으면 인기 여행지 목록(최근 30일 집계 기준 상위 10개, 집계 없을 시 추천 10개)을 반환합니다. 검색 시 최대 20건."
     )
     @ApiResponse(responseCode = "200", description = "조회 성공")
     ResponseEntity<ApiResult<List<DestinationInfo>>> searchDestinations(

--- a/src/main/java/com/dduru/gildongmu/destination/repository/DestinationRepository.java
+++ b/src/main/java/com/dduru/gildongmu/destination/repository/DestinationRepository.java
@@ -3,12 +3,22 @@ package com.dduru.gildongmu.destination.repository;
 import com.dduru.gildongmu.destination.domain.Destination;
 import com.dduru.gildongmu.destination.exception.DestinationNotFoundException;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface DestinationRepository extends JpaRepository<Destination, Long>, DestinationRepositoryCustom {
 
     List<Destination> findByCityIn(List<String> cities);
+
+    @Query(value = "SELECT p.destination_id FROM posts p " +
+            "WHERE p.created_at >= :since AND p.is_deleted = false " +
+            "GROUP BY p.destination_id " +
+            "ORDER BY (COUNT(*) + COALESCE(SUM(p.view_count), 0) + COALESCE(SUM(p.like_count), 0)) DESC " +
+            "LIMIT 10", nativeQuery = true)
+    List<Long> findPopularDestinationIds(@Param("since") LocalDateTime since);
 
     default Destination getByIdOrThrow(Long id) {
         return findById(id)

--- a/src/main/java/com/dduru/gildongmu/destination/service/DestinationService.java
+++ b/src/main/java/com/dduru/gildongmu/destination/service/DestinationService.java
@@ -9,8 +9,12 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
+import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -18,17 +22,35 @@ import java.util.List;
 @Transactional(readOnly = true)
 public class DestinationService {
 
-    private static final List<String> POPULAR_CITY_NAMES = List.of(
-            "제주도", "부산", "강릉", "후쿠오카", "오사카"
+    private static final int POPULAR_DAYS_CRITERIA = 30;
+
+    /** 집계 데이터가 없을 때 반환하는 추천 여행지 10개 (도시명 순서 고정) */
+    private static final List<String> FALLBACK_CITY_NAMES = List.of(
+            "제주도", "부산", "강릉", "후쿠오카", "오사카",
+            "서울", "도쿄", "교토", "방콕", "다낭"
     );
 
     private final DestinationRepository destinationRepository;
 
     public List<DestinationInfo> getPopularDestinations() {
-        log.debug("인기 여행지 목록 조회");
-        List<Destination> destinations = destinationRepository.findByCityIn(POPULAR_CITY_NAMES);
-        List<DestinationInfo> result = destinations.stream()
-                .sorted(Comparator.comparingInt(d -> POPULAR_CITY_NAMES.indexOf(d.getCity())))
+        log.debug("인기 여행지 목록 조회 (최근 {}일 기준)", POPULAR_DAYS_CRITERIA);
+        LocalDateTime since = LocalDateTime.now().minusDays(POPULAR_DAYS_CRITERIA);
+        List<Long> ids = destinationRepository.findPopularDestinationIds(since);
+
+        if (ids.isEmpty()) {
+            log.debug("집계 데이터 없음 - 추천 여행지 10개 반환");
+            List<Destination> fallback = destinationRepository.findByCityIn(FALLBACK_CITY_NAMES);
+            return fallback.stream()
+                    .sorted(Comparator.comparingInt(d -> FALLBACK_CITY_NAMES.indexOf(d.getCity())))
+                    .map(DestinationInfo::from)
+                    .toList();
+        }
+
+        List<Destination> destinations = destinationRepository.findAllById(ids);
+        Map<Long, Destination> byId = destinations.stream().collect(Collectors.toMap(Destination::getId, d -> d));
+        List<DestinationInfo> result = ids.stream()
+                .map(byId::get)
+                .filter(Objects::nonNull)
                 .map(DestinationInfo::from)
                 .toList();
         log.debug("인기 여행지 목록 조회 완료 - count={}", result.size());

--- a/src/main/java/com/dduru/gildongmu/destination/service/DestinationService.java
+++ b/src/main/java/com/dduru/gildongmu/destination/service/DestinationService.java
@@ -22,9 +22,8 @@ import java.util.stream.Collectors;
 @Transactional(readOnly = true)
 public class DestinationService {
 
-    private static final int POPULAR_DAYS_CRITERIA = 30;
+    private static final int POPULAR_DAYS_LIMIT = 30;
 
-    /** 집계 데이터가 없을 때 반환하는 추천 여행지 10개 (도시명 순서 고정) */
     private static final List<String> FALLBACK_CITY_NAMES = List.of(
             "제주도", "부산", "강릉", "후쿠오카", "오사카",
             "서울", "도쿄", "교토", "방콕", "다낭"
@@ -33,8 +32,8 @@ public class DestinationService {
     private final DestinationRepository destinationRepository;
 
     public List<DestinationInfo> getPopularDestinations() {
-        log.debug("인기 여행지 목록 조회 (최근 {}일 기준)", POPULAR_DAYS_CRITERIA);
-        LocalDateTime since = LocalDateTime.now().minusDays(POPULAR_DAYS_CRITERIA);
+        log.debug("인기 여행지 목록 조회 (최근 {}일 기준)", POPULAR_DAYS_LIMIT);
+        LocalDateTime since = LocalDateTime.now().minusDays(POPULAR_DAYS_LIMIT);
         List<Long> ids = destinationRepository.findPopularDestinationIds(since);
 
         if (ids.isEmpty()) {

--- a/src/main/java/com/dduru/gildongmu/post/dto/request/PostCreateRequest.java
+++ b/src/main/java/com/dduru/gildongmu/post/dto/request/PostCreateRequest.java
@@ -42,10 +42,10 @@ public record PostCreateRequest(
         Gender preferredGender,
 
         @NotNull(message = "선호 연령대는 필수입니다")
-        @Size(max = 2, message = "동행 연령대는 최대 2개까지 선택할 수 있습니다")
+        @Size(max = 2, message = "선호 연령대는 최대 2개까지 선택할 수 있습니다")
         List<AgeRange> preferredAges,
 
-        @Size(max = 1, message = "사진은 1장만 업로드 가능합니다")
+        @Size(max = 1, message = "사진은 최대 1장까지 업로드 가능합니다")
         List<String> photoUrls,
 
         @Size(max = 10, message = "태그는 최대 10개까지 가능합니다")

--- a/src/main/java/com/dduru/gildongmu/post/dto/request/PostCreateRequest.java
+++ b/src/main/java/com/dduru/gildongmu/post/dto/request/PostCreateRequest.java
@@ -42,7 +42,7 @@ public record PostCreateRequest(
         Gender preferredGender,
 
         @NotNull(message = "선호 연령대는 필수입니다")
-        @Size(max = 3, message = "선호 연령대는 최대 3개까지 선택할 수 있습니다")
+        @Size(max = 2, message = "동행 연령대는 최대 2개까지 선택할 수 있습니다")
         List<AgeRange> preferredAges,
 
         @Size(max = 5, message = "사진은 최대 5장까지 업로드 가능합니다")

--- a/src/main/java/com/dduru/gildongmu/post/dto/request/PostCreateRequest.java
+++ b/src/main/java/com/dduru/gildongmu/post/dto/request/PostCreateRequest.java
@@ -45,7 +45,7 @@ public record PostCreateRequest(
         @Size(max = 2, message = "동행 연령대는 최대 2개까지 선택할 수 있습니다")
         List<AgeRange> preferredAges,
 
-        @Size(max = 5, message = "사진은 최대 5장까지 업로드 가능합니다")
+        @Size(max = 1, message = "사진은 1장만 업로드 가능합니다")
         List<String> photoUrls,
 
         @Size(max = 10, message = "태그는 최대 10개까지 가능합니다")

--- a/src/main/java/com/dduru/gildongmu/post/dto/request/PostUpdateRequest.java
+++ b/src/main/java/com/dduru/gildongmu/post/dto/request/PostUpdateRequest.java
@@ -34,10 +34,10 @@ public record PostUpdateRequest(
 
         Gender preferredGender,
 
-        @Size(max = 2, message = "동행 연령대는 최대 2개까지 선택할 수 있습니다")
+        @Size(max = 2, message = "선호 연령대는 최대 2개까지 선택할 수 있습니다")
         List<AgeRange> preferredAges,
 
-        @Size(max = 1, message = "사진은 1장만 업로드 가능합니다")
+        @Size(max = 1, message = "사진은 최대 1장까지 업로드 가능합니다")
         List<String> photoUrls,
 
         @Size(max = 10, message = "태그는 최대 10개까지 가능합니다")

--- a/src/main/java/com/dduru/gildongmu/post/dto/request/PostUpdateRequest.java
+++ b/src/main/java/com/dduru/gildongmu/post/dto/request/PostUpdateRequest.java
@@ -37,7 +37,7 @@ public record PostUpdateRequest(
         @Size(max = 2, message = "동행 연령대는 최대 2개까지 선택할 수 있습니다")
         List<AgeRange> preferredAges,
 
-        @Size(max = 5, message = "사진은 최대 5장까지 업로드 가능합니다")
+        @Size(max = 1, message = "사진은 1장만 업로드 가능합니다")
         List<String> photoUrls,
 
         @Size(max = 10, message = "태그는 최대 10개까지 가능합니다")

--- a/src/main/java/com/dduru/gildongmu/post/dto/request/PostUpdateRequest.java
+++ b/src/main/java/com/dduru/gildongmu/post/dto/request/PostUpdateRequest.java
@@ -34,7 +34,7 @@ public record PostUpdateRequest(
 
         Gender preferredGender,
 
-        @Size(max = 3, message = "선호 연령대는 최대 3개까지 선택할 수 있습니다")
+        @Size(max = 2, message = "동행 연령대는 최대 2개까지 선택할 수 있습니다")
         List<AgeRange> preferredAges,
 
         @Size(max = 5, message = "사진은 최대 5장까지 업로드 가능합니다")

--- a/src/main/java/com/dduru/gildongmu/tag/service/TagService.java
+++ b/src/main/java/com/dduru/gildongmu/tag/service/TagService.java
@@ -9,15 +9,20 @@ import java.util.List;
 @RequiredArgsConstructor
 public class TagService {
 
-    private static final List<String> POPULAR_TAGS = List.of(
-            "힐링여행",
+    private static final List<String> TRAVEL_TAGS = List.of(
             "맛집투어",
             "사진명소",
+            "힐링",
             "액티비티",
-            "자연"
+            "현지바이브",
+            "야경명소",
+            "카페투어",
+            "커피",
+            "쇼핑",
+            "뚜벅이"
     );
 
     public List<String> getPopularTags() {
-        return POPULAR_TAGS;
+        return TRAVEL_TAGS;
     }
 }

--- a/src/test/java/com/dduru/gildongmu/destination/service/DestinationServiceTest.java
+++ b/src/test/java/com/dduru/gildongmu/destination/service/DestinationServiceTest.java
@@ -13,6 +13,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -26,28 +27,57 @@ class DestinationServiceTest {
     @InjectMocks
     private DestinationService destinationService;
 
-    @DisplayName("인기 여행지 목록을 조회하면 지정된 도시 순서대로 반환한다")
+    private static final List<String> FALLBACK_CITY_NAMES = List.of(
+            "제주도", "부산", "강릉", "후쿠오카", "오사카", "서울", "도쿄", "교토", "방콕", "다낭"
+    );
+
+    @DisplayName("집계 데이터가 없으면 추천 여행지 10개 순서대로 반환한다")
     @Test
-    void getPopularDestinations_returnsInOrder() {
+    void getPopularDestinations_noData_returnsFallbackInOrder() {
+        when(destinationRepository.findPopularDestinationIds(any())).thenReturn(List.of());
         Destination jeju = Destination.builder().countryCode("KR").countryName("대한민국").city("제주도").build();
         Destination busan = Destination.builder().countryCode("KR").countryName("대한민국").city("부산").build();
-        when(destinationRepository.findByCityIn(List.of("제주도", "부산", "강릉", "후쿠오카", "오사카")))
-                .thenReturn(List.of(busan, jeju));
+        when(destinationRepository.findByCityIn(FALLBACK_CITY_NAMES)).thenReturn(List.of(busan, jeju));
 
         List<DestinationInfo> result = destinationService.getPopularDestinations();
 
         assertThat(result).hasSize(2);
         assertThat(result.get(0).city()).isEqualTo("제주도");
         assertThat(result.get(1).city()).isEqualTo("부산");
-        verify(destinationRepository).findByCityIn(List.of("제주도", "부산", "강릉", "후쿠오카", "오사카"));
+        verify(destinationRepository).findByCityIn(FALLBACK_CITY_NAMES);
+    }
+
+    @DisplayName("최근 30일 집계가 있으면 점수 순 상위 10개 여행지를 반환한다")
+    @Test
+    void getPopularDestinations_withData_returnsOrderedByScore() throws Exception {
+        when(destinationRepository.findPopularDestinationIds(any())).thenReturn(List.of(2L, 1L));
+        Destination first = Destination.builder().countryCode("KR").countryName("대한민국").city("서울").build();
+        Destination second = Destination.builder().countryCode("KR").countryName("대한민국").city("부산").build();
+        setEntityId(first, 2L);
+        setEntityId(second, 1L);
+        when(destinationRepository.findAllById(List.of(2L, 1L))).thenReturn(List.of(second, first));
+
+        List<DestinationInfo> result = destinationService.getPopularDestinations();
+
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).city()).isEqualTo("서울");
+        assertThat(result.get(1).city()).isEqualTo("부산");
+        verify(destinationRepository).findPopularDestinationIds(any());
+        verify(destinationRepository).findAllById(List.of(2L, 1L));
+    }
+
+    private static void setEntityId(Object entity, Long id) throws Exception {
+        java.lang.reflect.Field idField = entity.getClass().getDeclaredField("id");
+        idField.setAccessible(true);
+        idField.set(entity, id);
     }
 
     @DisplayName("키워드가 없거나 공백이면 인기 여행지 목록을 반환한다")
     @Test
     void searchDestinations_emptyOrBlankKeyword_returnsPopularDestinations() {
+        when(destinationRepository.findPopularDestinationIds(any())).thenReturn(List.of());
         Destination jeju = Destination.builder().countryCode("KR").countryName("대한민국").city("제주도").build();
-        when(destinationRepository.findByCityIn(List.of("제주도", "부산", "강릉", "후쿠오카", "오사카")))
-                .thenReturn(List.of(jeju));
+        when(destinationRepository.findByCityIn(FALLBACK_CITY_NAMES)).thenReturn(List.of(jeju));
 
         List<DestinationInfo> resultEmpty = destinationService.searchDestinations("");
         List<DestinationInfo> resultBlank = destinationService.searchDestinations("   ");

--- a/src/test/java/com/dduru/gildongmu/destination/service/DestinationServiceTest.java
+++ b/src/test/java/com/dduru/gildongmu/destination/service/DestinationServiceTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.List;
 
@@ -49,12 +50,12 @@ class DestinationServiceTest {
 
     @DisplayName("최근 30일 집계가 있으면 점수 순 상위 10개 여행지를 반환한다")
     @Test
-    void getPopularDestinations_withData_returnsOrderedByScore() throws Exception {
+    void getPopularDestinations_withData_returnsOrderedByScore() {
         when(destinationRepository.findPopularDestinationIds(any())).thenReturn(List.of(2L, 1L));
         Destination first = Destination.builder().countryCode("KR").countryName("대한민국").city("서울").build();
         Destination second = Destination.builder().countryCode("KR").countryName("대한민국").city("부산").build();
-        setEntityId(first, 2L);
-        setEntityId(second, 1L);
+        ReflectionTestUtils.setField(first, "id", 2L);
+        ReflectionTestUtils.setField(second, "id", 1L);
         when(destinationRepository.findAllById(List.of(2L, 1L))).thenReturn(List.of(second, first));
 
         List<DestinationInfo> result = destinationService.getPopularDestinations();
@@ -64,12 +65,6 @@ class DestinationServiceTest {
         assertThat(result.get(1).city()).isEqualTo("부산");
         verify(destinationRepository).findPopularDestinationIds(any());
         verify(destinationRepository).findAllById(List.of(2L, 1L));
-    }
-
-    private static void setEntityId(Object entity, Long id) throws Exception {
-        java.lang.reflect.Field idField = entity.getClass().getDeclaredField("id");
-        idField.setAccessible(true);
-        idField.set(entity, id);
     }
 
     @DisplayName("키워드가 없거나 공백이면 인기 여행지 목록을 반환한다")

--- a/src/test/java/com/dduru/gildongmu/post/service/PostServiceTest.java
+++ b/src/test/java/com/dduru/gildongmu/post/service/PostServiceTest.java
@@ -26,8 +26,8 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
-import java.lang.reflect.Field;
 import java.time.LocalDate;
 import java.util.List;
 
@@ -59,13 +59,13 @@ class PostServiceTest {
 
     @DisplayName("게시글 생성 시 유효한 요청이면 생성 후 ID를 반환한다")
     @Test
-    void create_validRequest_returnsPostId() throws Exception {
+    void create_validRequest_returnsPostId() {
         Long userId = 1L;
         Long destinationId = 10L;
         User user = User.builder().email("a@a.com").name("user").oauthId("kakao-1").oauthType(OauthType.KAKAO).build();
-        setEntityId(user, 1L);
+        ReflectionTestUtils.setField(user, "id", 1L);
         Destination destination = Destination.builder().countryCode("KR").countryName("대한민국").city("제주도").build();
-        setEntityId(destination, destinationId);
+        ReflectionTestUtils.setField(destination, "id", destinationId);
 
         PostCreateRequest request = new PostCreateRequest(
                 destinationId,
@@ -89,7 +89,7 @@ class PostServiceTest {
         when(jsonConverter.convertListToJson(anyList())).thenReturn("[]");
         when(postRepository.save(any(Post.class))).thenAnswer(invocation -> {
             Post post = invocation.getArgument(0);
-            setEntityId(post, 100L);
+            ReflectionTestUtils.setField(post, "id", 100L);
             return post;
         });
 
@@ -185,13 +185,13 @@ class PostServiceTest {
 
     @DisplayName("게시글 수정 시 작성자가 아니면 예외가 발생한다")
     @Test
-    void update_notOwner_throwsPostAccessDeniedException() throws Exception {
+    void update_notOwner_throwsPostAccessDeniedException() {
         Long postId = 1L;
         Long ownerId = 10L;
         Long requesterId = 99L;
 
         User owner = User.builder().email("owner@a.com").name("owner").oauthId("kakao-10").oauthType(OauthType.KAKAO).build();
-        setEntityId(owner, ownerId);
+        ReflectionTestUtils.setField(owner, "id", ownerId);
         Post post = Post.builder()
                 .user(owner)
                 .destination(Destination.builder().countryCode("KR").countryName("대한민국").city("서울").build())
@@ -202,7 +202,7 @@ class PostServiceTest {
                 .photoUrls("[]").tags("[]")
                 .recruitType(RecruitType.PRIVATE).recruitMethod(RecruitMethod.ALWAYS).companionType(null)
                 .build();
-        setEntityId(post, postId);
+        ReflectionTestUtils.setField(post, "id", postId);
 
         when(postRepository.getActiveByIdOrThrow(postId)).thenReturn(post);
 
@@ -211,11 +211,5 @@ class PostServiceTest {
 
         assertThatThrownBy(() -> postService.update(postId, requesterId, updateRequest))
                 .isInstanceOf(PostAccessDeniedException.class);
-    }
-
-    private static void setEntityId(Object entity, Long id) throws Exception {
-        Field idField = entity.getClass().getDeclaredField("id");
-        idField.setAccessible(true);
-        idField.set(entity, id);
     }
 }

--- a/src/test/java/com/dduru/gildongmu/tag/service/TagServiceTest.java
+++ b/src/test/java/com/dduru/gildongmu/tag/service/TagServiceTest.java
@@ -17,17 +17,22 @@ class TagServiceTest {
     @InjectMocks
     private TagService tagService;
 
-    @DisplayName("인기 태그 목록을 조회하면 고정된 목록을 반환한다")
+    @DisplayName("여행 태그 목록을 조회하면 고정된 10개 목록을 반환한다")
     @Test
-    void getPopularTags_returnsFixedList() {
+    void getPopularTags_returnsFixedTravelTagList() {
         List<String> result = tagService.getPopularTags();
 
         assertThat(result).containsExactly(
-                "힐링여행",
                 "맛집투어",
                 "사진명소",
+                "힐링",
                 "액티비티",
-                "자연"
+                "현지바이브",
+                "야경명소",
+                "카페투어",
+                "커피",
+                "쇼핑",
+                "뚜벅이"
         );
     }
 }


### PR DESCRIPTION
## 🔎 작업 내용
* 인기 태그 목록 10개로 추가
* 동행 연령대 최대 2개로 수정
* 사진 업로드 최대 1장
* 인기 여행지 : 최근 30일 기준 여행글 등록 수 + 조회수 + 좋아요 수를 합산해 상위 10개 여행지를 반환
* 집계 데이터가 없으면 추천 여행지 10개 반환

## ➕ 이슈 링크
* Closed #167 

## 📝 체크리스트
- [x] 브랜치 이름은 `feature/개발내용` 형식으로 작성했는가?
- [x] 커밋 메시지는 `feat: 커밋 내용` 형식으로 작성했는가?
- [x] 작업 전 Issue를 작성했는가?
- [x] `dev` 브랜치로 병합을 요청했는가?
- [x] 불필요한 주석과 공백은 제거했는가?
- [x] 코드 리뷰어의 피드백을 반영했는가?
- [x] 테스트를 진행했는가?
- [x] 테스트 코드를 작성했는가?
