### PR TITLE
feat: 기존 신청 기능과 ChatRoom 초대 연동을 위한 도메인 변경 반영

### DIFF
--- a/src/main/java/com/dduru/gildongmu/chat/domain/ChatRoom.java
+++ b/src/main/java/com/dduru/gildongmu/chat/domain/ChatRoom.java
@@ -48,7 +48,7 @@ public class ChatRoom extends BaseTimeEntity {
     }
 
     public static ChatRoom createPendingGroupChat(Post post) {
-        int capacity = post.getRecruitCapacity() + 1;
+        int capacity = post.getRecruitCapacity();
         return newRoom(post, ChatRoomType.GROUP, capacity, ChatRoomStatus.PENDING);
     }
 

--- a/src/main/java/com/dduru/gildongmu/participation/domain/Participation.java
+++ b/src/main/java/com/dduru/gildongmu/participation/domain/Participation.java
@@ -38,6 +38,9 @@ public class Participation extends BaseTimeEntity {
     @Column(name = "message", length = 500)
     private String message;
 
+    @Column(name = "contacted_at")
+    private LocalDateTime contactedAt;
+
     @Column(name = "approved_at")
     private LocalDateTime approvedAt;
 
@@ -65,9 +68,26 @@ public class Participation extends BaseTimeEntity {
         this.approvedAt = LocalDateTime.now();
     }
 
+    public void contact() {
+        this.status = ParticipationStatus.CONTACTING;
+        this.contactedAt = LocalDateTime.now();
+    }
+
     public void reject() {
         this.status = ParticipationStatus.REJECTED;
         this.rejectedAt = LocalDateTime.now();
+    }
+
+    public boolean isPending() {
+        return status == ParticipationStatus.PENDING;
+    }
+
+    public boolean isContacting() {
+        return status == ParticipationStatus.CONTACTING;
+    }
+
+    public boolean isRejected() {
+        return status == ParticipationStatus.REJECTED;
     }
 
     public boolean isApproved() {

--- a/src/main/java/com/dduru/gildongmu/participation/domain/enums/ParticipationStatus.java
+++ b/src/main/java/com/dduru/gildongmu/participation/domain/enums/ParticipationStatus.java
@@ -2,6 +2,7 @@ package com.dduru.gildongmu.participation.domain.enums;
 
 public enum ParticipationStatus {
     PENDING,
+    CONTACTING,
     APPROVED,
     REJECTED
 }

--- a/src/main/java/com/dduru/gildongmu/participation/service/ParticipationService.java
+++ b/src/main/java/com/dduru/gildongmu/participation/service/ParticipationService.java
@@ -128,6 +128,7 @@ public class ParticipationService {
                     case PENDING -> MyParticipationStatus.PENDING;
                     case APPROVED -> MyParticipationStatus.APPROVED;
                     case REJECTED -> MyParticipationStatus.REJECTED;
+                    case CONTACTING -> MyParticipationStatus.CONTACTING;
                 })
                 .orElse(MyParticipationStatus.NONE);
     }
@@ -136,7 +137,7 @@ public class ParticipationService {
         if (post.getUser().getId().equals(user.getId())) {
             throw new SelfParticipationNotAllowedException();
         }
-        if (!post.isRecruitOpen()) {
+        if (post.isClosed()) {
             throw new RecruitmentClosedException();
         }
         if (participationRepository.existsByPostIdAndUserId(post.getId(), user.getId())) {

--- a/src/main/java/com/dduru/gildongmu/post/domain/Post.java
+++ b/src/main/java/com/dduru/gildongmu/post/domain/Post.java
@@ -5,7 +5,6 @@ import com.dduru.gildongmu.destination.domain.Destination;
 import com.dduru.gildongmu.participation.domain.Participation;
 import com.dduru.gildongmu.post.domain.enums.CompanionType;
 import com.dduru.gildongmu.post.domain.enums.PostStatus;
-import com.dduru.gildongmu.post.exception.InvalidPostStatusException;
 import com.dduru.gildongmu.post.exception.InvalidRecruitCapacityException;
 import com.dduru.gildongmu.post.exception.RecruitDeadlinePassedException;
 import com.dduru.gildongmu.post.exception.RecruitCountBelowZeroException;
@@ -184,14 +183,12 @@ public class Post extends BaseTimeEntity {
     }
 
     public void changeStatus(PostStatus newStatus) {
-        validateStatusChange(newStatus);
         this.status = newStatus;
     }
 
     public void approveParticipation(Participation participation) {
         participation.approve();
         incrementRecruitCount();
-        closeIfRecruitmentFull();
     }
 
     public void removeApprovedParticipation(Participation participation) {
@@ -200,7 +197,6 @@ public class Post extends BaseTimeEntity {
         }
 
         decrementRecruitCount();
-        reopenIfCapacityAvailable();
     }
 
     public void increaseLikes() {
@@ -211,8 +207,12 @@ public class Post extends BaseTimeEntity {
         this.likeCount--;
     }
 
-    public boolean isRecruitOpen() {
-        return status == PostStatus.OPEN;
+    public boolean isFull() {
+        return this.recruitCount >= this.recruitCapacity;
+    }
+
+    public boolean isClosed(){
+        return this.status == PostStatus.CLOSED;
     }
 
     public int getDaysUntilRecruitDeadline() {
@@ -285,24 +285,6 @@ public class Post extends BaseTimeEntity {
     private void applyRecruitCapacity(Integer recruitCapacity) {
         if (recruitCapacity != null) {
             updateRecruitCapacity(recruitCapacity);
-        }
-    }
-
-    private void validateStatusChange(PostStatus newStatus) {
-        if (this.status == PostStatus.FULL && newStatus == PostStatus.OPEN) {
-            throw new InvalidPostStatusException();
-        }
-    }
-
-    private void closeIfRecruitmentFull() {
-        if (this.recruitCount >= this.recruitCapacity) {
-            changeStatus(PostStatus.FULL);
-        }
-    }
-
-    private void reopenIfCapacityAvailable() {
-        if (this.status == PostStatus.FULL && this.recruitCount < this.recruitCapacity) {
-            this.status = PostStatus.OPEN;
         }
     }
 

--- a/src/main/java/com/dduru/gildongmu/post/domain/enums/PostStatus.java
+++ b/src/main/java/com/dduru/gildongmu/post/domain/enums/PostStatus.java
@@ -5,7 +5,6 @@ import lombok.Getter;
 @Getter
 public enum PostStatus {
     OPEN("게시글이 공개된 상태입니다."),
-    FULL("게시글이 모집 완료된 상태입니다."),
     CLOSED("게시글이 마감된 상태입니다.");
 
     private final String description;

--- a/src/main/java/com/dduru/gildongmu/post/dto/response/MyParticipationStatus.java
+++ b/src/main/java/com/dduru/gildongmu/post/dto/response/MyParticipationStatus.java
@@ -3,6 +3,7 @@ package com.dduru.gildongmu.post.dto.response;
 public enum MyParticipationStatus {
     NONE,
     PENDING,
+    CONTACTING,
     APPROVED,
     REJECTED
 }

--- a/src/main/java/com/dduru/gildongmu/post/dto/response/PostDetailResponse.java
+++ b/src/main/java/com/dduru/gildongmu/post/dto/response/PostDetailResponse.java
@@ -2,6 +2,7 @@ package com.dduru.gildongmu.post.dto.response;
 
 import com.dduru.gildongmu.common.util.JsonConverter;
 import com.dduru.gildongmu.post.domain.Post;
+import com.dduru.gildongmu.post.domain.enums.PostStatus;
 import com.dduru.gildongmu.profile.domain.enums.Gender;
 import com.dduru.gildongmu.profile.service.ProfileImageResolver;
 import com.dduru.gildongmu.user.dto.UserInfo;
@@ -15,7 +16,8 @@ public record PostDetailResponse(
         Long id,
         String title,
         String content,
-        boolean isRecruitOpen,
+        PostStatus status,
+        boolean isFull,
         int daysUntilRecruitDeadline,
         int daysUntilTravelStart,
         LocalDate startDate,
@@ -73,7 +75,8 @@ public record PostDetailResponse(
                 post.getId(),
                 post.getTitle(),
                 post.getContent(),
-                post.isRecruitOpen(),
+                post.getStatus(),
+                post.isFull(),
                 post.getDaysUntilRecruitDeadline(),
                 post.getDaysUntilTravelStart(),
                 post.getStartDate(),

--- a/src/main/java/com/dduru/gildongmu/post/dto/response/PostSummaryResponse.java
+++ b/src/main/java/com/dduru/gildongmu/post/dto/response/PostSummaryResponse.java
@@ -1,6 +1,7 @@
 package com.dduru.gildongmu.post.dto.response;
 
 import com.dduru.gildongmu.post.domain.Post;
+import com.dduru.gildongmu.post.domain.enums.PostStatus;
 import com.dduru.gildongmu.profile.domain.enums.Gender;
 import com.dduru.gildongmu.profile.service.ProfileImageResolver;
 import com.dduru.gildongmu.user.dto.UserInfo;
@@ -11,7 +12,8 @@ public record PostSummaryResponse(
         Long id,
         String title,
         String content,
-        boolean isRecruitOpen,
+        PostStatus status,
+        boolean isFull,
         int daysUntilRecruitDeadline,
         int daysUntilTravelStart,
         LocalDate startDate,
@@ -33,7 +35,8 @@ public record PostSummaryResponse(
                 post.getId(),
                 post.getTitle(),
                 post.getContent(),
-                post.isRecruitOpen(),
+                post.getStatus(),
+                post.isFull(),
                 post.getDaysUntilRecruitDeadline(),
                 post.getDaysUntilTravelStart(),
                 post.getStartDate(),

--- a/src/main/resources/db/migration/V7__participation_contacting_and_post_recruit_count.sql
+++ b/src/main/resources/db/migration/V7__participation_contacting_and_post_recruit_count.sql
@@ -1,0 +1,47 @@
+-- ============================================================
+-- 참여신청 흐름 정비
+-- 1) participations 테이블을 Flyway 기준으로 생성/보정
+-- 2) CONTACTING 상태와 contacted_at 컬럼 추가
+-- 3) posts.recruit_count 의미를 '호스트 포함 현재 인원 수'로 정렬
+-- 4) FULL 상태를 제거하고 OPEN/CLOSED만 사용
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS participations (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    post_id BIGINT NOT NULL,
+    user_id BIGINT NOT NULL,
+    status VARCHAR(20) NOT NULL DEFAULT 'PENDING' COMMENT 'PENDING, CONTACTING, APPROVED, REJECTED',
+    message VARCHAR(500) NULL,
+    contacted_at DATETIME(6) NULL,
+    approved_at DATETIME(6) NULL,
+    rejected_at DATETIME(6) NULL,
+    created_at DATETIME(6) NULL,
+    modified_at DATETIME(6) NULL,
+    CONSTRAINT uk_participations_post_user UNIQUE (post_id, user_id),
+    CONSTRAINT fk_participations_post
+        FOREIGN KEY (post_id) REFERENCES posts (id) ON DELETE CASCADE,
+    CONSTRAINT fk_participations_user
+        FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+ALTER TABLE participations
+    MODIFY COLUMN status VARCHAR(20) NOT NULL DEFAULT 'PENDING'
+        COMMENT 'PENDING, CONTACTING, APPROVED, REJECTED';
+
+ALTER TABLE participations
+    ADD COLUMN IF NOT EXISTS contacted_at DATETIME(6) NULL AFTER message;
+
+ALTER TABLE posts
+    MODIFY COLUMN recruit_count INT NOT NULL DEFAULT 1;
+
+UPDATE posts
+SET status = 'OPEN'
+WHERE status = 'FULL';
+
+UPDATE posts p
+SET recruit_count = (
+    SELECT COUNT(*) + 1
+    FROM participations pa
+    WHERE pa.post_id = p.id
+      AND pa.status = 'APPROVED'
+);

--- a/src/test/java/com/dduru/gildongmu/chat/service/ChatRoomServiceTest.java
+++ b/src/test/java/com/dduru/gildongmu/chat/service/ChatRoomServiceTest.java
@@ -96,7 +96,7 @@ class ChatRoomServiceTest {
         ChatRoom savedRoom = roomCaptor.getValue();
         assertThat(savedRoom.getRoomType()).isEqualTo(ChatRoomType.GROUP);
         assertThat(savedRoom.getStatus()).isEqualTo(ChatRoomStatus.PENDING);
-        assertThat(savedRoom.getMaxCapacity()).isEqualTo(4);
+        assertThat(savedRoom.getMaxCapacity()).isEqualTo(3);
 
         ArgumentCaptor<ChatRoomMember> memberCaptor = ArgumentCaptor.forClass(ChatRoomMember.class);
         verify(chatRoomMemberRepository).save(memberCaptor.capture());


### PR DESCRIPTION
## 🔎 작업 내용
* participations에 `contacted_at`, `CONTACTING` 상태 추가
* Post FULL 제거, 모집 마감은 recruit_count 기준 isFull로 판단
* 그룹 채팅방 정원을 모집 인원과 일치하도록 조정

## ➕ 이슈 링크
* Closed #201 

## 🧑‍💻 예정 작업
- #202 

## 📝 체크리스트
- [x] 브랜치 이름은 `feat/개발내용` 형식으로 작성했는가?
- [x] 커밋 메시지는 `feat(scope): 커밋 내용` 형식으로 작성했는가?
- [x] 작업 전 Issue를 작성했는가?
- [x] `dev` 브랜치로 병합을 요청했는가?
- [x] 불필요한 주석과 공백은 제거했는가?
- [x] 코드 리뷰어의 피드백을 반영했는가?
- [x] 테스트를 진행했는가?
- [x] 테스트 코드를 작성했는가? 
