### PR TITLE
feat: 웹소켓 STOMP 인증 및 에러 처리 기반 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ dependencies {
 	implementation 'org.flywaydb:flyway-mysql'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-websocket'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/dduru/gildongmu/common/config/SecurityConfig.java
+++ b/src/main/java/com/dduru/gildongmu/common/config/SecurityConfig.java
@@ -38,6 +38,7 @@ public class SecurityConfig {
                         /* API 권한 설정 */
                         .requestMatchers("/api/v1/auth/logout").authenticated()
                         .requestMatchers("/api/v1/auth/**").permitAll()
+                        .requestMatchers("/ws/**").permitAll()
                         // 게시글 목록 / 상세 조회만 비로그인 허용
                         .requestMatchers(HttpMethod.GET, "/api/v1/posts", "/api/v1/posts/*").permitAll()
                         .requestMatchers("/api/v1/verifications/**").authenticated()

--- a/src/main/java/com/dduru/gildongmu/common/config/SecurityConfig.java
+++ b/src/main/java/com/dduru/gildongmu/common/config/SecurityConfig.java
@@ -38,7 +38,7 @@ public class SecurityConfig {
                         /* API 권한 설정 */
                         .requestMatchers("/api/v1/auth/logout").authenticated()
                         .requestMatchers("/api/v1/auth/**").permitAll()
-                        .requestMatchers("/ws/**").permitAll()
+                        .requestMatchers("/ws/chat").permitAll()
                         // 게시글 목록 / 상세 조회만 비로그인 허용
                         .requestMatchers(HttpMethod.GET, "/api/v1/posts", "/api/v1/posts/*").permitAll()
                         .requestMatchers("/api/v1/verifications/**").authenticated()

--- a/src/main/java/com/dduru/gildongmu/common/config/WebSocketStompConfig.java
+++ b/src/main/java/com/dduru/gildongmu/common/config/WebSocketStompConfig.java
@@ -1,0 +1,41 @@
+package com.dduru.gildongmu.common.config;
+
+import com.dduru.gildongmu.common.websocket.JwtStompChannelInterceptor;
+import com.dduru.gildongmu.common.websocket.StompErrorHandler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+@RequiredArgsConstructor
+public class WebSocketStompConfig implements WebSocketMessageBrokerConfigurer {
+
+    private final JwtStompChannelInterceptor jwtStompChannelInterceptor;
+    private final StompErrorHandler stompErrorHandler;
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.setPreserveReceiveOrder(true);
+        registry.setErrorHandler(stompErrorHandler);
+        registry.addEndpoint("/ws/chat")
+                .setAllowedOriginPatterns("*");
+    }
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        // 단일 인스턴스 기준 기본 브로커. 확장 시 broker relay 또는 Redis 기반 fan-out으로 교체한다.
+        registry.enableSimpleBroker("/topic", "/queue");
+        registry.setApplicationDestinationPrefixes("/pub");
+        registry.setUserDestinationPrefix("/user");
+    }
+
+    @Override
+    public void configureClientInboundChannel(ChannelRegistration registration) {
+        registration.interceptors(jwtStompChannelInterceptor);
+    }
+}

--- a/src/main/java/com/dduru/gildongmu/common/websocket/JwtStompChannelInterceptor.java
+++ b/src/main/java/com/dduru/gildongmu/common/websocket/JwtStompChannelInterceptor.java
@@ -30,7 +30,7 @@ public class JwtStompChannelInterceptor implements ChannelInterceptor {
         }
 
         return switch (accessor.getCommand()) {
-            case CONNECT -> authenticate(message, accessor);
+            case CONNECT, STOMP -> authenticate(message, accessor);
             case SEND, SUBSCRIBE, UNSUBSCRIBE -> requireAuthenticated(message, accessor);
             default -> message;
         };

--- a/src/main/java/com/dduru/gildongmu/common/websocket/JwtStompChannelInterceptor.java
+++ b/src/main/java/com/dduru/gildongmu/common/websocket/JwtStompChannelInterceptor.java
@@ -1,0 +1,88 @@
+package com.dduru.gildongmu.common.websocket;
+
+import com.dduru.gildongmu.common.jwt.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageHeaderAccessor;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtStompChannelInterceptor implements ChannelInterceptor {
+
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    public Message<?> preSend(Message<?> message, MessageChannel channel) {
+        StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+        if (accessor == null || accessor.getCommand() == null) {
+            return message;
+        }
+
+        return switch (accessor.getCommand()) {
+            case CONNECT -> authenticate(message, accessor);
+            case SEND, SUBSCRIBE, UNSUBSCRIBE -> requireAuthenticated(message, accessor);
+            default -> message;
+        };
+    }
+
+    private Message<?> authenticate(Message<?> message, StompHeaderAccessor accessor) {
+        String token = resolveToken(accessor);
+        if (!StringUtils.hasText(token)) {
+            logConnectFailure(accessor, "missing_authorization");
+            throw WebSocketAuthException.missingAuthorizationHeader();
+        }
+        if (!jwtTokenProvider.validateToken(token)) {
+            logConnectFailure(accessor, "invalid_token");
+            throw WebSocketAuthException.invalidAccessToken();
+        }
+
+        Authentication authentication = jwtTokenProvider.resolveAuthentication(token, false);
+        if (authentication == null) {
+            logConnectFailure(accessor, "authentication_resolution_failed");
+            throw WebSocketAuthException.authenticationResolutionFailed();
+        }
+
+        accessor.setUser(authentication);
+        log.debug("WebSocket CONNECT 인증 완료 - userId={}, sessionId={}",
+                authentication.getName(), accessor.getSessionId());
+        return message;
+    }
+
+    private Message<?> requireAuthenticated(Message<?> message, StompHeaderAccessor accessor) {
+        if (accessor.getUser() == null) {
+            log.warn("인증되지 않은 WebSocket 요청 차단 - command={}, sessionId={}, destination={}",
+                    accessor.getCommand(), accessor.getSessionId(), accessor.getDestination());
+            throw WebSocketAuthException.unauthenticatedCommand(accessor.getCommand());
+        }
+        return message;
+    }
+
+    private String resolveToken(StompHeaderAccessor accessor) {
+        String bearerToken = accessor.getFirstNativeHeader(AUTHORIZATION_HEADER);
+        if (!StringUtils.hasText(bearerToken)) {
+            bearerToken = accessor.getFirstNativeHeader(AUTHORIZATION_HEADER.toLowerCase());
+        }
+        if (!StringUtils.hasText(bearerToken)) {
+            return null;
+        }
+        if (bearerToken.startsWith(BEARER_PREFIX)) {
+            return bearerToken.substring(BEARER_PREFIX.length());
+        }
+        return bearerToken;
+    }
+
+    private void logConnectFailure(StompHeaderAccessor accessor, String reason) {
+        log.warn("WebSocket CONNECT 인증 실패 - reason={}, sessionId={}", reason, accessor.getSessionId());
+    }
+}

--- a/src/main/java/com/dduru/gildongmu/common/websocket/StompErrorHandler.java
+++ b/src/main/java/com/dduru/gildongmu/common/websocket/StompErrorHandler.java
@@ -1,0 +1,128 @@
+package com.dduru.gildongmu.common.websocket;
+
+import com.dduru.gildongmu.common.exception.BusinessException;
+import com.dduru.gildongmu.common.exception.ErrorCode;
+import com.dduru.gildongmu.common.exception.ErrorData;
+import com.dduru.gildongmu.common.exception.ErrorResponse;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.lang.Nullable;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageDeliveryException;
+import org.springframework.messaging.MessagingException;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.MessageHeaderAccessor;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.stereotype.Component;
+import org.springframework.util.MimeTypeUtils;
+import org.springframework.web.socket.messaging.StompSubProtocolErrorHandler;
+
+import java.nio.charset.StandardCharsets;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class StompErrorHandler extends StompSubProtocolErrorHandler {
+
+    private static final String WEBSOCKET_AUTH_REQUIRED_MESSAGE = "WebSocket 인증이 필요합니다.";
+    private static final String WEBSOCKET_PROCESSING_ERROR_MESSAGE = "WebSocket 처리 중 오류가 발생했습니다.";
+    private static final ErrorResponse FALLBACK_ERROR_RESPONSE = ErrorResponse.of(ErrorCode.INTERNAL_SERVER_ERROR);
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public Message<byte[]> handleClientMessageProcessingError(@Nullable Message<byte[]> clientMessage, Throwable ex) {
+        Throwable cause = unwrap(ex);
+        ErrorResponse errorResponse = toErrorResponse(cause);
+        StompHeaderAccessor clientAccessor = getClientAccessor(clientMessage);
+        StompHeaderAccessor errorAccessor = createErrorAccessor(errorResponse, clientAccessor);
+        return handleInternal(errorAccessor, serialize(errorResponse), cause, clientAccessor);
+    }
+
+    private Throwable unwrap(Throwable throwable) {
+        Throwable current = throwable;
+        while (current.getCause() != null
+                && (current instanceof MessageDeliveryException || current instanceof MessagingException)) {
+            current = current.getCause();
+        }
+        return current;
+    }
+
+    private ErrorResponse toErrorResponse(Throwable throwable) {
+        if (throwable instanceof BusinessException businessException) {
+            return ErrorResponse.of(businessException.getErrorCode(), businessException.getMessage());
+        }
+        if (isAuthenticationFailure(throwable)) {
+            return ErrorResponse.of(ErrorCode.UNAUTHORIZED, WEBSOCKET_AUTH_REQUIRED_MESSAGE);
+        }
+        if (throwable instanceof IllegalArgumentException illegalArgumentException) {
+            return ErrorResponse.of(ErrorCode.INVALID_INPUT_VALUE, illegalArgumentException.getMessage());
+        }
+        log.error("WebSocket 처리 중 예외 발생", throwable);
+        return ErrorResponse.of(ErrorCode.INTERNAL_SERVER_ERROR, WEBSOCKET_PROCESSING_ERROR_MESSAGE);
+    }
+
+    private byte[] serialize(ErrorResponse errorResponse) {
+        try {
+            return objectMapper.writeValueAsBytes(errorResponse);
+        } catch (JsonProcessingException e) {
+            log.error("STOMP ERROR payload 직렬화 실패", e);
+            return serializeFallback(FALLBACK_ERROR_RESPONSE);
+        }
+    }
+
+    private StompHeaderAccessor getClientAccessor(@Nullable Message<byte[]> clientMessage) {
+        if (clientMessage == null) {
+            return null;
+        }
+        return MessageHeaderAccessor.getAccessor(clientMessage, StompHeaderAccessor.class);
+    }
+
+    private StompHeaderAccessor createErrorAccessor(ErrorResponse errorResponse,
+                                                    @Nullable StompHeaderAccessor clientAccessor) {
+        StompHeaderAccessor errorAccessor = StompHeaderAccessor.create(StompCommand.ERROR);
+        errorAccessor.setMessage(errorResponse.data().message());
+        errorAccessor.setContentType(MimeTypeUtils.APPLICATION_JSON);
+        errorAccessor.setLeaveMutable(true);
+
+        if (clientAccessor != null && clientAccessor.getReceipt() != null) {
+            errorAccessor.setReceiptId(clientAccessor.getReceipt());
+        }
+        return errorAccessor;
+    }
+
+    private boolean isAuthenticationFailure(Throwable throwable) {
+        return throwable instanceof AuthenticationException || throwable instanceof AccessDeniedException;
+    }
+
+    private byte[] serializeFallback(ErrorResponse errorResponse) {
+        ErrorData errorData = errorResponse.data();
+        String fieldJson = errorData.field() == null
+                ? ""
+                : ",\"field\":\"" + escapeJson(errorData.field()) + "\"";
+
+        String json = """
+                {"status":%d,"data":{"errorCode":"%s"%s,"message":"%s"}}
+                """.formatted(
+                errorResponse.status(),
+                escapeJson(errorData.errorCode()),
+                fieldJson,
+                escapeJson(errorData.message())
+        );
+
+        return json.getBytes(StandardCharsets.UTF_8);
+    }
+
+    private String escapeJson(String value) {
+        return value
+                .replace("\\", "\\\\")
+                .replace("\"", "\\\"")
+                .replace("\n", "\\n")
+                .replace("\r", "\\r")
+                .replace("\t", "\\t");
+    }
+}

--- a/src/main/java/com/dduru/gildongmu/common/websocket/WebSocketAuthException.java
+++ b/src/main/java/com/dduru/gildongmu/common/websocket/WebSocketAuthException.java
@@ -1,0 +1,40 @@
+package com.dduru.gildongmu.common.websocket;
+
+import com.dduru.gildongmu.common.exception.BusinessException;
+import com.dduru.gildongmu.common.exception.ErrorCode;
+import org.springframework.messaging.simp.stomp.StompCommand;
+
+public class WebSocketAuthException extends BusinessException {
+
+    private WebSocketAuthException(ErrorCode errorCode, String message) {
+        super(errorCode, message);
+    }
+
+    public static WebSocketAuthException missingAuthorizationHeader() {
+        return new WebSocketAuthException(
+                ErrorCode.UNAUTHORIZED,
+                "WebSocket CONNECT 시 Authorization 헤더가 필요합니다."
+        );
+    }
+
+    public static WebSocketAuthException invalidAccessToken() {
+        return new WebSocketAuthException(
+                ErrorCode.INVALID_TOKEN,
+                "WebSocket CONNECT 토큰이 유효하지 않습니다."
+        );
+    }
+
+    public static WebSocketAuthException authenticationResolutionFailed() {
+        return new WebSocketAuthException(
+                ErrorCode.INVALID_TOKEN,
+                "WebSocket CONNECT 인증 정보를 생성할 수 없습니다."
+        );
+    }
+
+    public static WebSocketAuthException unauthenticatedCommand(StompCommand command) {
+        return new WebSocketAuthException(
+                ErrorCode.UNAUTHORIZED,
+                "인증되지 않은 WebSocket " + command + " 요청입니다."
+        );
+    }
+}

--- a/src/test/java/com/dduru/gildongmu/common/websocket/JwtStompChannelInterceptorTest.java
+++ b/src/test/java/com/dduru/gildongmu/common/websocket/JwtStompChannelInterceptorTest.java
@@ -1,0 +1,103 @@
+package com.dduru.gildongmu.common.websocket;
+
+import com.dduru.gildongmu.common.jwt.JwtTokenProvider;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+import java.security.Principal;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class JwtStompChannelInterceptorTest {
+
+    @Mock
+    private JwtTokenProvider jwtTokenProvider;
+
+    @InjectMocks
+    private JwtStompChannelInterceptor interceptor;
+
+    @Test
+    @DisplayName("CONNECT에서 유효한 JWT를 보내면 Principal이 세션에 저장된다")
+    void preSend_connectWithValidToken_setsPrincipal() {
+        Authentication authentication = new UsernamePasswordAuthenticationToken(
+                "1",
+                null,
+                List.of(new SimpleGrantedAuthority("ROLE_USER"))
+        );
+        Message<byte[]> message = stompMessage(StompCommand.CONNECT, "Authorization", "Bearer valid-token", null);
+
+        when(jwtTokenProvider.validateToken("valid-token")).thenReturn(true);
+        when(jwtTokenProvider.resolveAuthentication("valid-token", false)).thenReturn(authentication);
+
+        Message<?> result = interceptor.preSend(message, mock(MessageChannel.class));
+
+        Principal principal = StompHeaderAccessor.wrap(result).getUser();
+        assertThat(principal).isEqualTo(authentication);
+    }
+
+    @Test
+    @DisplayName("CONNECT에서 Authorization 헤더가 없으면 예외가 발생한다")
+    void preSend_connectWithoutAuthorization_throwsUnauthorized() {
+        Message<byte[]> message = stompMessage(StompCommand.CONNECT, null, null, null);
+
+        assertThatThrownBy(() -> interceptor.preSend(message, mock(MessageChannel.class)))
+                .isInstanceOf(WebSocketAuthException.class)
+                .hasMessage("WebSocket CONNECT 시 Authorization 헤더가 필요합니다.");
+    }
+
+    @Test
+    @DisplayName("CONNECT에서 유효하지 않은 JWT를 보내면 예외가 발생한다")
+    void preSend_connectWithInvalidToken_throwsInvalidToken() {
+        Message<byte[]> message = stompMessage(StompCommand.CONNECT, "Authorization", "Bearer invalid-token", null);
+
+        when(jwtTokenProvider.validateToken("invalid-token")).thenReturn(false);
+
+        assertThatThrownBy(() -> interceptor.preSend(message, mock(MessageChannel.class)))
+                .isInstanceOf(WebSocketAuthException.class)
+                .hasMessage("WebSocket CONNECT 토큰이 유효하지 않습니다.");
+    }
+
+    @Test
+    @DisplayName("인증되지 않은 세션의 SEND 요청은 차단한다")
+    void preSend_sendWithoutPrincipal_throwsUnauthorized() {
+        Message<byte[]> message = stompMessage(StompCommand.SEND, null, null, null);
+
+        assertThatThrownBy(() -> interceptor.preSend(message, mock(MessageChannel.class)))
+                .isInstanceOf(WebSocketAuthException.class)
+                .hasMessage("인증되지 않은 WebSocket SEND 요청입니다.");
+    }
+
+    private static Message<byte[]> stompMessage(
+            StompCommand command,
+            String headerName,
+            String headerValue,
+            Principal principal
+    ) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.create(command);
+        if (headerName != null && headerValue != null) {
+            accessor.setNativeHeader(headerName, headerValue);
+        }
+        if (principal != null) {
+            accessor.setUser(principal);
+        }
+        accessor.setLeaveMutable(true);
+        return MessageBuilder.createMessage(new byte[0], accessor.getMessageHeaders());
+    }
+}

--- a/src/test/java/com/dduru/gildongmu/common/websocket/StompErrorHandlerTest.java
+++ b/src/test/java/com/dduru/gildongmu/common/websocket/StompErrorHandlerTest.java
@@ -1,0 +1,73 @@
+package com.dduru.gildongmu.common.websocket;
+
+import com.dduru.gildongmu.auth.exception.UnauthorizedException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.util.MimeTypeUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class StompErrorHandlerTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final StompErrorHandler stompErrorHandler = new StompErrorHandler(objectMapper);
+
+    @Test
+    @DisplayName("BusinessException은 JSON ERROR frame으로 변환된다")
+    void handleClientMessageProcessingError_businessException_returnsJsonErrorFrame() throws Exception {
+        Message<byte[]> clientMessage = connectMessage("receipt-123");
+
+        Message<byte[]> errorMessage = stompErrorHandler.handleClientMessageProcessingError(
+                clientMessage,
+                new UnauthorizedException("인증이 필요합니다.")
+        );
+
+        StompHeaderAccessor accessor = StompHeaderAccessor.wrap(errorMessage);
+        JsonNode payload = objectMapper.readTree(errorMessage.getPayload());
+
+        assertThat(accessor.getCommand()).isEqualTo(StompCommand.ERROR);
+        assertThat(accessor.getReceiptId()).isEqualTo("receipt-123");
+        assertThat(accessor.getContentType()).isEqualTo(MimeTypeUtils.APPLICATION_JSON);
+        assertThat(payload.get("status").asInt()).isEqualTo(401);
+        assertThat(payload.get("data").get("errorCode").asText()).isEqualTo("UNAUTHORIZED");
+        assertThat(payload.get("data").get("message").asText()).isEqualTo("인증이 필요합니다.");
+    }
+
+    @Test
+    @DisplayName("직렬화 실패 시에도 서비스 표준 ErrorResponse 포맷으로 내려간다")
+    void handleClientMessageProcessingError_serializationFails_returnsFallbackErrorResponse() throws Exception {
+        ObjectMapper failingObjectMapper = mock(ObjectMapper.class);
+        when(failingObjectMapper.writeValueAsBytes(org.mockito.ArgumentMatchers.any()))
+                .thenThrow(new JsonProcessingException("boom") {
+                });
+        StompErrorHandler fallbackHandler = new StompErrorHandler(failingObjectMapper);
+
+        Message<byte[]> errorMessage = fallbackHandler.handleClientMessageProcessingError(
+                connectMessage("receipt-456"),
+                new UnauthorizedException("인증이 필요합니다.")
+        );
+
+        JsonNode payload = objectMapper.readTree(errorMessage.getPayload());
+
+        assertThat(payload.get("status").asInt()).isEqualTo(500);
+        assertThat(payload.get("data").get("errorCode").asText()).isEqualTo("INTERNAL_SERVER_ERROR");
+        assertThat(payload.get("data").has("field")).isFalse();
+        assertThat(payload.get("data").get("message").asText()).isEqualTo("서버 오류가 발생했습니다.");
+    }
+
+    private static Message<byte[]> connectMessage(String receiptId) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.CONNECT);
+        accessor.setReceipt(receiptId);
+        accessor.setLeaveMutable(true);
+        return MessageBuilder.createMessage(new byte[0], accessor.getMessageHeaders());
+    }
+}


### PR DESCRIPTION
## 🔎 작업 내용
* STOMP 기반 WebSocket 연결 설정
* `/ws/chat` 엔드포인트와 `/pub`, `/topic`, `/queue`, `/user` prefix 구성
* `CONNECT`, `SEND`, `SUBSCRIBE`, `UNSUBSCRIBE` 요청에 대해 JWT 인증 인터셉터 추가
* `WebSocketAuthException` 추가
* STOMP 처리 중 발생한 예외를 서비스 표준 `ErrorResponse` 형태의 `ERROR` frame으로 내려주도록 `StompErrorHandler` 추가
* WebSocket 인증 인터셉터와 에러 핸들러에 대한 test code 추가
## ➕ 이슈 링크
* Closed #146 

## 📸 스크린샷
연결 설정 관련 개발이라 스크린샷 X

## 😎 리뷰 요구사항
<!--
리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?-->
> 엔드포인트 설정이 적절해보이는지 확인해주세요~! 

## 🧑‍💻 예정 작업
- #147 

## 📝 체크리스트
- [x] 브랜치 이름은 `feat/개발내용` 형식으로 작성했는가?
- [x] 커밋 메시지는 `feat(scope): 커밋 내용` 형식으로 작성했는가?
- [x] 작업 전 Issue를 작성했는가?
- [x] `dev` 브랜치로 병합을 요청했는가?
- [x] 불필요한 주석과 공백은 제거했는가?
- [ ] 코드 리뷰어의 피드백을 반영했는가?
- [x] 테스트를 진행했는가?
- [x] 테스트 코드를 작성했는가?
