### PR TITLE
feat: 무중단 배포(blue-green)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -2,7 +2,7 @@ name: CD - Continuous Deployment
 
 on:
   workflow_run:
-    workflows: ["CI - Continuous Integration"]
+    workflows: [ "CI - Continuous Integration" ]
     types:
       - completed
     branches:
@@ -117,7 +117,6 @@ jobs:
             cd ~/app
             tar -xzf deploy-bundle.tar.gz
             rm -f deploy-bundle.tar.gz
-            find deployment -maxdepth 5 -type f | sort
             test -f ~/app/deployment/nginx/conf.d/upstreams/active-upstream.blue.inc
             test -f ~/app/deployment/nginx/conf.d/upstreams/active-upstream.green.inc
             chmod +x ./deploy.sh && ./deploy.sh

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -58,7 +58,7 @@ jobs:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USER }}
           key: ${{ secrets.EC2_PRIVATE_KEY }}
-          source: "deploy.sh,docker-compose.prod.yml"
+          source: "deploy.sh,docker-compose.prod.yml,deployment/nginx"
           target: "~/app"
 
       - name: 🚀 Deploy to EC2

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -58,7 +58,7 @@ jobs:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USER }}
           key: ${{ secrets.EC2_PRIVATE_KEY }}
-          source: "deploy.sh,docker-compose.prod.yml,deployment/nginx"
+          source: "deploy.sh,docker-compose.prod.yml,deployment"
           target: "~/app"
 
       - name: 🚀 Deploy to EC2

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -52,13 +52,19 @@ jobs:
           docker push --all-tags $ECR_REGISTRY/$ECR_REPOSITORY
           echo "✅ Image pushed: $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
 
-      - name: 📂 Copy deployment files to EC2
+      - name: 📦 Package deployment bundle
+        run: |
+          tar --exclude='deployment/nginx/conf.d/upstreams/active-upstream.inc' \
+              -czf deploy-bundle.tar.gz \
+              deploy.sh docker-compose.prod.yml deployment
+
+      - name: 📂 Copy deployment bundle to EC2
         uses: appleboy/scp-action@v0.1.4
         with:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USER }}
           key: ${{ secrets.EC2_PRIVATE_KEY }}
-          source: "deploy.sh,docker-compose.prod.yml,deployment"
+          source: "deploy-bundle.tar.gz"
           target: "~/app"
 
       - name: 🚀 Deploy to EC2
@@ -107,5 +113,11 @@ jobs:
 
             # 배포 스크립트 실행
             set -e
+            mkdir -p ~/app
             cd ~/app
+            tar -xzf deploy-bundle.tar.gz
+            rm -f deploy-bundle.tar.gz
+            find deployment -maxdepth 5 -type f | sort
+            test -f ~/app/deployment/nginx/conf.d/upstreams/active-upstream.blue.inc
+            test -f ~/app/deployment/nginx/conf.d/upstreams/active-upstream.green.inc
             chmod +x ./deploy.sh && ./deploy.sh

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ out/
 
 ### env 환경변수 파일 ###
 .env
+
+### Blue-Green runtime state ###
+deployment/nginx/conf.d/upstreams/active-upstream.inc

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,11 @@ FROM eclipse-temurin:17-jre
 
 WORKDIR /app
 
+# readiness/healthcheck 확인용 도구 설치
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl \
+    && rm -rf /var/lib/apt/lists/*
+
 # 빌드된 JAR 파일만 복사
 COPY --from=build /app/build/libs/*.jar app.jar
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -56,6 +56,26 @@ require_compose_v2() {
   fi
 }
 
+require_file() {
+  local path="$1"
+  if [ ! -f "$path" ]; then
+    echo "필수 파일이 없습니다: ${path}" >&2
+    exit 1
+  fi
+}
+
+bootstrap_active_upstream() {
+  if [ -f "$ACTIVE_UPSTREAM_FILE" ]; then
+    return 0
+  fi
+
+  cp "${UPSTREAM_DIR}/active-upstream.blue.inc" "$ACTIVE_UPSTREAM_FILE" || {
+    echo "active upstream 초기화에 실패했습니다: ${UPSTREAM_DIR}/active-upstream.blue.inc" >&2
+    exit 1
+  }
+  log "ℹ️ active upstream 파일이 없어 blue로 초기화했습니다."
+}
+
 wait_for_readiness() {
   local service="$1"
   local i=1
@@ -83,16 +103,26 @@ switch_upstream() {
   local target_color="$1"
   local rollback_color="$2"
 
-  cp "${UPSTREAM_DIR}/active-upstream.${target_color}.inc" "$ACTIVE_UPSTREAM_FILE"
+  cp "${UPSTREAM_DIR}/active-upstream.${target_color}.inc" "$ACTIVE_UPSTREAM_FILE" || {
+    log "❌ upstream 파일 복사 실패: ${UPSTREAM_DIR}/active-upstream.${target_color}.inc"
+    return 1
+  }
 
   if ! "${COMPOSE[@]}" exec -T nginx nginx -t >/dev/null 2>&1; then
-    cp "${UPSTREAM_DIR}/active-upstream.${rollback_color}.inc" "$ACTIVE_UPSTREAM_FILE"
+    cp "${UPSTREAM_DIR}/active-upstream.${rollback_color}.inc" "$ACTIVE_UPSTREAM_FILE" || true
     "${COMPOSE[@]}" exec -T nginx nginx -t >/dev/null 2>&1 || true
     log "❌ nginx 설정 검증 실패. upstream를 ${rollback_color} 로 복구"
     return 1
   fi
 
-  "${COMPOSE[@]}" exec -T nginx nginx -s reload
+  if ! "${COMPOSE[@]}" exec -T nginx nginx -s reload >/dev/null 2>&1; then
+    cp "${UPSTREAM_DIR}/active-upstream.${rollback_color}.inc" "$ACTIVE_UPSTREAM_FILE" || true
+    "${COMPOSE[@]}" exec -T nginx nginx -t >/dev/null 2>&1 || true
+    "${COMPOSE[@]}" exec -T nginx nginx -s reload >/dev/null 2>&1 || true
+    log "❌ nginx reload 실패. upstream를 ${rollback_color} 로 복구"
+    return 1
+  fi
+
   log "🔀 active upstream -> ${target_color}"
 }
 
@@ -105,6 +135,12 @@ require_env IMAGE_TAG
 require_command aws
 require_command docker
 require_compose_v2
+require_file "${SCRIPT_DIR}/docker-compose.prod.yml"
+require_file "${SCRIPT_DIR}/deployment/nginx/nginx.conf"
+require_file "${SCRIPT_DIR}/deployment/nginx/conf.d/default.conf"
+require_file "${UPSTREAM_DIR}/active-upstream.blue.inc"
+require_file "${UPSTREAM_DIR}/active-upstream.green.inc"
+bootstrap_active_upstream
 
 log "🔐 ECR 로그인"
 aws ecr get-login-password --region "${AWS_REGION}" | docker login --username AWS --password-stdin "${ECR_REGISTRY}"

--- a/deploy.sh
+++ b/deploy.sh
@@ -61,8 +61,6 @@ switch_upstream() {
   echo "🔀 active upstream -> ${target_color}"
 }
 
-load_dotenv "${SCRIPT_DIR}/.env"
-
 echo "🚀 DDU-RU Backend Blue-Green 배포 시작..."
 
 for key in AWS_REGION ECR_REGISTRY ECR_REPOSITORY IMAGE_TAG; do

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,27 +1,11 @@
 #!/bin/bash
-set -Eeuo pipefail
+
+# DDU-RU Backend Blue-Green 배포 스크립트
+
+set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-
-load_dotenv() {
-  local env_file="$1"
-  [ -f "$env_file" ] || return 0
-  while IFS= read -r line || [ -n "$line" ]; do
-    line="${line%$'\r'}"
-    [[ "$line" =~ ^[[:space:]]*# ]] && continue
-    [[ -z "${line//[[:space:]]/}" ]] && continue
-    [[ "$line" != *=* ]] && continue
-    local key="${line%%=*}"
-    local value="${line#*=}"
-    key="${key%"${key##*[![:space:]]}"}"
-    key="${key#"${key%%[![:space:]]*}"}"
-    [[ "$key" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || continue
-    export "$key"="$value"
-  done <"$env_file"
-}
-load_dotenv "${SCRIPT_DIR}/.env"
-
-COMPOSE=(docker compose -f "${SCRIPT_DIR}/docker-compose.prod.yml")
+COMPOSE_FILE="${SCRIPT_DIR}/docker-compose.prod.yml"
 UPSTREAM_DIR="${SCRIPT_DIR}/deployment/nginx/conf.d/upstreams"
 ACTIVE_UPSTREAM_FILE="${UPSTREAM_DIR}/active-upstream.inc"
 READINESS_PATH="http://localhost:8080/actuator/health/readiness"
@@ -29,164 +13,170 @@ MAX_RETRIES=24
 RETRY_INTERVAL=5
 DRAIN_SECONDS=10
 
-log() {
-  echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*"
+load_dotenv() {
+  local env_file="$1"
+  [ -f "$env_file" ] || return 0
+
+  while IFS= read -r line || [ -n "$line" ]; do
+    line="${line%$'\r'}"
+    [[ "$line" =~ ^[[:space:]]*# ]] && continue
+    [[ -z "${line//[[:space:]]/}" ]] && continue
+    [[ "$line" != *=* ]] && continue
+
+    local key="${line%%=*}"
+    local value="${line#*=}"
+    key="${key%"${key##*[![:space:]]}"}"
+    key="${key#"${key%%[![:space:]]*}"}"
+
+    [[ "$key" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || continue
+    export "$key"="$value"
+  done <"$env_file"
 }
 
-require_env() {
-  local key="$1"
-  if [ -z "${!key:-}" ]; then
-    echo "환경변수 ${key} 가 비어 있습니다." >&2
-    exit 1
-  fi
-}
-
-require_command() {
-  local cmd="$1"
-  if ! command -v "$cmd" >/dev/null 2>&1; then
-    echo "필요한 명령을 찾을 수 없습니다: ${cmd}" >&2
-    exit 1
-  fi
-}
-
-require_compose_v2() {
-  if ! docker compose version >/dev/null 2>&1; then
-    echo "docker compose v2가 필요합니다." >&2
-    exit 1
-  fi
-}
-
-require_file() {
-  local path="$1"
-  if [ ! -f "$path" ]; then
-    echo "필수 파일이 없습니다: ${path}" >&2
-    exit 1
-  fi
-}
-
-bootstrap_active_upstream() {
-  if [ -f "$ACTIVE_UPSTREAM_FILE" ]; then
-    return 0
-  fi
-
-  cp "${UPSTREAM_DIR}/active-upstream.blue.inc" "$ACTIVE_UPSTREAM_FILE" || {
-    echo "active upstream 초기화에 실패했습니다: ${UPSTREAM_DIR}/active-upstream.blue.inc" >&2
-    exit 1
-  }
-  log "ℹ️ active upstream 파일이 없어 blue로 초기화했습니다."
+compose() {
+  docker compose -f "${COMPOSE_FILE}" "$@"
 }
 
 wait_for_readiness() {
   local service="$1"
-  local i=1
-  while [ "$i" -le "$MAX_RETRIES" ]; do
-    if "${COMPOSE[@]}" exec -T "$service" sh -c "curl -fsS ${READINESS_PATH} | grep -q '\"status\":\"UP\"'" >/dev/null 2>&1; then
-      log "✅ ${service} readiness 통과"
+
+  echo "⏳ ${service} readiness 확인 중..."
+  for i in $(seq 1 "${MAX_RETRIES}"); do
+    if compose exec -T "$service" sh -c "curl -fsS ${READINESS_PATH} | grep -q '\"status\":\"UP\"'" >/dev/null 2>&1; then
+      echo "✅ ${service} readiness 통과"
       return 0
     fi
-    log "⏳ ${service} readiness 대기 중... (${i}/${MAX_RETRIES})"
-    sleep "$RETRY_INTERVAL"
-    i=$((i + 1))
-  done
-  return 1
-}
 
-current_active_color() {
-  if [ -f "$ACTIVE_UPSTREAM_FILE" ] && grep -q "app_green:8080" "$ACTIVE_UPSTREAM_FILE"; then
-    echo "green"
-  else
-    echo "blue"
-  fi
+    echo "Attempt ${i}/${MAX_RETRIES}: 아직 준비되지 않았습니다. ${RETRY_INTERVAL}초 후 재시도..."
+    sleep "${RETRY_INTERVAL}"
+  done
+
+  return 1
 }
 
 switch_upstream() {
   local target_color="$1"
   local rollback_color="$2"
 
-  cp "${UPSTREAM_DIR}/active-upstream.${target_color}.inc" "$ACTIVE_UPSTREAM_FILE" || {
-    log "❌ upstream 파일 복사 실패: ${UPSTREAM_DIR}/active-upstream.${target_color}.inc"
+  cp "${UPSTREAM_DIR}/active-upstream.${target_color}.inc" "${ACTIVE_UPSTREAM_FILE}" || {
+    echo "❌ upstream 파일 복사 실패: ${UPSTREAM_DIR}/active-upstream.${target_color}.inc"
     return 1
   }
 
-  if ! "${COMPOSE[@]}" exec -T nginx nginx -t >/dev/null 2>&1; then
-    cp "${UPSTREAM_DIR}/active-upstream.${rollback_color}.inc" "$ACTIVE_UPSTREAM_FILE" || true
-    "${COMPOSE[@]}" exec -T nginx nginx -t >/dev/null 2>&1 || true
-    log "❌ nginx 설정 검증 실패. upstream를 ${rollback_color} 로 복구"
+  if ! compose exec -T nginx nginx -t >/dev/null 2>&1; then
+    cp "${UPSTREAM_DIR}/active-upstream.${rollback_color}.inc" "${ACTIVE_UPSTREAM_FILE}" || true
+    compose exec -T nginx nginx -t >/dev/null 2>&1 || true
+    echo "❌ nginx 설정 검증 실패. upstream를 ${rollback_color} 로 복구합니다."
     return 1
   fi
 
-  if ! "${COMPOSE[@]}" exec -T nginx nginx -s reload >/dev/null 2>&1; then
-    cp "${UPSTREAM_DIR}/active-upstream.${rollback_color}.inc" "$ACTIVE_UPSTREAM_FILE" || true
-    "${COMPOSE[@]}" exec -T nginx nginx -t >/dev/null 2>&1 || true
-    "${COMPOSE[@]}" exec -T nginx nginx -s reload >/dev/null 2>&1 || true
-    log "❌ nginx reload 실패. upstream를 ${rollback_color} 로 복구"
+  if ! compose exec -T nginx nginx -s reload >/dev/null 2>&1; then
+    cp "${UPSTREAM_DIR}/active-upstream.${rollback_color}.inc" "${ACTIVE_UPSTREAM_FILE}" || true
+    compose exec -T nginx nginx -t >/dev/null 2>&1 || true
+    compose exec -T nginx nginx -s reload >/dev/null 2>&1 || true
+    echo "❌ nginx reload 실패. upstream를 ${rollback_color} 로 복구합니다."
     return 1
   fi
 
-  log "🔀 active upstream -> ${target_color}"
+  echo "🔀 active upstream -> ${target_color}"
 }
 
-log "🚀 DDU-RU Backend Blue-Green 배포 시작"
+load_dotenv "${SCRIPT_DIR}/.env"
 
-require_env AWS_REGION
-require_env ECR_REGISTRY
-require_env ECR_REPOSITORY
-require_env IMAGE_TAG
-require_command aws
-require_command docker
-require_compose_v2
-require_file "${SCRIPT_DIR}/docker-compose.prod.yml"
-require_file "${SCRIPT_DIR}/deployment/nginx/nginx.conf"
-require_file "${SCRIPT_DIR}/deployment/nginx/conf.d/default.conf"
-require_file "${UPSTREAM_DIR}/active-upstream.blue.inc"
-require_file "${UPSTREAM_DIR}/active-upstream.green.inc"
-bootstrap_active_upstream
+echo "🚀 DDU-RU Backend Blue-Green 배포 시작..."
 
-log "🔐 ECR 로그인"
+for key in AWS_REGION ECR_REGISTRY ECR_REPOSITORY IMAGE_TAG; do
+  if [ -z "${!key:-}" ]; then
+    echo "❌ 환경변수 ${key} 가 비어 있습니다." >&2
+    exit 1
+  fi
+done
+
+for cmd in aws docker; do
+  if ! command -v "${cmd}" >/dev/null 2>&1; then
+    echo "❌ 필요한 명령을 찾을 수 없습니다: ${cmd}" >&2
+    exit 1
+  fi
+done
+
+if ! docker compose version >/dev/null 2>&1; then
+  echo "❌ docker compose v2가 필요합니다." >&2
+  exit 1
+fi
+
+for file in \
+  "${COMPOSE_FILE}" \
+  "${SCRIPT_DIR}/deployment/nginx/nginx.conf" \
+  "${SCRIPT_DIR}/deployment/nginx/conf.d/default.conf" \
+  "${UPSTREAM_DIR}/active-upstream.blue.inc" \
+  "${UPSTREAM_DIR}/active-upstream.green.inc"; do
+  if [ ! -f "${file}" ]; then
+    echo "❌ 필수 파일이 없습니다: ${file}" >&2
+    exit 1
+  fi
+done
+
+if [ ! -f "${ACTIVE_UPSTREAM_FILE}" ]; then
+  cp "${UPSTREAM_DIR}/active-upstream.blue.inc" "${ACTIVE_UPSTREAM_FILE}" || {
+    echo "❌ active upstream 초기화 실패: ${UPSTREAM_DIR}/active-upstream.blue.inc" >&2
+    exit 1
+  }
+  echo "ℹ️ active upstream 파일이 없어 blue로 초기화했습니다."
+fi
+
+echo "🧾 배포 컨텍스트 확인"
+echo "AWS_REGION=${AWS_REGION}"
+echo "ECR_REGISTRY=${ECR_REGISTRY}"
+echo "ECR_REPOSITORY=${ECR_REPOSITORY}"
+echo "IMAGE_TAG=${IMAGE_TAG}"
+
+echo "🔐 ECR에 Docker 로그인..."
 aws ecr get-login-password --region "${AWS_REGION}" | docker login --username AWS --password-stdin "${ECR_REGISTRY}"
 
-active_color="$(current_active_color)"
-if [ "$active_color" = "blue" ]; then
-  idle_color="green"
+if grep -q "app_green:8080" "${ACTIVE_UPSTREAM_FILE}"; then
+  ACTIVE_COLOR="green"
+  IDLE_COLOR="blue"
 else
-  idle_color="blue"
+  ACTIVE_COLOR="blue"
+  IDLE_COLOR="green"
 fi
 
-active_service="app_${active_color}"
-idle_service="app_${idle_color}"
+ACTIVE_SERVICE="app_${ACTIVE_COLOR}"
+IDLE_SERVICE="app_${IDLE_COLOR}"
 
-log "현재 활성 색상: ${active_color}, 배포 대상: ${idle_color}"
+echo "현재 활성 색상: ${ACTIVE_COLOR}, 배포 대상: ${IDLE_COLOR}"
 
-log "🧱 필수 인프라(redis) 기동 보장"
-"${COMPOSE[@]}" up -d redis
+echo "🧱 필수 인프라(redis) 기동 보장..."
+compose up -d redis
 
-log "📥 새 버전 이미지 pull (${idle_service})"
-"${COMPOSE[@]}" pull "${idle_service}"
+echo "📥 새 버전 이미지 가져오는 중... (${IDLE_SERVICE})"
+compose pull "${IDLE_SERVICE}"
 
-log "🚀 대상 색상 기동 (${idle_service})"
-"${COMPOSE[@]}" up -d --no-deps "${idle_service}"
+echo "🚀 대상 색상 기동... (${IDLE_SERVICE})"
+compose up -d --no-deps "${IDLE_SERVICE}"
 
-if ! wait_for_readiness "${idle_service}"; then
-  log "❌ ${idle_service} readiness 실패. 새 색상 중지 후 종료"
-  "${COMPOSE[@]}" logs --tail=200 "${idle_service}" || true
-  "${COMPOSE[@]}" stop "${idle_service}" || true
+if ! wait_for_readiness "${IDLE_SERVICE}"; then
+  echo "❌ ${IDLE_SERVICE} readiness 실패"
+  echo "🔍 로그 확인:"
+  compose logs --tail=200 "${IDLE_SERVICE}" || true
+  compose stop "${IDLE_SERVICE}" || true
   exit 1
 fi
 
-log "🧱 Nginx 기동 보장"
-"${COMPOSE[@]}" up -d nginx
+echo "🧱 Nginx 기동 보장..."
+compose up -d nginx
 
-log "🌐 Nginx upstream 전환 (${idle_color})"
-if ! switch_upstream "${idle_color}" "${active_color}"; then
-  "${COMPOSE[@]}" stop "${idle_service}" || true
+echo "🌐 Nginx upstream 전환... (${IDLE_COLOR})"
+if ! switch_upstream "${IDLE_COLOR}" "${ACTIVE_COLOR}"; then
+  compose stop "${IDLE_SERVICE}" || true
   exit 1
 fi
 
-log "🕒 기존 색상 커넥션 드레인 대기 (${DRAIN_SECONDS}s)"
+echo "🕒 기존 색상 연결 정리 대기... (${DRAIN_SECONDS}s)"
 sleep "${DRAIN_SECONDS}"
 
-log "🛑 이전 색상 중지 (${active_service})"
-"${COMPOSE[@]}" stop "${active_service}" || true
+echo "🛑 이전 색상 중지... (${ACTIVE_SERVICE})"
+compose stop "${ACTIVE_SERVICE}" || true
 
-log "✅ 배포 완료: active=${idle_color}, inactive=${active_color}"
-"${COMPOSE[@]}" ps
+echo "✅ 배포 완료: active=${IDLE_COLOR}, inactive=${ACTIVE_COLOR}"
+compose ps

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,20 +1,29 @@
 #!/bin/bash
-
 set -Eeuo pipefail
 
-# 프로젝트 루트의 .env는 docker compose가 치환용으로만 읽고, 셸에는 자동 주입되지 않음
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-if [ -f "${SCRIPT_DIR}/.env" ]; then
-  set -a
-  # shellcheck disable=SC1091
-  . "${SCRIPT_DIR}/.env"
-  set +a
-fi
 
-COMPOSE=(docker compose -f docker-compose.prod.yml)
-UPSTREAM_DIR="deployment/nginx/conf.d/upstreams"
+load_dotenv() {
+  local env_file="$1"
+  [ -f "$env_file" ] || return 0
+  while IFS= read -r line || [ -n "$line" ]; do
+    line="${line%$'\r'}"
+    [[ "$line" =~ ^[[:space:]]*# ]] && continue
+    [[ -z "${line//[[:space:]]/}" ]] && continue
+    [[ "$line" != *=* ]] && continue
+    local key="${line%%=*}"
+    local value="${line#*=}"
+    key="${key%"${key##*[![:space:]]}"}"
+    key="${key#"${key%%[![:space:]]*}"}"
+    [[ "$key" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || continue
+    export "$key"="$value"
+  done <"$env_file"
+}
+load_dotenv "${SCRIPT_DIR}/.env"
+
+COMPOSE=(docker compose -f "${SCRIPT_DIR}/docker-compose.prod.yml")
+UPSTREAM_DIR="${SCRIPT_DIR}/deployment/nginx/conf.d/upstreams"
 ACTIVE_UPSTREAM_FILE="${UPSTREAM_DIR}/active-upstream.inc"
-NGINX_UPSTREAM_PATH_IN_CONTAINER="/etc/nginx/conf.d/upstreams/active-upstream.inc"
 READINESS_PATH="http://localhost:8080/actuator/health/readiness"
 MAX_RETRIES=24
 RETRY_INTERVAL=5
@@ -28,6 +37,21 @@ require_env() {
   local key="$1"
   if [ -z "${!key:-}" ]; then
     echo "환경변수 ${key} 가 비어 있습니다." >&2
+    exit 1
+  fi
+}
+
+require_command() {
+  local cmd="$1"
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "필요한 명령을 찾을 수 없습니다: ${cmd}" >&2
+    exit 1
+  fi
+}
+
+require_compose_v2() {
+  if ! docker compose version >/dev/null 2>&1; then
+    echo "docker compose v2가 필요합니다." >&2
     exit 1
   fi
 }
@@ -56,10 +80,20 @@ current_active_color() {
 }
 
 switch_upstream() {
-  local color="$1"
-  cp "${UPSTREAM_DIR}/active-upstream.${color}.inc" "$ACTIVE_UPSTREAM_FILE"
+  local target_color="$1"
+  local rollback_color="$2"
+
+  cp "${UPSTREAM_DIR}/active-upstream.${target_color}.inc" "$ACTIVE_UPSTREAM_FILE"
+
+  if ! "${COMPOSE[@]}" exec -T nginx nginx -t >/dev/null 2>&1; then
+    cp "${UPSTREAM_DIR}/active-upstream.${rollback_color}.inc" "$ACTIVE_UPSTREAM_FILE"
+    "${COMPOSE[@]}" exec -T nginx nginx -t >/dev/null 2>&1 || true
+    log "❌ nginx 설정 검증 실패. upstream를 ${rollback_color} 로 복구"
+    return 1
+  fi
+
   "${COMPOSE[@]}" exec -T nginx nginx -s reload
-  log "🔀 active upstream -> ${color}"
+  log "🔀 active upstream -> ${target_color}"
 }
 
 log "🚀 DDU-RU Backend Blue-Green 배포 시작"
@@ -68,6 +102,9 @@ require_env AWS_REGION
 require_env ECR_REGISTRY
 require_env ECR_REPOSITORY
 require_env IMAGE_TAG
+require_command aws
+require_command docker
+require_compose_v2
 
 log "🔐 ECR 로그인"
 aws ecr get-login-password --region "${AWS_REGION}" | docker login --username AWS --password-stdin "${ECR_REGISTRY}"
@@ -94,8 +131,9 @@ log "🚀 대상 색상 기동 (${idle_service})"
 "${COMPOSE[@]}" up -d --no-deps "${idle_service}"
 
 if ! wait_for_readiness "${idle_service}"; then
-  log "❌ ${idle_service} readiness 실패. 롤백 없이 종료"
+  log "❌ ${idle_service} readiness 실패. 새 색상 중지 후 종료"
   "${COMPOSE[@]}" logs --tail=200 "${idle_service}" || true
+  "${COMPOSE[@]}" stop "${idle_service}" || true
   exit 1
 fi
 
@@ -103,11 +141,8 @@ log "🧱 Nginx 기동 보장"
 "${COMPOSE[@]}" up -d nginx
 
 log "🌐 Nginx upstream 전환 (${idle_color})"
-switch_upstream "${idle_color}"
-
-if ! "${COMPOSE[@]}" exec -T nginx sh -c "test -f ${NGINX_UPSTREAM_PATH_IN_CONTAINER}"; then
-  log "❌ Nginx 내부 upstream 파일 확인 실패. 이전 색상으로 롤백"
-  switch_upstream "${active_color}"
+if ! switch_upstream "${idle_color}" "${active_color}"; then
+  "${COMPOSE[@]}" stop "${idle_service}" || true
   exit 1
 fi
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -13,26 +13,6 @@ MAX_RETRIES=24
 RETRY_INTERVAL=5
 DRAIN_SECONDS=10
 
-load_dotenv() {
-  local env_file="$1"
-  [ -f "$env_file" ] || return 0
-
-  while IFS= read -r line || [ -n "$line" ]; do
-    line="${line%$'\r'}"
-    [[ "$line" =~ ^[[:space:]]*# ]] && continue
-    [[ -z "${line//[[:space:]]/}" ]] && continue
-    [[ "$line" != *=* ]] && continue
-
-    local key="${line%%=*}"
-    local value="${line#*=}"
-    key="${key%"${key##*[![:space:]]}"}"
-    key="${key#"${key%%[![:space:]]*}"}"
-
-    [[ "$key" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || continue
-    export "$key"="$value"
-  done <"$env_file"
-}
-
 compose() {
   docker compose -f "${COMPOSE_FILE}" "$@"
 }

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,48 +1,121 @@
 #!/bin/bash
 
-# DDU-RU Backend ECR 배포 스크립트
+set -Eeuo pipefail
 
-set -e # 에러 발생시 스크립트 중단
+# 프로젝트 루트의 .env는 docker compose가 치환용으로만 읽고, 셸에는 자동 주입되지 않음
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [ -f "${SCRIPT_DIR}/.env" ]; then
+  set -a
+  # shellcheck disable=SC1091
+  . "${SCRIPT_DIR}/.env"
+  set +a
+fi
 
-echo "🚀 DDU-RU Backend ECR 배포 시작..."
-
-echo "🧾 배포 컨텍스트 확인"
-echo "AWS_REGION=${AWS_REGION}"
-echo "ECR_REGISTRY=${ECR_REGISTRY}"
-echo "ECR_REPOSITORY=${ECR_REPOSITORY}"
-echo "IMAGE_TAG=${IMAGE_TAG}"
-
-echo "🔐 ECR에 Docker 로그인..."
-aws ecr get-login-password --region ${AWS_REGION} | docker login --username AWS --password-stdin ${ECR_REGISTRY}
-
-echo "📥 ECR에서 최신 이미지 가져오는 중..."
-docker-compose -f docker-compose.prod.yml pull app
-
-echo "📋 현재 실행중인 컨테이너 확인..."
-docker-compose -f docker-compose.prod.yml ps
-
-echo "🛑 기존 컨테이너 중지 및 제거..."
-docker-compose -f docker-compose.prod.yml down
-
-echo "🧹 사용하지 않는 Docker 이미지 정리..."
-docker image prune -f
-
-echo "🚀 서비스 시작..."
-docker-compose -f docker-compose.prod.yml up -d
-
-echo "⏳ 서비스 상태 확인 중..."
-MAX_RETRIES=12
+COMPOSE=(docker compose -f docker-compose.prod.yml)
+UPSTREAM_DIR="deployment/nginx/conf.d/upstreams"
+ACTIVE_UPSTREAM_FILE="${UPSTREAM_DIR}/active-upstream.inc"
+NGINX_UPSTREAM_PATH_IN_CONTAINER="/etc/nginx/conf.d/upstreams/active-upstream.inc"
+READINESS_PATH="http://localhost:8080/actuator/health/readiness"
+MAX_RETRIES=24
 RETRY_INTERVAL=5
-for i in $(seq 1 $MAX_RETRIES); do
-  if docker exec app-app-1 curl -fs http://localhost:8080/actuator/health | grep -q '"status":"UP"'; then
-    echo "✅ 애플리케이션이 정상적으로 실행 중입니다!"
-    exit 0
-  fi
-  echo "Attempt $i/$MAX_RETRIES: 아직 실행되지 않았습니다. $RETRY_INTERVAL초 후 재시도..."
-  sleep $RETRY_INTERVAL
-done
+DRAIN_SECONDS=10
 
-echo "❌ 애플리케이션이 정상적으로 실행되지 않았습니다!"
-echo "🔍 로그 확인:"
-docker-compose -f docker-compose.prod.yml logs app
-exit 1
+log() {
+  echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*"
+}
+
+require_env() {
+  local key="$1"
+  if [ -z "${!key:-}" ]; then
+    echo "환경변수 ${key} 가 비어 있습니다." >&2
+    exit 1
+  fi
+}
+
+wait_for_readiness() {
+  local service="$1"
+  local i=1
+  while [ "$i" -le "$MAX_RETRIES" ]; do
+    if "${COMPOSE[@]}" exec -T "$service" sh -c "curl -fsS ${READINESS_PATH} | grep -q '\"status\":\"UP\"'" >/dev/null 2>&1; then
+      log "✅ ${service} readiness 통과"
+      return 0
+    fi
+    log "⏳ ${service} readiness 대기 중... (${i}/${MAX_RETRIES})"
+    sleep "$RETRY_INTERVAL"
+    i=$((i + 1))
+  done
+  return 1
+}
+
+current_active_color() {
+  if [ -f "$ACTIVE_UPSTREAM_FILE" ] && grep -q "app_green:8080" "$ACTIVE_UPSTREAM_FILE"; then
+    echo "green"
+  else
+    echo "blue"
+  fi
+}
+
+switch_upstream() {
+  local color="$1"
+  cp "${UPSTREAM_DIR}/active-upstream.${color}.inc" "$ACTIVE_UPSTREAM_FILE"
+  "${COMPOSE[@]}" exec -T nginx nginx -s reload
+  log "🔀 active upstream -> ${color}"
+}
+
+log "🚀 DDU-RU Backend Blue-Green 배포 시작"
+
+require_env AWS_REGION
+require_env ECR_REGISTRY
+require_env ECR_REPOSITORY
+require_env IMAGE_TAG
+
+log "🔐 ECR 로그인"
+aws ecr get-login-password --region "${AWS_REGION}" | docker login --username AWS --password-stdin "${ECR_REGISTRY}"
+
+active_color="$(current_active_color)"
+if [ "$active_color" = "blue" ]; then
+  idle_color="green"
+else
+  idle_color="blue"
+fi
+
+active_service="app_${active_color}"
+idle_service="app_${idle_color}"
+
+log "현재 활성 색상: ${active_color}, 배포 대상: ${idle_color}"
+
+log "🧱 필수 인프라(redis) 기동 보장"
+"${COMPOSE[@]}" up -d redis
+
+log "📥 새 버전 이미지 pull (${idle_service})"
+"${COMPOSE[@]}" pull "${idle_service}"
+
+log "🚀 대상 색상 기동 (${idle_service})"
+"${COMPOSE[@]}" up -d --no-deps "${idle_service}"
+
+if ! wait_for_readiness "${idle_service}"; then
+  log "❌ ${idle_service} readiness 실패. 롤백 없이 종료"
+  "${COMPOSE[@]}" logs --tail=200 "${idle_service}" || true
+  exit 1
+fi
+
+log "🧱 Nginx 기동 보장"
+"${COMPOSE[@]}" up -d nginx
+
+log "🌐 Nginx upstream 전환 (${idle_color})"
+switch_upstream "${idle_color}"
+
+if ! "${COMPOSE[@]}" exec -T nginx sh -c "test -f ${NGINX_UPSTREAM_PATH_IN_CONTAINER}"; then
+  log "❌ Nginx 내부 upstream 파일 확인 실패. 이전 색상으로 롤백"
+  switch_upstream "${active_color}"
+  exit 1
+fi
+
+log "🕒 기존 색상 커넥션 드레인 대기 (${DRAIN_SECONDS}s)"
+sleep "${DRAIN_SECONDS}"
+
+log "🛑 이전 색상 중지 (${active_service})"
+"${COMPOSE[@]}" stop "${active_service}" || true
+
+log "✅ 배포 완료: active=${idle_color}, inactive=${active_color}"
+"${COMPOSE[@]}" ps

--- a/deployment/nginx/conf.d/default.conf
+++ b/deployment/nginx/conf.d/default.conf
@@ -5,7 +5,28 @@ upstream app_backend {
 
 server {
   listen 80;
-  server_name _;
+  listen [::]:80;
+  server_name api.dduru.app;
+
+  location /.well-known/acme-challenge/ {
+    root /var/www/certbot;
+  }
+
+  location / {
+    return 301 https://$host$request_uri;
+  }
+}
+
+server {
+  listen 443 ssl;
+  listen [::]:443 ssl;
+  http2 on;
+  server_name api.dduru.app;
+
+  ssl_certificate /etc/nginx/ssl/fullchain.pem;
+  ssl_certificate_key /etc/nginx/ssl/privkey.pem;
+  ssl_protocols TLSv1.2 TLSv1.3;
+  ssl_prefer_server_ciphers off;
 
   location / {
     proxy_http_version 1.1;

--- a/deployment/nginx/conf.d/default.conf
+++ b/deployment/nginx/conf.d/default.conf
@@ -1,0 +1,26 @@
+upstream app_backend {
+  include /etc/nginx/conf.d/upstreams/active-upstream.inc;
+  keepalive 32;
+}
+
+server {
+  listen 80;
+  server_name _;
+
+  location / {
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+
+    proxy_connect_timeout 3s;
+    proxy_send_timeout 60s;
+    proxy_read_timeout 60s;
+
+    proxy_next_upstream error timeout http_502 http_503 http_504;
+    proxy_pass http://app_backend;
+  }
+}

--- a/deployment/nginx/conf.d/upstreams/active-upstream.blue.inc
+++ b/deployment/nginx/conf.d/upstreams/active-upstream.blue.inc
@@ -1,0 +1,1 @@
+server app_blue:8080 max_fails=3 fail_timeout=10s;

--- a/deployment/nginx/conf.d/upstreams/active-upstream.green.inc
+++ b/deployment/nginx/conf.d/upstreams/active-upstream.green.inc
@@ -1,0 +1,1 @@
+server app_green:8080 max_fails=3 fail_timeout=10s;

--- a/deployment/nginx/conf.d/upstreams/active-upstream.inc
+++ b/deployment/nginx/conf.d/upstreams/active-upstream.inc
@@ -1,0 +1,1 @@
+server app_blue:8080 max_fails=3 fail_timeout=10s;

--- a/deployment/nginx/conf.d/upstreams/active-upstream.inc
+++ b/deployment/nginx/conf.d/upstreams/active-upstream.inc
@@ -1,1 +1,0 @@
-server app_blue:8080 max_fails=3 fail_timeout=10s;

--- a/deployment/nginx/nginx.conf
+++ b/deployment/nginx/nginx.conf
@@ -1,0 +1,30 @@
+user nginx;
+worker_processes auto;
+
+error_log /var/log/nginx/error.log warn;
+pid /var/run/nginx.pid;
+
+events {
+  worker_connections 1024;
+}
+
+http {
+  include /etc/nginx/mime.types;
+  default_type application/octet-stream;
+
+  log_format main '$remote_addr - $remote_user [$time_local] "$request" '
+                  '$status $body_bytes_sent "$http_referer" '
+                  '"$http_user_agent" "$http_x_forwarded_for"';
+
+  access_log /var/log/nginx/access.log main;
+
+  sendfile on;
+  tcp_nopush on;
+  tcp_nodelay on;
+  keepalive_timeout 65;
+  types_hash_max_size 2048;
+
+  server_tokens off;
+
+  include /etc/nginx/conf.d/*.conf;
+}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -9,9 +9,11 @@ services:
     restart: unless-stopped
     networks:
       - ddu-ru-network
-  app:
+
+  app_blue: &app_template
     image: ${ECR_REGISTRY}/${ECR_REPOSITORY}:${IMAGE_TAG}
     restart: unless-stopped
+    stop_grace_period: 40s
     expose:
       - "8080"
     volumes:
@@ -57,13 +59,16 @@ services:
       PROFILE_DEFAULT_IMAGE_URL: ${PROFILE_DEFAULT_IMAGE_URL}
 
     healthcheck:
-      test: ["CMD-SHELL", "curl -fs http://localhost:8080/actuator/health || exit 1"]
+      test: ["CMD-SHELL", "curl -fs http://localhost:8080/actuator/health/readiness || exit 1"]
       interval: 30s
       retries: 5
       timeout: 10s
       start_period: 60s
     networks:
       - ddu-ru-network
+
+  app_green:
+    <<: *app_template
 
   nginx:
     image: nginx:alpine
@@ -77,8 +82,6 @@ services:
       - ./deployment/nginx/ssl:/etc/nginx/ssl:ro
       - ./deployment/nginx/certbot/www:/var/www/certbot:ro
       - nginx-logs:/var/log/nginx
-    depends_on:
-      - app
     networks:
       - ddu-ru-network
 

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -25,6 +25,8 @@ spring:
     redis:
       host: ${REDIS_HOST}
       port: ${REDIS_PORT}
+  lifecycle:
+    timeout-per-shutdown-phase: 30s
 
 jwt:
   expiration: ${JWT_EXPIRATION}
@@ -36,6 +38,9 @@ logging:
   pattern:
     console: "%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - [reqId=%X{requestId:-} ip=%X{clientIp:-} method=%X{method:-} uri=%X{uri:-} userId=%X{userId:-}] %msg%n"
 
+server:
+  shutdown: graceful
+
 management:
   endpoints:
     web:
@@ -44,3 +49,15 @@ management:
   endpoint:
     health:
       show-details: when-authorized
+      probes:
+        enabled: true
+      group:
+        readiness:
+          include: readinessState,db,redis
+        liveness:
+          include: livenessState
+  health:
+    readinessstate:
+      enabled: true
+    livenessstate:
+      enabled: true


### PR DESCRIPTION
## 🔎 작업 내용
* 운영 배포 구조를 단일 `app` 재기동 방식에서 `blue-green` 기반 무중단 배포 구조로 변경
* `application-prod.yml`에 `graceful shutdown`, `readiness/liveness probe` 설정을 추가.
* `Dockerfile`에 readiness/healthcheck 확인용 `curl`을 추가.
* `docker-compose.prod.yml`을 `app_blue` / `app_green` 구조로 분리, readiness healthcheck 및 `stop_grace_period`를 적용.
* Nginx를 `active-upstream.inc` 기반으로 active color만 전환하는 구조로 변경.
* HTTP(80) 요청을 HTTPS(443)로 리다이렉트하고, SSL 프록시 설정을 반영.
* `deploy.sh`를 `현재 active 확인 -> idle 기동 -> readiness 확인 -> upstream 전환 -> old stop` 흐름의 blue-green 배포 스크립트로 개편.
* 첫 배포 시 `active-upstream.inc`가 없으면 기본값을 bootstrap 하도록 처리.
* 배포 실패 시 Nginx 설정 검증 및 전환 rollback 로직을 추가.
* GitHub Actions CD에서 배포 파일을 번들로 EC2에 전달하도록 수정해 경로 누락 문제를 방지.
* EC2 배포 전 upstream 관련 파일 존재 여부를 검증하도록 수정.
* 기존에 git에서 관리되던 `active-upstream.inc`는 런타임 상태 파일로 보고 저장소 추적 대상에서 제외.

## ➕ 이슈 링크
* Closed #225 

## 📸 스크린샷
그린
<img width="3216" height="188" alt="image" src="https://github.com/user-attachments/assets/d266f2d3-06da-44d2-84dd-2f74350940ff" />

블루
<img width="3208" height="284" alt="image" src="https://github.com/user-attachments/assets/666e54ac-0507-4016-b423-f29c23acb2ac" />
