### PR TITLE
feat: 관리자용 게시글 조회/삭제 API

### DIFF
--- a/src/main/java/com/dduru/gildongmu/admin/post/controller/AdminPostApiDocs.java
+++ b/src/main/java/com/dduru/gildongmu/admin/post/controller/AdminPostApiDocs.java
@@ -1,0 +1,39 @@
+package com.dduru.gildongmu.admin.post.controller;
+
+import com.dduru.gildongmu.admin.post.dto.response.AdminPostDetailResponse;
+import com.dduru.gildongmu.common.annotation.ApiErrorResponses;
+import com.dduru.gildongmu.common.dto.ApiResult;
+import com.dduru.gildongmu.common.exception.ErrorCode;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "Admin Posts", description = "관리자 게시글 API")
+public interface AdminPostApiDocs {
+
+    @Operation(summary = "관리자 게시글 단건 조회", description = "삭제된 게시글을 포함하여 게시글 상세를 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "조회 성공")
+    @ApiErrorResponses({
+            ErrorCode.POST_NOT_FOUND,
+            ErrorCode.UNAUTHORIZED,
+            ErrorCode.ACCESS_DENIED
+    })
+    ResponseEntity<ApiResult<AdminPostDetailResponse>> getPost(
+            @Parameter(description = "게시글 ID") Long postId
+    );
+
+    @Operation(summary = "관리자 게시글 삭제", description = "게시글을 소프트 삭제합니다. 이미 삭제된 게시글은 성공으로 처리합니다.")
+    @ApiResponse(responseCode = "204", description = "삭제 성공", content = @Content())
+    @ApiErrorResponses({
+            ErrorCode.POST_NOT_FOUND,
+            ErrorCode.UNAUTHORIZED,
+            ErrorCode.ACCESS_DENIED
+    })
+    ResponseEntity<ApiResult<Void>> deletePost(
+            @Parameter(description = "게시글 ID") Long postId,
+            @Parameter(hidden = true) Long adminUserId
+    );
+}

--- a/src/main/java/com/dduru/gildongmu/admin/post/controller/AdminPostController.java
+++ b/src/main/java/com/dduru/gildongmu/admin/post/controller/AdminPostController.java
@@ -1,0 +1,39 @@
+package com.dduru.gildongmu.admin.post.controller;
+
+import com.dduru.gildongmu.admin.post.dto.response.AdminPostDetailResponse;
+import com.dduru.gildongmu.admin.post.service.AdminPostService;
+import com.dduru.gildongmu.common.annotation.CurrentUser;
+import com.dduru.gildongmu.common.dto.ApiResult;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/admin/posts")
+public class AdminPostController implements AdminPostApiDocs {
+
+    private final AdminPostService adminPostService;
+
+    @Override
+    @GetMapping("/{postId}")
+    public ResponseEntity<ApiResult<AdminPostDetailResponse>> getPost(@PathVariable Long postId) {
+        AdminPostDetailResponse response = adminPostService.getDetail(postId);
+        return ResponseEntity.ok(ApiResult.ok(response));
+    }
+
+    @Override
+    @DeleteMapping("/{postId}")
+    public ResponseEntity<ApiResult<Void>> deletePost(
+            @PathVariable Long postId,
+            @CurrentUser Long adminUserId
+    ) {
+        adminPostService.delete(postId, adminUserId);
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).body(ApiResult.noContent());
+    }
+}

--- a/src/main/java/com/dduru/gildongmu/admin/post/dto/response/AdminPostDetailResponse.java
+++ b/src/main/java/com/dduru/gildongmu/admin/post/dto/response/AdminPostDetailResponse.java
@@ -1,0 +1,61 @@
+package com.dduru.gildongmu.admin.post.dto.response;
+
+import com.dduru.gildongmu.common.util.JsonConverter;
+import com.dduru.gildongmu.post.domain.Post;
+import com.dduru.gildongmu.post.domain.enums.PostStatus;
+import com.dduru.gildongmu.profile.domain.enums.AgeRange;
+import com.dduru.gildongmu.profile.domain.enums.Gender;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record AdminPostDetailResponse(
+        Long id,
+        String title,
+        String content,
+        PostStatus status,
+        String destination,
+        LocalDate startDate,
+        LocalDate endDate,
+        Integer recruitCapacity,
+        Integer recruitCount,
+        LocalDate recruitDeadline,
+        Gender preferredGender,
+        List<AgeRange> preferredAges,
+        List<String> photoUrls,
+        List<String> tags,
+        Long authorId,
+        String authorName,
+        LocalDateTime createdAt,
+        boolean isDeleted,
+        LocalDateTime deletedAt,
+        Long deletedBy
+) {
+    public static AdminPostDetailResponse from(Post post, JsonConverter jsonConverter) {
+        List<String> photoUrls = jsonConverter.convertJsonToList(post.getPhotoUrls());
+        List<String> tags = jsonConverter.convertJsonToList(post.getTags());
+        return new AdminPostDetailResponse(
+                post.getId(),
+                post.getTitle(),
+                post.getContent(),
+                post.getStatus(),
+                post.getDestination().getCity(),
+                post.getStartDate(),
+                post.getEndDate(),
+                post.getRecruitCapacity(),
+                post.getRecruitCount(),
+                post.getRecruitDeadline(),
+                post.getPreferredGender(),
+                post.getPreferredAges(),
+                photoUrls,
+                tags,
+                post.getUser().getId(),
+                post.getUser().getName(),
+                post.getCreatedAt(),
+                post.isDeleted(),
+                post.getDeletedAt(),
+                post.getDeletedBy()
+        );
+    }
+}

--- a/src/main/java/com/dduru/gildongmu/admin/post/service/AdminPostService.java
+++ b/src/main/java/com/dduru/gildongmu/admin/post/service/AdminPostService.java
@@ -1,0 +1,41 @@
+package com.dduru.gildongmu.admin.post.service;
+
+import com.dduru.gildongmu.admin.post.dto.response.AdminPostDetailResponse;
+import com.dduru.gildongmu.common.util.JsonConverter;
+import com.dduru.gildongmu.post.domain.Post;
+import com.dduru.gildongmu.post.repository.PostRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminPostService {
+
+    private final PostRepository postRepository;
+    private final JsonConverter jsonConverter;
+
+    public AdminPostDetailResponse getDetail(Long postId) {
+        log.debug("관리자 게시글 상세 조회 - postId={}", postId);
+        Post post = postRepository.getByIdOrThrow(postId);
+        return AdminPostDetailResponse.from(post, jsonConverter);
+    }
+
+    @Transactional
+    public void delete(Long postId, Long adminUserId) {
+        log.debug("관리자 게시글 삭제 - postId={}, adminUserId={}", postId, adminUserId);
+
+        Post post = postRepository.getByIdOrThrow(postId);
+
+        if (post.isDeleted()) {
+            log.debug("이미 삭제된 게시글 - postId={}, adminUserId={}", postId, adminUserId);
+            return;
+        }
+
+        post.softDelete(adminUserId);
+        log.info("관리자 게시글 삭제됨 - postId={}, adminUserId={}", postId, adminUserId);
+    }
+}

--- a/src/main/java/com/dduru/gildongmu/post/repository/PostRepository.java
+++ b/src/main/java/com/dduru/gildongmu/post/repository/PostRepository.java
@@ -26,4 +26,9 @@ public interface PostRepository extends JpaRepository<Post, Long>,PostRepository
         return findActiveById(id)
                 .orElseThrow(() -> PostNotFoundException.of(id));
     }
+
+    default Post getByIdOrThrow(Long id) {
+        return findById(id)
+                .orElseThrow(() -> PostNotFoundException.of(id));
+    }
 }

--- a/src/test/java/com/dduru/gildongmu/admin/post/service/AdminPostServiceTest.java
+++ b/src/test/java/com/dduru/gildongmu/admin/post/service/AdminPostServiceTest.java
@@ -1,0 +1,151 @@
+package com.dduru.gildongmu.admin.post.service;
+
+import com.dduru.gildongmu.admin.post.dto.response.AdminPostDetailResponse;
+import com.dduru.gildongmu.common.util.JsonConverter;
+import com.dduru.gildongmu.destination.domain.Destination;
+import com.dduru.gildongmu.post.domain.Post;
+import com.dduru.gildongmu.post.domain.enums.RecruitMethod;
+import com.dduru.gildongmu.post.domain.enums.RecruitType;
+import com.dduru.gildongmu.post.exception.PostNotFoundException;
+import com.dduru.gildongmu.post.repository.PostRepository;
+import com.dduru.gildongmu.profile.domain.enums.AgeRange;
+import com.dduru.gildongmu.profile.domain.enums.Gender;
+import com.dduru.gildongmu.user.domain.User;
+import com.dduru.gildongmu.user.domain.enums.OauthType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("AdminPostService 테스트")
+class AdminPostServiceTest {
+
+    @Mock
+    private PostRepository postRepository;
+
+    @Mock
+    private JsonConverter jsonConverter;
+
+    @InjectMocks
+    private AdminPostService adminPostService;
+
+    @DisplayName("관리자 게시글 상세 조회 시 응답에 게시글 정보가 담긴다")
+    @Test
+    void getDetail_returnsAdminPostDetailResponse() {
+        Long postId = 42L;
+        Post post = createPost(postId, false);
+
+        when(postRepository.getByIdOrThrow(postId)).thenReturn(post);
+        when(jsonConverter.convertJsonToList(any())).thenReturn(List.of());
+
+        AdminPostDetailResponse response = adminPostService.getDetail(postId);
+
+        assertThat(response.id()).isEqualTo(postId);
+        assertThat(response.title()).isEqualTo("제목");
+        assertThat(response.destination()).isEqualTo("서울");
+        assertThat(response.authorId()).isEqualTo(7L);
+        assertThat(response.authorName()).isEqualTo("작성자");
+        assertThat(response.isDeleted()).isFalse();
+        verify(postRepository).getByIdOrThrow(postId);
+    }
+
+    @DisplayName("관리자 게시글 상세 조회 시 게시글이 없으면 PostNotFoundException이 발생한다")
+    @Test
+    void getDetail_postNotFound_throwsPostNotFoundException() {
+        Long postId = 999L;
+        when(postRepository.getByIdOrThrow(postId)).thenThrow(PostNotFoundException.of(postId));
+
+        assertThatThrownBy(() -> adminPostService.getDetail(postId))
+                .isInstanceOf(PostNotFoundException.class)
+                .hasMessageContaining("게시글을 찾을 수 없습니다");
+    }
+
+    @DisplayName("관리자 게시글 삭제 시 미삭제 게시글이면 softDelete가 호출된다")
+    @Test
+    void delete_notYetDeleted_callsSoftDelete() {
+        Long postId = 1L;
+        Long adminUserId = 100L;
+        Post post = createPost(postId, false);
+
+        when(postRepository.getByIdOrThrow(postId)).thenReturn(post);
+
+        adminPostService.delete(postId, adminUserId);
+
+        assertThat(post.isDeleted()).isTrue();
+        assertThat(post.getDeletedBy()).isEqualTo(adminUserId);
+        verify(postRepository).getByIdOrThrow(postId);
+    }
+
+    @DisplayName("관리자 게시글 삭제 시 이미 삭제된 게시글이면 softDelete를 다시 호출하지 않는다")
+    @Test
+    void delete_alreadyDeleted_doesNotOverwriteSoftDelete() {
+        Long postId = 1L;
+        Long adminUserId = 200L;
+        Post post = createPost(postId, true);
+        var originalDeletedAt = post.getDeletedAt();
+        var originalDeletedBy = post.getDeletedBy();
+
+        when(postRepository.getByIdOrThrow(postId)).thenReturn(post);
+
+        adminPostService.delete(postId, adminUserId);
+
+        assertThat(post.getDeletedAt()).isEqualTo(originalDeletedAt);
+        assertThat(post.getDeletedBy()).isEqualTo(originalDeletedBy);
+        verify(postRepository).getByIdOrThrow(postId);
+    }
+
+    private static Post createPost(Long postId, boolean deleted) {
+        User user = User.builder()
+                .email("u@u.com")
+                .name("작성자")
+                .oauthId("kakao-7")
+                .oauthType(OauthType.KAKAO)
+                .build();
+        ReflectionTestUtils.setField(user, "id", 7L);
+
+        Destination destination = Destination.builder()
+                .countryCode("KR")
+                .countryName("대한민국")
+                .city("서울")
+                .build();
+        ReflectionTestUtils.setField(destination, "id", 3L);
+
+        Post post = Post.builder()
+                .user(user)
+                .destination(destination)
+                .title("제목")
+                .content("내용내용내용내용내용내용내용내용")
+                .startDate(LocalDate.now().plusDays(1))
+                .endDate(LocalDate.now().plusDays(3))
+                .recruitCapacity(4)
+                .recruitDeadline(LocalDate.now().plusDays(1))
+                .preferredGender(Gender.M)
+                .preferredAges(List.of(AgeRange.AGE_20s))
+                .photoUrls("[]")
+                .tags("[]")
+                .recruitType(RecruitType.PRIVATE)
+                .recruitMethod(RecruitMethod.ALWAYS)
+                .companionType(null)
+                .build();
+        ReflectionTestUtils.setField(post, "id", postId);
+
+        if (deleted) {
+            post.softDelete(55L);
+        }
+
+        return post;
+    }
+}


### PR DESCRIPTION
## 🔎 작업 내용
* 관리자 전용 게시글 단건 조회 API (GET /api/v1/admin/posts/{postId}) - 삭제된 게시글 포함 조회
* 관리자 전용 게시글 소프트 삭제 API (DELETE /api/v1/admin/posts/{postId}} - 이미 삭제된 경우 멱등 처리

## ➕ 이슈 링크
* Closed #179 

## 📝 체크리스트
- [x] 브랜치 이름은 `feat/개발내용` 형식으로 작성했는가?
- [x] 커밋 메시지는 `feat(scope): 커밋 내용` 형식으로 작성했는가?
- [x] 작업 전 Issue를 작성했는가?
- [x] `dev` 브랜치로 병합을 요청했는가?
- [x] 불필요한 주석과 공백은 제거했는가?
- [x] 코드 리뷰어의 피드백을 반영했는가?
- [x] 테스트를 진행했는가?
- [x] 테스트 코드를 작성했는가?
