### PR TITLE
chore: 프로필 이미지 응답 형식 변경 

### DIFF
--- a/src/main/java/com/dduru/gildongmu/participation/dto/query/ParticipationRetrieveQueryResult.java
+++ b/src/main/java/com/dduru/gildongmu/participation/dto/query/ParticipationRetrieveQueryResult.java
@@ -12,6 +12,7 @@ public record ParticipationRetrieveQueryResult(
         ProfileImageType profileImageType,
         String uploadedImageUrl,
         String avatarImageUrl,
+        Long bgColorId,
         String message,
         ParticipationStatus status,
         LocalDateTime appliedAt,

--- a/src/main/java/com/dduru/gildongmu/participation/dto/response/ParticipationRetrieveResponse.java
+++ b/src/main/java/com/dduru/gildongmu/participation/dto/response/ParticipationRetrieveResponse.java
@@ -2,6 +2,7 @@ package com.dduru.gildongmu.participation.dto.response;
 
 import com.dduru.gildongmu.participation.domain.enums.ParticipationStatus;
 import com.dduru.gildongmu.participation.dto.query.ParticipationRetrieveQueryResult;
+import com.dduru.gildongmu.profile.dto.response.ProfileImageInfo;
 import com.dduru.gildongmu.profile.service.ProfileImageResolver;
 import io.swagger.v3.oas.annotations.media.Schema;
 
@@ -15,8 +16,8 @@ public record ParticipationRetrieveResponse(
         Long userId,
         @Schema(description = "신청자 이름", example = "여행메이트")
         String userName,
-        @Schema(description = "신청자 프로필 이미지 URL", example = "https://example.com/profile.jpg")
-        String profileImageUrl,
+        @Schema(description = "신청자 프로필 이미지 정보")
+        ProfileImageInfo profileImage,
         @Schema(description = "신청 메시지", example = "안녕하세요. 일정이 비슷해서 신청드립니다.")
         String message,
         @Schema(description = "신청 상태", example = "PENDING", allowableValues = {"PENDING", "CONTACTING", "APPROVED", "REJECTED"})
@@ -42,10 +43,12 @@ public record ParticipationRetrieveResponse(
                 queryResult.participationId(),
                 queryResult.userId(),
                 queryResult.userName(),
-                profileImageResolver.resolve(
+                ProfileImageInfo.from(
                         queryResult.profileImageType(),
                         queryResult.uploadedImageUrl(),
-                        queryResult.avatarImageUrl()
+                        queryResult.avatarImageUrl(),
+                        queryResult.bgColorId(),
+                        profileImageResolver
                 ),
                 queryResult.message(),
                 queryResult.status(),

--- a/src/main/java/com/dduru/gildongmu/participation/dto/response/ParticipationRetrieveResponse.java
+++ b/src/main/java/com/dduru/gildongmu/participation/dto/response/ParticipationRetrieveResponse.java
@@ -3,7 +3,7 @@ package com.dduru.gildongmu.participation.dto.response;
 import com.dduru.gildongmu.participation.domain.enums.ParticipationStatus;
 import com.dduru.gildongmu.participation.dto.query.ParticipationRetrieveQueryResult;
 import com.dduru.gildongmu.profile.dto.response.ProfileImageInfo;
-import com.dduru.gildongmu.profile.service.ProfileImageResolver;
+import com.dduru.gildongmu.profile.utils.ProfileImageResolver;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;

--- a/src/main/java/com/dduru/gildongmu/participation/repository/ParticipationRepositoryImpl.java
+++ b/src/main/java/com/dduru/gildongmu/participation/repository/ParticipationRepositoryImpl.java
@@ -12,6 +12,7 @@ import java.util.List;
 
 import static com.dduru.gildongmu.participation.domain.QParticipation.participation;
 import static com.dduru.gildongmu.post.domain.QPost.post;
+import static com.dduru.gildongmu.profile.domain.QBgColor.bgColor;
 import static com.dduru.gildongmu.profile.domain.QProfile.profile;
 import static com.dduru.gildongmu.survey.domain.QAvatarProfile.avatarProfile;
 import static com.dduru.gildongmu.user.domain.QUser.user;
@@ -36,6 +37,7 @@ public class ParticipationRepositoryImpl implements ParticipationRepositoryCusto
                         profile.profileImageType,
                         profile.uploadedImageUrl,
                         avatarProfile.imageUrl,
+                        bgColor.id,
                         participation.message,
                         participation.status,
                         participation.createdAt,
@@ -51,6 +53,7 @@ public class ParticipationRepositoryImpl implements ParticipationRepositoryCusto
                 // nullable 연관을 타면 implicit join이 inner join처럼 동작해서 avatar가 없는 유저가 결과에서 빠질 수 있어서 명시적으로 left join으로 profile 가져옴.
                 .leftJoin(user.profile, profile)
                 .leftJoin(profile.avatar, avatarProfile)
+                .leftJoin(profile.bgColor, bgColor)
                 .where(
                         post.user.id.eq(postOwnerId),
                         post.isDeleted.isFalse(),

--- a/src/main/java/com/dduru/gildongmu/participation/service/ParticipationApplicantService.java
+++ b/src/main/java/com/dduru/gildongmu/participation/service/ParticipationApplicantService.java
@@ -18,7 +18,7 @@ import com.dduru.gildongmu.post.domain.Post;
 import com.dduru.gildongmu.post.dto.response.MyParticipationStatus;
 import com.dduru.gildongmu.post.dto.response.ParticipantInfo;
 import com.dduru.gildongmu.post.repository.PostRepository;
-import com.dduru.gildongmu.profile.service.ProfileImageResolver;
+import com.dduru.gildongmu.profile.utils.ProfileImageResolver;
 import com.dduru.gildongmu.user.domain.User;
 import com.dduru.gildongmu.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/dduru/gildongmu/participation/service/ParticipationCommandService.java
+++ b/src/main/java/com/dduru/gildongmu/participation/service/ParticipationCommandService.java
@@ -13,7 +13,7 @@ import com.dduru.gildongmu.participation.repository.ParticipationRepository;
 import com.dduru.gildongmu.post.domain.Post;
 import com.dduru.gildongmu.post.exception.PostAccessDeniedException;
 import com.dduru.gildongmu.post.repository.PostRepository;
-import com.dduru.gildongmu.profile.service.ProfileImageResolver;
+import com.dduru.gildongmu.profile.utils.ProfileImageResolver;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;

--- a/src/main/java/com/dduru/gildongmu/post/dto/response/ParticipantInfo.java
+++ b/src/main/java/com/dduru/gildongmu/post/dto/response/ParticipantInfo.java
@@ -1,29 +1,24 @@
 package com.dduru.gildongmu.post.dto.response;
 
 import com.dduru.gildongmu.profile.domain.Profile;
-import com.dduru.gildongmu.profile.domain.enums.ProfileImageType;
+import com.dduru.gildongmu.profile.dto.response.ProfileImageInfo;
 import com.dduru.gildongmu.profile.service.ProfileImageResolver;
-import com.dduru.gildongmu.survey.domain.enums.AvatarType;
 import com.dduru.gildongmu.user.domain.User;
 
 public record ParticipantInfo(
         Long userId,
         String nickname,
-        ProfileImageType profileImageType,
-        String profileImage,
-        AvatarType avatarType,
-        String bgColorHex,
+        ProfileImageInfo profileImage,
         boolean isHost
 ) {
     public static ParticipantInfo from(User user, boolean isHost, ProfileImageResolver profileImageResolver) {
         Profile profile = user.getProfile();
+        ProfileImageInfo profileImage = ProfileImageInfo.from(profile, profileImageResolver);
+
         return new ParticipantInfo(
                 user.getId(),
                 profile.getNickname(),
-                profile.getProfileImageType(),
-                profileImageResolver.resolve(profile),
-                profile.getAvatar() != null ? profile.getAvatar().getAvatarType() : null,
-                profile.getBgColor() != null ? profile.getBgColor().getHexCode() : null,
+                profileImage,
                 isHost
         );
     }

--- a/src/main/java/com/dduru/gildongmu/post/dto/response/ParticipantInfo.java
+++ b/src/main/java/com/dduru/gildongmu/post/dto/response/ParticipantInfo.java
@@ -2,7 +2,7 @@ package com.dduru.gildongmu.post.dto.response;
 
 import com.dduru.gildongmu.profile.domain.Profile;
 import com.dduru.gildongmu.profile.dto.response.ProfileImageInfo;
-import com.dduru.gildongmu.profile.service.ProfileImageResolver;
+import com.dduru.gildongmu.profile.utils.ProfileImageResolver;
 import com.dduru.gildongmu.user.domain.User;
 
 public record ParticipantInfo(

--- a/src/main/java/com/dduru/gildongmu/post/dto/response/PostDetailResponse.java
+++ b/src/main/java/com/dduru/gildongmu/post/dto/response/PostDetailResponse.java
@@ -4,7 +4,7 @@ import com.dduru.gildongmu.common.util.JsonConverter;
 import com.dduru.gildongmu.post.domain.Post;
 import com.dduru.gildongmu.post.domain.enums.PostStatus;
 import com.dduru.gildongmu.profile.domain.enums.Gender;
-import com.dduru.gildongmu.profile.service.ProfileImageResolver;
+import com.dduru.gildongmu.profile.utils.ProfileImageResolver;
 import com.dduru.gildongmu.user.dto.UserInfo;
 
 import java.time.LocalDate;

--- a/src/main/java/com/dduru/gildongmu/post/dto/response/PostSummaryResponse.java
+++ b/src/main/java/com/dduru/gildongmu/post/dto/response/PostSummaryResponse.java
@@ -3,7 +3,7 @@ package com.dduru.gildongmu.post.dto.response;
 import com.dduru.gildongmu.post.domain.Post;
 import com.dduru.gildongmu.post.domain.enums.PostStatus;
 import com.dduru.gildongmu.profile.domain.enums.Gender;
-import com.dduru.gildongmu.profile.service.ProfileImageResolver;
+import com.dduru.gildongmu.profile.utils.ProfileImageResolver;
 import com.dduru.gildongmu.user.dto.UserInfo;
 
 import java.time.LocalDate;

--- a/src/main/java/com/dduru/gildongmu/post/service/PostQueryService.java
+++ b/src/main/java/com/dduru/gildongmu/post/service/PostQueryService.java
@@ -5,7 +5,7 @@ import com.dduru.gildongmu.post.dto.request.PostListRequest;
 import com.dduru.gildongmu.post.dto.response.PostListResponse;
 import com.dduru.gildongmu.post.dto.response.PostSummaryResponse;
 import com.dduru.gildongmu.post.repository.PostRepository;
-import com.dduru.gildongmu.profile.service.ProfileImageResolver;
+import com.dduru.gildongmu.profile.utils.ProfileImageResolver;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;

--- a/src/main/java/com/dduru/gildongmu/post/service/PostService.java
+++ b/src/main/java/com/dduru/gildongmu/post/service/PostService.java
@@ -20,7 +20,7 @@ import com.dduru.gildongmu.post.exception.InvalidPostStatusException;
 import com.dduru.gildongmu.post.exception.InvalidPreferredAgeException;
 import com.dduru.gildongmu.post.exception.PostAccessDeniedException;
 import com.dduru.gildongmu.post.repository.PostRepository;
-import com.dduru.gildongmu.profile.service.ProfileImageResolver;
+import com.dduru.gildongmu.profile.utils.ProfileImageResolver;
 import com.dduru.gildongmu.tag.service.TagValidator;
 import com.dduru.gildongmu.user.domain.User;
 import com.dduru.gildongmu.user.repository.UserRepository;

--- a/src/main/java/com/dduru/gildongmu/profile/domain/BgColor.java
+++ b/src/main/java/com/dduru/gildongmu/profile/domain/BgColor.java
@@ -17,7 +17,7 @@ public class BgColor extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "hex_code", nullable = false, length = 7)
+    @Column(name = "hex_code", length = 10)
     private String hexCode;
 
     @Column(name = "display_order", nullable = false)

--- a/src/main/java/com/dduru/gildongmu/profile/dto/response/ProfileImageInfo.java
+++ b/src/main/java/com/dduru/gildongmu/profile/dto/response/ProfileImageInfo.java
@@ -1,0 +1,47 @@
+package com.dduru.gildongmu.profile.dto.response;
+
+import com.dduru.gildongmu.profile.domain.Profile;
+import com.dduru.gildongmu.profile.domain.enums.ProfileImageType;
+import com.dduru.gildongmu.profile.service.ProfileImageResolver;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "프로필 이미지 표시 정보")
+public record ProfileImageInfo(
+        ProfileImageType type,
+        String url,
+        Long bgColorId
+) {
+
+    public static ProfileImageInfo from(Profile profile, ProfileImageResolver profileImageResolver) {
+        if (profile == null) {
+            return null;
+        }
+
+        return new ProfileImageInfo(
+                profile.getProfileImageType(),
+                profileImageResolver.resolve(profile),
+                resolveBgColorId(
+                        profile.getProfileImageType(),
+                        profile.getBgColor() != null ? profile.getBgColor().getId() : null
+                )
+        );
+    }
+
+    public static ProfileImageInfo from(
+            ProfileImageType profileImageType,
+            String uploadedImageUrl,
+            String avatarImageUrl,
+            Long bgColorId,
+            ProfileImageResolver profileImageResolver
+    ) {
+        return new ProfileImageInfo(
+                profileImageType,
+                profileImageResolver.resolve(profileImageType, uploadedImageUrl, avatarImageUrl),
+                resolveBgColorId(profileImageType, bgColorId)
+        );
+    }
+
+    private static Long resolveBgColorId(ProfileImageType profileImageType, Long bgColorId) {
+        return profileImageType == ProfileImageType.AVATAR ? bgColorId : null;
+    }
+}

--- a/src/main/java/com/dduru/gildongmu/profile/dto/response/ProfileImageInfo.java
+++ b/src/main/java/com/dduru/gildongmu/profile/dto/response/ProfileImageInfo.java
@@ -2,7 +2,7 @@ package com.dduru.gildongmu.profile.dto.response;
 
 import com.dduru.gildongmu.profile.domain.Profile;
 import com.dduru.gildongmu.profile.domain.enums.ProfileImageType;
-import com.dduru.gildongmu.profile.service.ProfileImageResolver;
+import com.dduru.gildongmu.profile.utils.ProfileImageResolver;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "프로필 이미지 표시 정보")

--- a/src/main/java/com/dduru/gildongmu/profile/service/ProfileImageResolver.java
+++ b/src/main/java/com/dduru/gildongmu/profile/service/ProfileImageResolver.java
@@ -16,22 +16,26 @@ public class ProfileImageResolver {
             return null;
         }
 
-        return switch (profile.getProfileImageType()) {
-            case DEFAULT -> defaultProfileImageUrl;
-            case UPLOADED -> profile.getUploadedImageUrl();
-            case AVATAR -> profile.getAvatar().getImageUrl();
-        };
+        return resolve(
+                profile.getProfileImageType(),
+                profile.getUploadedImageUrl(),
+                profile.getAvatar() != null ? profile.getAvatar().getImageUrl() : null
+        );
     }
 
     public String resolve(ProfileImageType profileImageType, String uploadedImageUrl, String avatarImageUrl) {
         if (profileImageType == null) {
-            return null;
+            return defaultProfileImageUrl;
         }
 
         return switch (profileImageType) {
             case DEFAULT -> defaultProfileImageUrl;
-            case UPLOADED -> uploadedImageUrl;
-            case AVATAR -> avatarImageUrl;
+            case UPLOADED -> hasText(uploadedImageUrl) ? uploadedImageUrl : defaultProfileImageUrl;
+            case AVATAR -> hasText(avatarImageUrl) ? avatarImageUrl : defaultProfileImageUrl;
         };
+    }
+
+    private boolean hasText(String value) {
+        return value != null && !value.isBlank();
     }
 }

--- a/src/main/java/com/dduru/gildongmu/profile/utils/ProfileImageResolver.java
+++ b/src/main/java/com/dduru/gildongmu/profile/utils/ProfileImageResolver.java
@@ -1,4 +1,4 @@
-package com.dduru.gildongmu.profile.service;
+package com.dduru.gildongmu.profile.utils;
 
 import com.dduru.gildongmu.profile.domain.Profile;
 import com.dduru.gildongmu.profile.domain.enums.ProfileImageType;

--- a/src/main/java/com/dduru/gildongmu/profile/utils/ProfileImageResolver.java
+++ b/src/main/java/com/dduru/gildongmu/profile/utils/ProfileImageResolver.java
@@ -12,7 +12,7 @@ public class ProfileImageResolver {
     private String defaultProfileImageUrl;
 
     public String resolve(Profile profile) {
-        if (profile == null || profile.getProfileImageType() == null) {
+        if (profile == null) {
             return null;
         }
 

--- a/src/main/java/com/dduru/gildongmu/user/dto/UserInfo.java
+++ b/src/main/java/com/dduru/gildongmu/user/dto/UserInfo.java
@@ -2,9 +2,8 @@ package com.dduru.gildongmu.user.dto;
 
 import com.dduru.gildongmu.profile.domain.Profile;
 import com.dduru.gildongmu.profile.domain.enums.Gender;
-import com.dduru.gildongmu.profile.domain.enums.ProfileImageType;
+import com.dduru.gildongmu.profile.dto.response.ProfileImageInfo;
 import com.dduru.gildongmu.profile.service.ProfileImageResolver;
-import com.dduru.gildongmu.survey.domain.enums.AvatarType;
 import com.dduru.gildongmu.user.domain.User;
 
 import java.time.LocalDate;
@@ -12,42 +11,19 @@ import java.time.LocalDate;
 public record UserInfo(
         Long id,
         String name,
-        ProfileImageType profileImageType,
-        String profileImage,
-        AvatarType avatarType,
-        Long bgColorId,
-        String bgColorHex,
+        ProfileImageInfo profileImage,
         Gender gender,
         LocalDate birthday,
         String nickname
 ) {
     public static UserInfo from(User user, ProfileImageResolver profileImageResolver) {
         Profile profile = user.getProfile();
-        ProfileImageType imageType = profile.getProfileImageType();
-
-        String profileImage = profileImageResolver.resolve(profile);
-        AvatarType avatarType = null;
-        Long bgColorId = null;
-        String bgColorHex = null;
-
-        if (imageType == ProfileImageType.AVATAR) {
-            avatarType = profile.getAvatar() != null
-                    ? profile.getAvatar().getAvatarType()
-                    : null;
-            if (profile.getBgColor() != null) {
-                bgColorId = profile.getBgColor().getId();
-                bgColorHex = profile.getBgColor().getHexCode();
-            }
-        }
+        ProfileImageInfo profileImage = ProfileImageInfo.from(profile, profileImageResolver);
 
         return new UserInfo(
                 user.getId(),
                 user.getName(),
-                imageType,
                 profileImage,
-                avatarType,
-                bgColorId,
-                bgColorHex,
                 profile.getGender(),
                 profile.getBirthday(),
                 profile.getNickname()

--- a/src/main/java/com/dduru/gildongmu/user/dto/UserInfo.java
+++ b/src/main/java/com/dduru/gildongmu/user/dto/UserInfo.java
@@ -3,7 +3,7 @@ package com.dduru.gildongmu.user.dto;
 import com.dduru.gildongmu.profile.domain.Profile;
 import com.dduru.gildongmu.profile.domain.enums.Gender;
 import com.dduru.gildongmu.profile.dto.response.ProfileImageInfo;
-import com.dduru.gildongmu.profile.service.ProfileImageResolver;
+import com.dduru.gildongmu.profile.utils.ProfileImageResolver;
 import com.dduru.gildongmu.user.domain.User;
 
 import java.time.LocalDate;

--- a/src/main/resources/db/migration/V11_update_background_color.sql
+++ b/src/main/resources/db/migration/V11_update_background_color.sql
@@ -1,0 +1,31 @@
+-- 2026/04/14 (화)
+-- 배경색(hex_code) 컬럼의 데이터 타입을 VARCHAR(10)으로 변경, nullable로 변경
+-- 클라 측에서 bg_colors를 관리하고 있기 때문에 백엔드에서는 id 존재 여부만 확인하는 측이 낫다고 판단함. 하지만 우선은 hex code값 넣어두기
+ALTER TABLE bg_colors
+    MODIFY COLUMN hex_code VARCHAR(10) NULL;
+
+-- 기존에 있던 id 16 ~ 24는 삭제 완료 (운영서버에서는 이미 삭제되어 있음)
+-- DELETE FROM bg_colors
+-- WHERE id BETWEEN 16 AND 24;
+
+UPDATE bg_colors
+SET
+    hex_code = CASE id
+                   WHEN 1 THEN '0xFFF4B3BE'
+                   WHEN 2 THEN '0xFFFCE29F'
+                   WHEN 3 THEN '0xFFD8E6A8'
+                   WHEN 4 THEN '0xFFCDF5FF'
+                   WHEN 5 THEN '0xFFFAF8F4'
+                   WHEN 6 THEN '0xFFF3CAD8'
+                   WHEN 7 THEN '0xFFF8D495'
+                   WHEN 8 THEN '0xFFC2DCAF'
+                   WHEN 9 THEN '0xFFCDE8FF'
+                   WHEN 10 THEN '0xFFDEDEDE'
+                   WHEN 11 THEN '0xFFDCCDFC'
+                   WHEN 12 THEN '0xFFF2C49B'
+                   WHEN 13 THEN '0xFF9BC289'
+                   WHEN 14 THEN '0xFFB8CCFF'
+                   WHEN 15 THEN '0xFFB2B2B2'
+        END,
+    modified_at = NOW(6)
+WHERE id BETWEEN 1 AND 15;

--- a/src/test/java/com/dduru/gildongmu/participation/dto/response/ParticipationRetrieveResponseTest.java
+++ b/src/test/java/com/dduru/gildongmu/participation/dto/response/ParticipationRetrieveResponseTest.java
@@ -3,7 +3,7 @@ package com.dduru.gildongmu.participation.dto.response;
 import com.dduru.gildongmu.participation.domain.enums.ParticipationStatus;
 import com.dduru.gildongmu.participation.dto.query.ParticipationRetrieveQueryResult;
 import com.dduru.gildongmu.profile.domain.enums.ProfileImageType;
-import com.dduru.gildongmu.profile.service.ProfileImageResolver;
+import com.dduru.gildongmu.profile.utils.ProfileImageResolver;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/com/dduru/gildongmu/participation/dto/response/ParticipationRetrieveResponseTest.java
+++ b/src/test/java/com/dduru/gildongmu/participation/dto/response/ParticipationRetrieveResponseTest.java
@@ -1,0 +1,80 @@
+package com.dduru.gildongmu.participation.dto.response;
+
+import com.dduru.gildongmu.participation.domain.enums.ParticipationStatus;
+import com.dduru.gildongmu.participation.dto.query.ParticipationRetrieveQueryResult;
+import com.dduru.gildongmu.profile.domain.enums.ProfileImageType;
+import com.dduru.gildongmu.profile.service.ProfileImageResolver;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@DisplayName("ParticipationRetrieveResponse 테스트")
+class ParticipationRetrieveResponseTest {
+
+    @Test
+    @DisplayName("AVATAR 타입이면 bgColorId를 함께 응답한다")
+    void from_avatarType_includesBgColor() {
+        ParticipationRetrieveQueryResult queryResult = new ParticipationRetrieveQueryResult(
+                1L,
+                2L,
+                "신청자",
+                ProfileImageType.AVATAR,
+                null,
+                "https://example.com/avatar.png",
+                5L,
+                "안녕하세요",
+                ParticipationStatus.PENDING,
+                LocalDateTime.of(2026, 4, 14, 10, 0),
+                null,
+                null,
+                null,
+                10L,
+                "제주도 같이 가실 분"
+        );
+        ProfileImageResolver profileImageResolver = mock(ProfileImageResolver.class);
+        when(profileImageResolver.resolve(ProfileImageType.AVATAR, null, "https://example.com/avatar.png"))
+                .thenReturn("https://example.com/avatar.png");
+
+        ParticipationRetrieveResponse response = ParticipationRetrieveResponse.from(queryResult, profileImageResolver);
+
+        assertThat(response.profileImage().type()).isEqualTo(ProfileImageType.AVATAR);
+        assertThat(response.profileImage().url()).isEqualTo("https://example.com/avatar.png");
+        assertThat(response.profileImage().bgColorId()).isEqualTo(5L);
+    }
+
+    @Test
+    @DisplayName("AVATAR 타입이 아니면 남아 있는 bgColor 값이 있어도 응답에는 노출하지 않는다")
+    void from_nonAvatarType_hidesBgColor() {
+        ParticipationRetrieveQueryResult queryResult = new ParticipationRetrieveQueryResult(
+                1L,
+                2L,
+                "신청자",
+                ProfileImageType.DEFAULT,
+                null,
+                "https://example.com/avatar.png",
+                5L,
+                "안녕하세요",
+                ParticipationStatus.PENDING,
+                LocalDateTime.of(2026, 4, 14, 10, 0),
+                null,
+                null,
+                null,
+                10L,
+                "제주도 같이 가실 분"
+        );
+        ProfileImageResolver profileImageResolver = mock(ProfileImageResolver.class);
+        when(profileImageResolver.resolve(ProfileImageType.DEFAULT, null, "https://example.com/avatar.png"))
+                .thenReturn("https://example.com/default.png");
+
+        ParticipationRetrieveResponse response = ParticipationRetrieveResponse.from(queryResult, profileImageResolver);
+
+        assertThat(response.profileImage().type()).isEqualTo(ProfileImageType.DEFAULT);
+        assertThat(response.profileImage().url()).isEqualTo("https://example.com/default.png");
+        assertThat(response.profileImage().bgColorId()).isNull();
+    }
+}

--- a/src/test/java/com/dduru/gildongmu/participation/service/ParticipationCommandServiceTest.java
+++ b/src/test/java/com/dduru/gildongmu/participation/service/ParticipationCommandServiceTest.java
@@ -11,7 +11,7 @@ import com.dduru.gildongmu.participation.dto.response.ParticipationContactRespon
 import com.dduru.gildongmu.participation.repository.ParticipationRepository;
 import com.dduru.gildongmu.post.domain.Post;
 import com.dduru.gildongmu.post.repository.PostRepository;
-import com.dduru.gildongmu.profile.service.ProfileImageResolver;
+import com.dduru.gildongmu.profile.utils.ProfileImageResolver;
 import com.dduru.gildongmu.user.domain.User;
 import com.dduru.gildongmu.user.domain.enums.OauthType;
 import org.junit.jupiter.api.DisplayName;

--- a/src/test/java/com/dduru/gildongmu/post/dto/response/ParticipantInfoTest.java
+++ b/src/test/java/com/dduru/gildongmu/post/dto/response/ParticipantInfoTest.java
@@ -3,7 +3,7 @@ package com.dduru.gildongmu.post.dto.response;
 import com.dduru.gildongmu.profile.domain.BgColor;
 import com.dduru.gildongmu.profile.domain.Profile;
 import com.dduru.gildongmu.profile.domain.enums.ProfileImageType;
-import com.dduru.gildongmu.profile.service.ProfileImageResolver;
+import com.dduru.gildongmu.profile.utils.ProfileImageResolver;
 import com.dduru.gildongmu.survey.domain.AvatarProfile;
 import com.dduru.gildongmu.survey.domain.enums.AvatarType;
 import com.dduru.gildongmu.user.domain.User;

--- a/src/test/java/com/dduru/gildongmu/post/dto/response/ParticipantInfoTest.java
+++ b/src/test/java/com/dduru/gildongmu/post/dto/response/ParticipantInfoTest.java
@@ -1,8 +1,11 @@
 package com.dduru.gildongmu.post.dto.response;
 
+import com.dduru.gildongmu.profile.domain.BgColor;
 import com.dduru.gildongmu.profile.domain.Profile;
 import com.dduru.gildongmu.profile.domain.enums.ProfileImageType;
 import com.dduru.gildongmu.profile.service.ProfileImageResolver;
+import com.dduru.gildongmu.survey.domain.AvatarProfile;
+import com.dduru.gildongmu.survey.domain.enums.AvatarType;
 import com.dduru.gildongmu.user.domain.User;
 import com.dduru.gildongmu.user.domain.enums.OauthType;
 import org.junit.jupiter.api.DisplayName;
@@ -22,6 +25,24 @@ class ParticipantInfoTest {
     void from_defaultType_usesResolvedDefaultImageUrl() {
         User user = createUser("default@example.com", "기본유저", "oauth-default", OauthType.KAKAO);
         Profile profile = new Profile(user);
+
+        AvatarProfile avatarProfile = AvatarProfile.builder()
+                .avatarType(AvatarType.TTUR_DASOM)
+                .displayName("다솜")
+                .speechBubbleText("설명")
+                .descriptionLine1("성격")
+                .descriptionLine2("강점")
+                .descriptionLine3("팁")
+                .imageUrl("https://example.com/avatar.png")
+                .tags("[]")
+                .build();
+        BgColor bgColor = BgColor.builder()
+                .hexCode("#F5E6C8")
+                .displayOrder(1)
+                .build();
+        ReflectionTestUtils.setField(bgColor, "id", 7L);
+        profile.updateAvatar(avatarProfile);
+        ReflectionTestUtils.setField(profile, "bgColor", bgColor);
         profile.updateProfile("기본닉", null, ProfileImageType.DEFAULT, null, "소개");
         ReflectionTestUtils.setField(user, "profile", profile);
 
@@ -30,8 +51,9 @@ class ParticipantInfoTest {
 
         ParticipantInfo participantInfo = ParticipantInfo.from(user, true, profileImageResolver);
 
-        assertThat(participantInfo.profileImageType()).isEqualTo(ProfileImageType.DEFAULT);
-        assertThat(participantInfo.profileImage()).isEqualTo("https://example.com/default.png");
+        assertThat(participantInfo.profileImage().type()).isEqualTo(ProfileImageType.DEFAULT);
+        assertThat(participantInfo.profileImage().url()).isEqualTo("https://example.com/default.png");
+        assertThat(participantInfo.profileImage().bgColorId()).isNull();
         assertThat(participantInfo.isHost()).isTrue();
         verify(profileImageResolver).resolve(profile);
     }
@@ -41,7 +63,24 @@ class ParticipantInfoTest {
     void from_avatarType_usesResolvedAvatarImageUrl() {
         User user = createUser("avatar@example.com", "아바타유저", "oauth-avatar", OauthType.GOOGLE);
         Profile profile = new Profile(user);
-        profile.updateProfile("아바타닉", null, ProfileImageType.AVATAR, null, "소개");
+
+        AvatarProfile avatarProfile = AvatarProfile.builder()
+                .avatarType(AvatarType.TTUR_DASOM)
+                .displayName("다솜")
+                .speechBubbleText("설명")
+                .descriptionLine1("성격")
+                .descriptionLine2("강점")
+                .descriptionLine3("팁")
+                .imageUrl("https://example.com/avatar.png")
+                .tags("[]")
+                .build();
+        BgColor bgColor = BgColor.builder()
+                .hexCode("#F5E6C8")
+                .displayOrder(1)
+                .build();
+        ReflectionTestUtils.setField(bgColor, "id", 3L);
+        profile.updateAvatar(avatarProfile);
+        profile.updateProfile("아바타닉", null, ProfileImageType.AVATAR, bgColor, "소개");
         ReflectionTestUtils.setField(user, "profile", profile);
 
         ProfileImageResolver profileImageResolver = mock(ProfileImageResolver.class);
@@ -49,8 +88,9 @@ class ParticipantInfoTest {
 
         ParticipantInfo participantInfo = ParticipantInfo.from(user, false, profileImageResolver);
 
-        assertThat(participantInfo.profileImageType()).isEqualTo(ProfileImageType.AVATAR);
-        assertThat(participantInfo.profileImage()).isEqualTo("https://example.com/avatar.png");
+        assertThat(participantInfo.profileImage().type()).isEqualTo(ProfileImageType.AVATAR);
+        assertThat(participantInfo.profileImage().url()).isEqualTo("https://example.com/avatar.png");
+        assertThat(participantInfo.profileImage().bgColorId()).isEqualTo(3L);
         assertThat(participantInfo.isHost()).isFalse();
         verify(profileImageResolver).resolve(profile);
     }

--- a/src/test/java/com/dduru/gildongmu/post/service/PostServiceTest.java
+++ b/src/test/java/com/dduru/gildongmu/post/service/PostServiceTest.java
@@ -16,7 +16,7 @@ import com.dduru.gildongmu.post.exception.InvalidPreferredAgeException;
 import com.dduru.gildongmu.post.exception.PostAccessDeniedException;
 import com.dduru.gildongmu.post.repository.PostRepository;
 import com.dduru.gildongmu.profile.domain.enums.Gender;
-import com.dduru.gildongmu.profile.service.ProfileImageResolver;
+import com.dduru.gildongmu.profile.utils.ProfileImageResolver;
 import com.dduru.gildongmu.user.domain.User;
 import com.dduru.gildongmu.user.domain.enums.OauthType;
 import com.dduru.gildongmu.user.repository.UserRepository;

--- a/src/test/java/com/dduru/gildongmu/profile/dto/response/ProfileImageInfoTest.java
+++ b/src/test/java/com/dduru/gildongmu/profile/dto/response/ProfileImageInfoTest.java
@@ -2,7 +2,7 @@ package com.dduru.gildongmu.profile.dto.response;
 
 import com.dduru.gildongmu.profile.domain.Profile;
 import com.dduru.gildongmu.profile.domain.enums.ProfileImageType;
-import com.dduru.gildongmu.profile.service.ProfileImageResolver;
+import com.dduru.gildongmu.profile.utils.ProfileImageResolver;
 import com.dduru.gildongmu.user.domain.User;
 import com.dduru.gildongmu.user.domain.enums.OauthType;
 import org.junit.jupiter.api.DisplayName;

--- a/src/test/java/com/dduru/gildongmu/profile/dto/response/ProfileImageInfoTest.java
+++ b/src/test/java/com/dduru/gildongmu/profile/dto/response/ProfileImageInfoTest.java
@@ -1,0 +1,57 @@
+package com.dduru.gildongmu.profile.dto.response;
+
+import com.dduru.gildongmu.profile.domain.Profile;
+import com.dduru.gildongmu.profile.domain.enums.ProfileImageType;
+import com.dduru.gildongmu.profile.service.ProfileImageResolver;
+import com.dduru.gildongmu.user.domain.User;
+import com.dduru.gildongmu.user.domain.enums.OauthType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("ProfileImageInfo 테스트")
+class ProfileImageInfoTest {
+
+    @Test
+    @DisplayName("AVATAR 타입이 아니면 bgColorId를 노출하지 않는다")
+    void from_nonAvatarType_hidesBgColorId() {
+        ProfileImageResolver resolver = new ProfileImageResolver();
+        ReflectionTestUtils.setField(resolver, "defaultProfileImageUrl", "https://example.com/default.png");
+
+        ProfileImageInfo profileImageInfo = ProfileImageInfo.from(
+                ProfileImageType.DEFAULT,
+                null,
+                "https://example.com/avatar.png",
+                3L,
+                resolver
+        );
+
+        assertThat(profileImageInfo.type()).isEqualTo(ProfileImageType.DEFAULT);
+        assertThat(profileImageInfo.url()).isEqualTo("https://example.com/default.png");
+        assertThat(profileImageInfo.bgColorId()).isNull();
+    }
+
+    @Test
+    @DisplayName("Profile 엔티티에서 프로필 이미지 정보를 조립한다")
+    void from_profile_buildsProfileImageInfo() {
+        ProfileImageResolver resolver = new ProfileImageResolver();
+        ReflectionTestUtils.setField(resolver, "defaultProfileImageUrl", "https://example.com/default.png");
+
+        User user = User.builder()
+                .email("test@example.com")
+                .name("테스터")
+                .oauthId("oauth-1")
+                .oauthType(OauthType.KAKAO)
+                .build();
+        Profile profile = new Profile(user);
+        profile.updateProfile("테스트닉", "https://example.com/uploaded.png", ProfileImageType.UPLOADED, null, "소개");
+
+        ProfileImageInfo profileImageInfo = ProfileImageInfo.from(profile, resolver);
+
+        assertThat(profileImageInfo.type()).isEqualTo(ProfileImageType.UPLOADED);
+        assertThat(profileImageInfo.url()).isEqualTo("https://example.com/uploaded.png");
+        assertThat(profileImageInfo.bgColorId()).isNull();
+    }
+}

--- a/src/test/java/com/dduru/gildongmu/profile/service/ProfileImageResolverTest.java
+++ b/src/test/java/com/dduru/gildongmu/profile/service/ProfileImageResolverTest.java
@@ -49,4 +49,67 @@ class ProfileImageResolverTest {
         // then
         assertThat(resolved).isEqualTo("https://example.com/avatar-sweet.png");
     }
+
+    @Test
+    @DisplayName("AVATAR 타입인데 매핑된 아바타가 없으면 기본 이미지를 반환한다")
+    void resolve_avatarTypeWithoutAvatar_returnsDefaultImageUrl() {
+        ProfileImageResolver resolver = new ProfileImageResolver();
+        ReflectionTestUtils.setField(resolver, "defaultProfileImageUrl", "https://example.com/default-profile.png");
+
+        User user = User.builder()
+                .email("test@example.com")
+                .name("테스터")
+                .oauthId("oauth-1")
+                .oauthType(OauthType.KAKAO)
+                .build();
+        Profile profile = new Profile(user);
+        profile.updateProfile("테스트닉", null, ProfileImageType.AVATAR, null, "소개");
+
+        String resolved = resolver.resolve(profile);
+
+        assertThat(resolved).isEqualTo("https://example.com/default-profile.png");
+    }
+
+    @Test
+    @DisplayName("UPLOADED 타입인데 업로드 URL이 없으면 기본 이미지를 반환한다")
+    void resolve_uploadedTypeWithoutUploadedUrl_returnsDefaultImageUrl() {
+        ProfileImageResolver resolver = new ProfileImageResolver();
+        ReflectionTestUtils.setField(resolver, "defaultProfileImageUrl", "https://example.com/default-profile.png");
+
+        User user = User.builder()
+                .email("test@example.com")
+                .name("테스터")
+                .oauthId("oauth-1")
+                .oauthType(OauthType.KAKAO)
+                .build();
+        Profile profile = new Profile(user);
+        profile.updateProfile("테스트닉", "https://example.com/uploaded.png", ProfileImageType.UPLOADED, null, "소개");
+        ReflectionTestUtils.setField(profile, "uploadedImageUrl", null);
+
+        String resolved = resolver.resolve(profile);
+
+        assertThat(resolved).isEqualTo("https://example.com/default-profile.png");
+    }
+
+    @Test
+    @DisplayName("쿼리 기반 resolve에서도 AVATAR 이미지가 없으면 기본 이미지를 반환한다")
+    void resolve_queryAvatarWithoutImageUrl_returnsDefaultImageUrl() {
+        ProfileImageResolver resolver = new ProfileImageResolver();
+        ReflectionTestUtils.setField(resolver, "defaultProfileImageUrl", "https://example.com/default-profile.png");
+
+        String resolved = resolver.resolve(ProfileImageType.AVATAR, null, null);
+
+        assertThat(resolved).isEqualTo("https://example.com/default-profile.png");
+    }
+
+    @Test
+    @DisplayName("쿼리 기반 resolve에서도 UPLOADED URL이 없으면 기본 이미지를 반환한다")
+    void resolve_queryUploadedWithoutImageUrl_returnsDefaultImageUrl() {
+        ProfileImageResolver resolver = new ProfileImageResolver();
+        ReflectionTestUtils.setField(resolver, "defaultProfileImageUrl", "https://example.com/default-profile.png");
+
+        String resolved = resolver.resolve(ProfileImageType.UPLOADED, null, null);
+
+        assertThat(resolved).isEqualTo("https://example.com/default-profile.png");
+    }
 }

--- a/src/test/java/com/dduru/gildongmu/profile/service/ProfileImageResolverTest.java
+++ b/src/test/java/com/dduru/gildongmu/profile/service/ProfileImageResolverTest.java
@@ -2,6 +2,7 @@ package com.dduru.gildongmu.profile.service;
 
 import com.dduru.gildongmu.profile.domain.Profile;
 import com.dduru.gildongmu.profile.domain.enums.ProfileImageType;
+import com.dduru.gildongmu.profile.utils.ProfileImageResolver;
 import com.dduru.gildongmu.survey.domain.AvatarProfile;
 import com.dduru.gildongmu.survey.domain.enums.AvatarType;
 import com.dduru.gildongmu.user.domain.User;

--- a/src/test/java/com/dduru/gildongmu/profile/service/ProfileImageResolverTest.java
+++ b/src/test/java/com/dduru/gildongmu/profile/service/ProfileImageResolverTest.java
@@ -93,6 +93,25 @@ class ProfileImageResolverTest {
     }
 
     @Test
+    @DisplayName("ProfileImageType이 null이면 기본 이미지를 반환한다")
+    void resolve_nullProfileImageType_returnsDefaultImageUrl() {
+        ProfileImageResolver resolver = new ProfileImageResolver();
+        ReflectionTestUtils.setField(resolver, "defaultProfileImageUrl", "https://example.com/default-profile.png");
+
+        User user = User.builder()
+                .email("test@example.com")
+                .name("테스터")
+                .oauthId("oauth-1")
+                .oauthType(OauthType.KAKAO)
+                .build();
+        Profile profile = new Profile(user);
+
+        String resolved = resolver.resolve(profile);
+
+        assertThat(resolved).isEqualTo("https://example.com/default-profile.png");
+    }
+
+    @Test
     @DisplayName("쿼리 기반 resolve에서도 AVATAR 이미지가 없으면 기본 이미지를 반환한다")
     void resolve_queryAvatarWithoutImageUrl_returnsDefaultImageUrl() {
         ProfileImageResolver resolver = new ProfileImageResolver();

--- a/src/test/java/com/dduru/gildongmu/user/dto/UserInfoTest.java
+++ b/src/test/java/com/dduru/gildongmu/user/dto/UserInfoTest.java
@@ -1,8 +1,11 @@
 package com.dduru.gildongmu.user.dto;
 
+import com.dduru.gildongmu.profile.domain.BgColor;
 import com.dduru.gildongmu.profile.domain.Profile;
 import com.dduru.gildongmu.profile.domain.enums.ProfileImageType;
 import com.dduru.gildongmu.profile.service.ProfileImageResolver;
+import com.dduru.gildongmu.survey.domain.AvatarProfile;
+import com.dduru.gildongmu.survey.domain.enums.AvatarType;
 import com.dduru.gildongmu.user.domain.User;
 import com.dduru.gildongmu.user.domain.enums.OauthType;
 import org.junit.jupiter.api.DisplayName;
@@ -36,8 +39,9 @@ class UserInfoTest {
         UserInfo userInfo = UserInfo.from(user, profileImageResolver);
 
         // then
-        assertThat(userInfo.profileImageType()).isEqualTo(ProfileImageType.DEFAULT);
-        assertThat(userInfo.profileImage()).isEqualTo("https://example.com/default.png");
+        assertThat(userInfo.profileImage().type()).isEqualTo(ProfileImageType.DEFAULT);
+        assertThat(userInfo.profileImage().url()).isEqualTo("https://example.com/default.png");
+        assertThat(userInfo.profileImage().bgColorId()).isNull();
     }
 
     @Test
@@ -60,7 +64,49 @@ class UserInfoTest {
         UserInfo userInfo = UserInfo.from(user, profileImageResolver);
 
         // then
-        assertThat(userInfo.profileImageType()).isEqualTo(ProfileImageType.UPLOADED);
-        assertThat(userInfo.profileImage()).isEqualTo("https://example.com/uploaded.png");
+        assertThat(userInfo.profileImage().type()).isEqualTo(ProfileImageType.UPLOADED);
+        assertThat(userInfo.profileImage().url()).isEqualTo("https://example.com/uploaded.png");
+        assertThat(userInfo.profileImage().bgColorId()).isNull();
+    }
+
+    @Test
+    @DisplayName("AVATAR 타입이면 profileImage 객체에 bgColor 정보를 함께 담는다")
+    void from_AVATAR_includesAvatarAndBgColor() {
+        User user = User.builder()
+                .email("test3@example.com")
+                .name("테스터3")
+                .oauthId("oauth-3")
+                .oauthType(OauthType.GOOGLE)
+                .build();
+        Profile profile = new Profile(user);
+
+        AvatarProfile avatarProfile = AvatarProfile.builder()
+                .avatarType(AvatarType.TTUR_DASOM)
+                .displayName("다솜")
+                .speechBubbleText("설명")
+                .descriptionLine1("성격")
+                .descriptionLine2("강점")
+                .descriptionLine3("팁")
+                .imageUrl("https://example.com/avatar.png")
+                .tags("[]")
+                .build();
+        BgColor bgColor = BgColor.builder()
+                .hexCode("#F5E6C8")
+                .displayOrder(1)
+                .build();
+        ReflectionTestUtils.setField(bgColor, "id", 9L);
+
+        profile.updateAvatar(avatarProfile);
+        profile.updateProfile("아바타닉", null, ProfileImageType.AVATAR, bgColor, "소개");
+        ReflectionTestUtils.setField(user, "profile", profile);
+
+        ProfileImageResolver profileImageResolver = mock(ProfileImageResolver.class);
+        when(profileImageResolver.resolve(profile)).thenReturn("https://example.com/avatar.png");
+
+        UserInfo userInfo = UserInfo.from(user, profileImageResolver);
+
+        assertThat(userInfo.profileImage().type()).isEqualTo(ProfileImageType.AVATAR);
+        assertThat(userInfo.profileImage().url()).isEqualTo("https://example.com/avatar.png");
+        assertThat(userInfo.profileImage().bgColorId()).isEqualTo(9L);
     }
 }

--- a/src/test/java/com/dduru/gildongmu/user/dto/UserInfoTest.java
+++ b/src/test/java/com/dduru/gildongmu/user/dto/UserInfoTest.java
@@ -3,7 +3,7 @@ package com.dduru.gildongmu.user.dto;
 import com.dduru.gildongmu.profile.domain.BgColor;
 import com.dduru.gildongmu.profile.domain.Profile;
 import com.dduru.gildongmu.profile.domain.enums.ProfileImageType;
-import com.dduru.gildongmu.profile.service.ProfileImageResolver;
+import com.dduru.gildongmu.profile.utils.ProfileImageResolver;
 import com.dduru.gildongmu.survey.domain.AvatarProfile;
 import com.dduru.gildongmu.survey.domain.enums.AvatarType;
 import com.dduru.gildongmu.user.domain.User;


### PR DESCRIPTION
## 🔎 작업 내용
* null-safe하게 `ProfileImageResolver`내용 수정
* `ProfileImageInfo` - 내부에서 프로필이미지 타입, 이미지, 배경색을 한 dto로 감싸서 응답하도록 수정
     * 빠진 bg color 필드 응답에 추가
* `ProfileImageResolver` service -> utils로 명확한 위치 변경
## ➕ 이슈 링크
* Closed #214 

## 🧑‍💻 예정 작업
- #

## 📝 체크리스트
- [x] 브랜치 이름은 `feat/개발내용` 형식으로 작성했는가?
- [x] 커밋 메시지는 `feat(scope): 커밋 내용` 형식으로 작성했는가?
- [x] 작업 전 Issue를 작성했는가?
- [x] `dev` 브랜치로 병합을 요청했는가?
- [x] 불필요한 주석과 공백은 제거했는가?
- [x] 코드 리뷰어의 피드백을 반영했는가?
- [x] 테스트를 진행했는가?
- [x] 테스트 코드를 작성했는가?
