### PR TITLE
feat: 채팅 메시지 전송/브로드캐스트

### DIFF
--- a/src/main/java/com/dduru/gildongmu/chat/constants/ChatDestinationPaths.java
+++ b/src/main/java/com/dduru/gildongmu/chat/constants/ChatDestinationPaths.java
@@ -1,0 +1,15 @@
+package com.dduru.gildongmu.chat.constants;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class ChatDestinationPaths {
+
+    public static final String PUB_ROOM_MESSAGES_PATTERN = "/chat/rooms/{roomId}/messages";
+    public static final String TOPIC_ROOM_PREFIX = "/topic/chat/rooms/";
+
+    public static String topicRoom(Long roomId) {
+        return TOPIC_ROOM_PREFIX + roomId;
+    }
+}

--- a/src/main/java/com/dduru/gildongmu/chat/constants/ChatMessageConstants.java
+++ b/src/main/java/com/dduru/gildongmu/chat/constants/ChatMessageConstants.java
@@ -1,0 +1,11 @@
+package com.dduru.gildongmu.chat.constants;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class ChatMessageConstants {
+
+    public static final int MAX_TEXT_LENGTH = 4_000;
+    public static final int MAX_IMAGE_URL_LENGTH = 2_048;
+}

--- a/src/main/java/com/dduru/gildongmu/chat/controller/ChatStompController.java
+++ b/src/main/java/com/dduru/gildongmu/chat/controller/ChatStompController.java
@@ -1,0 +1,30 @@
+package com.dduru.gildongmu.chat.controller;
+
+import com.dduru.gildongmu.chat.dto.ws.ChatMessageSendRequest;
+import com.dduru.gildongmu.chat.service.ChatMessageSendService;
+import com.dduru.gildongmu.chat.constants.ChatDestinationPaths;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.stereotype.Controller;
+
+import java.security.Principal;
+
+@Controller
+@RequiredArgsConstructor
+public class ChatStompController {
+
+    private final ChatMessageSendService chatMessageSendService;
+
+    @MessageMapping(ChatDestinationPaths.PUB_ROOM_MESSAGES_PATTERN)
+    public void sendMessage(
+            Principal principal,
+            @DestinationVariable Long roomId,
+            @Valid @Payload ChatMessageSendRequest request
+    ) {
+        Long userId = Long.parseLong(principal.getName());
+        chatMessageSendService.sendUserMessage(userId, roomId, request);
+    }
+}

--- a/src/main/java/com/dduru/gildongmu/chat/domain/ChatMessage.java
+++ b/src/main/java/com/dduru/gildongmu/chat/domain/ChatMessage.java
@@ -34,11 +34,20 @@ public class ChatMessage extends BaseTimeEntity {
     @Column(nullable = false, columnDefinition = "TEXT")
     private String content;
 
-    @Builder
-    public ChatMessage(ChatRoom room, User sender, ChatMessageType messageType, String content) {
+    @Builder(access = AccessLevel.PRIVATE)
+    private ChatMessage(ChatRoom room, User sender, ChatMessageType messageType, String content) {
         this.room = room;
         this.sender = sender;
         this.messageType = messageType;
         this.content = content;
+    }
+
+    public static ChatMessage create(ChatRoom room, User sender, ChatMessageType messageType, String content) {
+        return ChatMessage.builder()
+                .room(room)
+                .sender(sender)
+                .messageType(messageType)
+                .content(content)
+                .build();
     }
 }

--- a/src/main/java/com/dduru/gildongmu/chat/dto/ws/ChatMessageBroadcastPayload.java
+++ b/src/main/java/com/dduru/gildongmu/chat/dto/ws/ChatMessageBroadcastPayload.java
@@ -1,7 +1,13 @@
 package com.dduru.gildongmu.chat.dto.ws;
 
+import com.dduru.gildongmu.chat.domain.ChatMessage;
 import com.dduru.gildongmu.chat.domain.enums.ChatMessageType;
+import com.dduru.gildongmu.chat.system.ChatSystemMessageFactory;
+import com.dduru.gildongmu.post.domain.Post;
+import com.dduru.gildongmu.profile.utils.ProfileImageResolver;
+import com.dduru.gildongmu.user.domain.User;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
 
 import java.time.LocalDateTime;
 
@@ -9,6 +15,7 @@ import java.time.LocalDateTime;
  * 채팅방 토픽 구독자에게 브로드캐스트되는 메시지 페이로드.
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@Builder
 public record ChatMessageBroadcastPayload(
         Long messageId,
         Long roomId,
@@ -21,4 +28,35 @@ public record ChatMessageBroadcastPayload(
         ChatSystemMessagePayload systemMessage,
         LocalDateTime createdAt
 ) {
+    public static ChatMessageBroadcastPayload ofUserMessage(ChatMessage message, Post post, User sender, ProfileImageResolver profileImageResolver) {
+        return ChatMessageBroadcastPayload.builder()
+                .messageId(message.getId())
+                .roomId(message.getRoom().getId())
+                .postTitle(post.getTitle())
+                .recruitCount(post.getRecruitCount())
+                .recruitCapacity(post.getRecruitCapacity())
+                .messageType(message.getMessageType())
+                .sender(ChatMessageSenderPayload.from(sender, post.getUser().getId(), profileImageResolver))
+                .userMessage(ChatUserMessagePayload.from(message.getMessageType(), message.getContent()))
+                .systemMessage(null)
+                .createdAt(message.getCreatedAt())
+                .build();
+
+    }
+
+    public static ChatMessageBroadcastPayload ofSystemMessage(ChatMessage message, Post post, ChatSystemMessageFactory chatSystemMessageFactory) {
+        return ChatMessageBroadcastPayload.builder()
+                .messageId(message.getId())
+                .roomId(message.getRoom().getId())
+                .postTitle(post.getTitle())
+                .recruitCount(post.getRecruitCount())
+                .recruitCapacity(post.getRecruitCapacity())
+                .messageType(message.getMessageType())
+                .sender(null)
+                .userMessage(null)
+                .systemMessage(chatSystemMessageFactory.deserialize(message.getContent()))
+                .createdAt(message.getCreatedAt())
+                .build();
+    }
+
 }

--- a/src/main/java/com/dduru/gildongmu/chat/dto/ws/ChatMessageBroadcastPayload.java
+++ b/src/main/java/com/dduru/gildongmu/chat/dto/ws/ChatMessageBroadcastPayload.java
@@ -17,6 +17,8 @@ public record ChatMessageBroadcastPayload(
         int recruitCapacity,
         ChatMessageType messageType,
         ChatMessageSenderPayload sender,
+        ChatUserMessagePayload userMessage,
+        ChatSystemMessagePayload systemMessage,
         LocalDateTime createdAt
 ) {
 }

--- a/src/main/java/com/dduru/gildongmu/chat/dto/ws/ChatMessageBroadcastPayload.java
+++ b/src/main/java/com/dduru/gildongmu/chat/dto/ws/ChatMessageBroadcastPayload.java
@@ -1,0 +1,22 @@
+package com.dduru.gildongmu.chat.dto.ws;
+
+import com.dduru.gildongmu.chat.domain.enums.ChatMessageType;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.time.LocalDateTime;
+
+/**
+ * 채팅방 토픽 구독자에게 브로드캐스트되는 메시지 페이로드.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record ChatMessageBroadcastPayload(
+        Long messageId,
+        Long roomId,
+        String postTitle,
+        int recruitCount,
+        int recruitCapacity,
+        ChatMessageType messageType,
+        ChatMessageSenderPayload sender,
+        LocalDateTime createdAt
+) {
+}

--- a/src/main/java/com/dduru/gildongmu/chat/dto/ws/ChatMessageSendRequest.java
+++ b/src/main/java/com/dduru/gildongmu/chat/dto/ws/ChatMessageSendRequest.java
@@ -1,0 +1,16 @@
+package com.dduru.gildongmu.chat.dto.ws;
+
+import com.dduru.gildongmu.chat.domain.enums.ChatMessageType;
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * STOMP 클라이언트 전송 페이로드. {@link ChatMessageType#SYSTEM} 은 서버에서만 생성한다.
+ * content 검증은 messageType 에 따라 달라서 서비스 계층의 전용 validator가 담당한다.
+ */
+public record ChatMessageSendRequest(
+        @NotNull(message = "메세지 타입은 필수입니다.")
+        ChatMessageType messageType,
+
+        String content
+) {
+}

--- a/src/main/java/com/dduru/gildongmu/chat/dto/ws/ChatMessageSenderPayload.java
+++ b/src/main/java/com/dduru/gildongmu/chat/dto/ws/ChatMessageSenderPayload.java
@@ -1,0 +1,22 @@
+package com.dduru.gildongmu.chat.dto.ws;
+
+import com.dduru.gildongmu.profile.dto.response.ProfileImageInfo;
+import com.dduru.gildongmu.profile.utils.ProfileImageResolver;
+import com.dduru.gildongmu.user.domain.User;
+
+public record ChatMessageSenderPayload(
+        Long id,
+        String name,
+        ProfileImageInfo profileImageInfo,
+        boolean isHost
+) {
+
+    public static ChatMessageSenderPayload from(User sender, Long hostUserId, ProfileImageResolver profileImageResolver) {
+        return new ChatMessageSenderPayload(
+                sender.getId(),
+                sender.getName(),
+                ProfileImageInfo.from(sender.getProfile(), profileImageResolver),
+                sender.getId().equals(hostUserId)
+        );
+    }
+}

--- a/src/main/java/com/dduru/gildongmu/chat/dto/ws/ChatSystemMessagePayload.java
+++ b/src/main/java/com/dduru/gildongmu/chat/dto/ws/ChatSystemMessagePayload.java
@@ -1,0 +1,30 @@
+package com.dduru.gildongmu.chat.dto.ws;
+
+import com.dduru.gildongmu.chat.system.ChatSystemMessageType;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record ChatSystemMessagePayload(
+        ChatSystemMessageType type,
+        Long actorUserId,
+        Long inviteeUserId,
+        Long userId,
+        Long targetUserId
+) {
+
+    public static ChatSystemMessagePayload userInvited(long inviteeUserId, long actorUserId) {
+        return new ChatSystemMessagePayload(ChatSystemMessageType.USER_INVITED, actorUserId, inviteeUserId, null, null);
+    }
+
+    public static ChatSystemMessagePayload userLeft(long userId) {
+        return new ChatSystemMessagePayload(ChatSystemMessageType.USER_LEFT, null, null, userId, null);
+    }
+
+    public static ChatSystemMessagePayload userKicked(long targetUserId, long actorUserId) {
+        return new ChatSystemMessagePayload(ChatSystemMessageType.USER_KICKED, actorUserId, null, null, targetUserId);
+    }
+
+    public static ChatSystemMessagePayload roomClosed() {
+        return new ChatSystemMessagePayload(ChatSystemMessageType.ROOM_CLOSED, null, null, null, null);
+    }
+}

--- a/src/main/java/com/dduru/gildongmu/chat/dto/ws/ChatUserMessagePayload.java
+++ b/src/main/java/com/dduru/gildongmu/chat/dto/ws/ChatUserMessagePayload.java
@@ -1,0 +1,19 @@
+package com.dduru.gildongmu.chat.dto.ws;
+
+import com.dduru.gildongmu.chat.domain.enums.ChatMessageType;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record ChatUserMessagePayload(
+        String text,
+        String imageUrl
+) {
+
+    public static ChatUserMessagePayload from(ChatMessageType messageType, String content) {
+        return switch (messageType) {
+            case TEXT -> new ChatUserMessagePayload(content, null);
+            case IMAGE -> new ChatUserMessagePayload(null, content);
+            case SYSTEM -> throw new IllegalArgumentException("SYSTEM 메시지는 사용자 메시지 payload를 만들 수 없습니다.");
+        };
+    }
+}

--- a/src/main/java/com/dduru/gildongmu/chat/exception/ChatAccessDeniedException.java
+++ b/src/main/java/com/dduru/gildongmu/chat/exception/ChatAccessDeniedException.java
@@ -1,0 +1,10 @@
+package com.dduru.gildongmu.chat.exception;
+
+import com.dduru.gildongmu.common.exception.BusinessException;
+import com.dduru.gildongmu.common.exception.ErrorCode;
+
+public class ChatAccessDeniedException extends BusinessException {
+    public ChatAccessDeniedException() {
+        super(ErrorCode.CHAT_ACCESS_DENIED);
+    }
+}

--- a/src/main/java/com/dduru/gildongmu/chat/exception/ChatSystemMessageSendAccessDeniedException.java
+++ b/src/main/java/com/dduru/gildongmu/chat/exception/ChatSystemMessageSendAccessDeniedException.java
@@ -1,0 +1,10 @@
+package com.dduru.gildongmu.chat.exception;
+
+import com.dduru.gildongmu.common.exception.BusinessException;
+import com.dduru.gildongmu.common.exception.ErrorCode;
+
+public class ChatSystemMessageSendAccessDeniedException extends BusinessException {
+    public ChatSystemMessageSendAccessDeniedException() {
+        super(ErrorCode.CHAT_SYSTEM_MESSAGE_SEND_ACCESS_DENIED);
+    }
+}

--- a/src/main/java/com/dduru/gildongmu/chat/exception/InvalidChatImageUrlException.java
+++ b/src/main/java/com/dduru/gildongmu/chat/exception/InvalidChatImageUrlException.java
@@ -1,0 +1,35 @@
+package com.dduru.gildongmu.chat.exception;
+
+import com.dduru.gildongmu.common.exception.BusinessException;
+import com.dduru.gildongmu.common.exception.ErrorCode;
+
+public class InvalidChatImageUrlException extends BusinessException {
+
+    private InvalidChatImageUrlException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public static InvalidChatImageUrlException missing() {
+        return new InvalidChatImageUrlException(ErrorCode.CHAT_IMAGE_URL_REQUIRED);
+    }
+
+    public static InvalidChatImageUrlException blank() {
+        return new InvalidChatImageUrlException(ErrorCode.CHAT_IMAGE_URL_BLANK);
+    }
+
+    public static InvalidChatImageUrlException tooLong() {
+        return new InvalidChatImageUrlException(ErrorCode.CHAT_IMAGE_URL_TOO_LONG);
+    }
+
+    public static InvalidChatImageUrlException invalidFormat() {
+        return new InvalidChatImageUrlException(ErrorCode.CHAT_IMAGE_URL_INVALID_FORMAT);
+    }
+
+    public static InvalidChatImageUrlException notAbsolute() {
+        return new InvalidChatImageUrlException(ErrorCode.CHAT_IMAGE_URL_NOT_ABSOLUTE);
+    }
+
+    public static InvalidChatImageUrlException nonHttpsScheme() {
+        return new InvalidChatImageUrlException(ErrorCode.CHAT_IMAGE_URL_INVALID_SCHEME);
+    }
+}

--- a/src/main/java/com/dduru/gildongmu/chat/exception/InvalidChatTextException.java
+++ b/src/main/java/com/dduru/gildongmu/chat/exception/InvalidChatTextException.java
@@ -1,0 +1,23 @@
+package com.dduru.gildongmu.chat.exception;
+
+import com.dduru.gildongmu.common.exception.BusinessException;
+import com.dduru.gildongmu.common.exception.ErrorCode;
+
+public class InvalidChatTextException extends BusinessException {
+
+    private InvalidChatTextException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public static InvalidChatTextException missing() {
+        return new InvalidChatTextException(ErrorCode.CHAT_TEXT_REQUIRED);
+    }
+
+    public static InvalidChatTextException blank() {
+        return new InvalidChatTextException(ErrorCode.CHAT_TEXT_BLANK);
+    }
+
+    public static InvalidChatTextException tooLong() {
+        return new InvalidChatTextException(ErrorCode.CHAT_TEXT_TOO_LONG);
+    }
+}

--- a/src/main/java/com/dduru/gildongmu/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/dduru/gildongmu/chat/repository/ChatMessageRepository.java
@@ -4,4 +4,6 @@ import com.dduru.gildongmu.chat.domain.ChatMessage;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
+
+    long countByRoom_Id(Long roomId);
 }

--- a/src/main/java/com/dduru/gildongmu/chat/service/ChatMessageSendService.java
+++ b/src/main/java/com/dduru/gildongmu/chat/service/ChatMessageSendService.java
@@ -6,10 +6,8 @@ import com.dduru.gildongmu.chat.domain.ChatRoom;
 import com.dduru.gildongmu.chat.domain.enums.ChatMessageType;
 import com.dduru.gildongmu.chat.domain.enums.ChatRoomStatus;
 import com.dduru.gildongmu.chat.dto.ws.ChatMessageBroadcastPayload;
-import com.dduru.gildongmu.chat.dto.ws.ChatMessageSenderPayload;
 import com.dduru.gildongmu.chat.dto.ws.ChatMessageSendRequest;
 import com.dduru.gildongmu.chat.dto.ws.ChatSystemMessagePayload;
-import com.dduru.gildongmu.chat.dto.ws.ChatUserMessagePayload;
 import com.dduru.gildongmu.chat.exception.ChatAccessDeniedException;
 import com.dduru.gildongmu.chat.exception.ChatRoomClosedException;
 import com.dduru.gildongmu.chat.exception.ChatSystemMessageSendAccessDeniedException;
@@ -40,7 +38,6 @@ public class ChatMessageSendService {
     private final ChatMessageRepository chatMessageRepository;
     private final UserRepository userRepository;
 
-    private final GroupChatRoomService groupChatRoomService;
     private final ProfileImageResolver profileImageResolver;
     private final SimpMessagingTemplate simpMessagingTemplate;
     private final ChatSystemMessageFactory chatSystemMessageFactory;
@@ -52,37 +49,18 @@ public class ChatMessageSendService {
 
         User sender = userRepository.getWithProfileByIdOrThrow(senderUserId);
         String content = resolveUserMessageContent(request);
-        saveUserMessageAndMaybeActivate(room, sender, request.messageType(), content);
+        saveUserMessageAndBroadcast(room, sender, request.messageType(), content);
     }
 
-    /**
-     * 멤버 초대 성공 등 서버 전용 시스템 메시지를 저장하고 브로드캐스트한다.
-     */
-    public void publishUserInvited(Long roomId, long inviteeUserId, long actorUserId) {
-        saveSystemMessageAndBroadcast(
-                roomId,
-                chatSystemMessageFactory.userInvited(inviteeUserId, actorUserId)
+    public void publishUserInvited(ChatRoom room, long inviteeUserId, long actorUserId) {
+        saveSystemMessageAndBroadcast(room, chatSystemMessageFactory.userInvited(inviteeUserId, actorUserId));
+    }
+
+    private void saveSystemMessageAndBroadcast(ChatRoom room, ChatSystemMessagePayload systemMessage) {
+        ChatMessage chatMessage = saveMessageAndActivateRoomIfFirstMessage(room, null, ChatMessageType.SYSTEM,
+                chatSystemMessageFactory.serialize(systemMessage)
         );
-    }
-
-    /**
-     * 서버에서 생성한 시스템 메시지를 JSON content로 저장하고 typed payload로 동일 토픽에 전달한다.
-     */
-    public void saveSystemMessageAndBroadcast(Long roomId, ChatSystemMessagePayload systemMessage) {
-        ChatRoom room = chatRoomRepository.getByIdOrThrow(roomId);
-        validateRoomOpen(room);
-        long beforeCount = chatMessageRepository.countByRoom_Id(roomId);
-        ChatMessage saved = chatMessageRepository.save(ChatMessage.builder()
-                .room(room)
-                .sender(null)
-                .messageType(ChatMessageType.SYSTEM)
-                .content(chatSystemMessageFactory.serialize(systemMessage))
-                .build());
-        chatMessageRepository.flush();
-        if (beforeCount == 0) {
-            groupChatRoomService.activateChatOnFirstMessage(room);
-        }
-        scheduleBroadcastAfterCommit(toPayload(saved), roomId);
+        broadcastAfterCommit(toPayload(chatMessage), room.getId());
     }
 
     private void checkSenderIsMember(Long senderUserId, Long roomId) {
@@ -91,57 +69,48 @@ public class ChatMessageSendService {
         }
     }
 
-    private void saveUserMessageAndMaybeActivate(ChatRoom room, User sender, ChatMessageType messageType, String content) {
-        long beforeCount = chatMessageRepository.countByRoom_Id(room.getId());
-        ChatMessage saved = chatMessageRepository.save(ChatMessage.builder()
-                .room(room)
-                .sender(sender)
-                .messageType(messageType)
-                .content(content)
-                .build());
+    private void saveUserMessageAndBroadcast(ChatRoom room, User sender, ChatMessageType messageType, String content) {
+        ChatMessage chatMessage = saveMessageAndActivateRoomIfFirstMessage(room, sender, messageType, content);
+        broadcastAfterCommit(toPayload(chatMessage), room.getId());
+    }
+
+    private ChatMessage saveMessageAndActivateRoomIfFirstMessage(
+            ChatRoom room,
+            User sender,
+            ChatMessageType messageType,
+            String content
+    ) {
+        long beforeMessageCount = chatMessageRepository.countByRoom_Id(room.getId());
+        ChatMessage message = saveAndFlushMessage(room, sender, messageType, content);
+        activateRoomIfFirstMessage(room, beforeMessageCount);
+        return message;
+    }
+
+    private ChatMessage saveAndFlushMessage(ChatRoom room, User sender, ChatMessageType messageType, String content) {
+        ChatMessage message = chatMessageRepository.save(ChatMessage.create(room, sender, messageType, content));
         chatMessageRepository.flush();
-        if (beforeCount == 0) {
-            groupChatRoomService.activateChatOnFirstMessage(room);
-        }
-        scheduleBroadcastAfterCommit(toPayload(saved), room.getId());
+        return message;
     }
 
-    private ChatMessageBroadcastPayload toPayload(ChatMessage saved) {
-        Post post = saved.getRoom().getPost();
-
-        if (saved.getMessageType() == ChatMessageType.SYSTEM) {
-            return new ChatMessageBroadcastPayload(
-                    saved.getId(),
-                    saved.getRoom().getId(),
-                    post.getTitle(),
-                    post.getRecruitCount(),
-                    post.getRecruitCapacity(),
-                    saved.getMessageType(),
-                    null,
-                    null,
-                    chatSystemMessageFactory.deserialize(saved.getContent()),
-                    saved.getCreatedAt()
-            );
+    private void activateRoomIfFirstMessage(ChatRoom room, long beforeMessageCount) {
+        if (beforeMessageCount == 0) {
+            room.activateIfPending();
         }
-
-        User sender = requireSender(saved);
-
-        return new ChatMessageBroadcastPayload(
-                saved.getId(),
-                saved.getRoom().getId(),
-                post.getTitle(),
-                post.getRecruitCount(),
-                post.getRecruitCapacity(),
-                saved.getMessageType(),
-                ChatMessageSenderPayload.from(sender, post.getUser().getId(), profileImageResolver),
-                ChatUserMessagePayload.from(saved.getMessageType(), saved.getContent()),
-                null,
-                saved.getCreatedAt()
-        );
     }
 
-    private static User requireSender(ChatMessage saved) {
-        User sender = saved.getSender();
+    private ChatMessageBroadcastPayload toPayload(ChatMessage message) {
+        Post post = message.getRoom().getPost();
+
+        if (message.getMessageType() == ChatMessageType.SYSTEM) {
+            return ChatMessageBroadcastPayload.ofSystemMessage(message, post, chatSystemMessageFactory);
+        }
+
+        User sender = requireSender(message.getSender());
+
+        return ChatMessageBroadcastPayload.ofUserMessage(message, post, sender, profileImageResolver);
+    }
+
+    private static User requireSender(User sender) {
         if (sender == null) {
             throw new IllegalStateException("사용자 메시지에는 sender가 필요합니다.");
         }
@@ -166,7 +135,7 @@ public class ChatMessageSendService {
      * 트랜잭션이 커밋된 뒤에만 브로드캐스트해서, 롤백 시 잘못된 실시간 메시지가 나가지 않게 한다.
      * 테스트 등 비트랜잭션 호출에서는 즉시 전송한다.
      */
-    private void scheduleBroadcastAfterCommit(ChatMessageBroadcastPayload payload, Long roomId) {
+    private void broadcastAfterCommit(ChatMessageBroadcastPayload payload, Long roomId) {
         String destination = ChatDestinationPaths.topicRoom(roomId);
         if (TransactionSynchronizationManager.isSynchronizationActive()) {
             TransactionSynchronizationManager.registerSynchronization(

--- a/src/main/java/com/dduru/gildongmu/chat/service/ChatMessageSendService.java
+++ b/src/main/java/com/dduru/gildongmu/chat/service/ChatMessageSendService.java
@@ -1,0 +1,121 @@
+package com.dduru.gildongmu.chat.service;
+
+import com.dduru.gildongmu.chat.constants.ChatDestinationPaths;
+import com.dduru.gildongmu.chat.domain.ChatMessage;
+import com.dduru.gildongmu.chat.domain.ChatRoom;
+import com.dduru.gildongmu.chat.domain.enums.ChatMessageType;
+import com.dduru.gildongmu.chat.domain.enums.ChatRoomStatus;
+import com.dduru.gildongmu.chat.dto.ws.ChatMessageBroadcastPayload;
+import com.dduru.gildongmu.chat.dto.ws.ChatMessageSendRequest;
+import com.dduru.gildongmu.chat.exception.ChatAccessDeniedException;
+import com.dduru.gildongmu.chat.exception.ChatRoomClosedException;
+import com.dduru.gildongmu.chat.exception.ChatSystemMessageSendAccessDeniedException;
+import com.dduru.gildongmu.chat.repository.ChatMessageRepository;
+import com.dduru.gildongmu.chat.repository.ChatRoomMemberRepository;
+import com.dduru.gildongmu.chat.repository.ChatRoomRepository;
+import com.dduru.gildongmu.chat.validation.ChatImageUrlValidator;
+import com.dduru.gildongmu.chat.validation.ChatTextValidator;
+import com.dduru.gildongmu.post.domain.Post;
+import com.dduru.gildongmu.profile.utils.ProfileImageResolver;
+import com.dduru.gildongmu.user.domain.User;
+import com.dduru.gildongmu.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ChatMessageSendService {
+
+    private final ChatRoomRepository chatRoomRepository;
+    private final ChatRoomMemberRepository chatRoomMemberRepository;
+    private final ChatMessageRepository chatMessageRepository;
+    private final UserRepository userRepository;
+
+    private final GroupChatRoomService groupChatRoomService;
+    private final ProfileImageResolver profileImageResolver;
+    private final SimpMessagingTemplate simpMessagingTemplate;
+
+    public void sendUserMessage(Long senderUserId, Long roomId, ChatMessageSendRequest request) {
+        ChatRoom room = chatRoomRepository.getByIdOrThrow(roomId);
+        validateRoomOpen(room);
+        checkSenderIsMember(senderUserId, roomId);
+
+        User sender = userRepository.getByIdOrThrow(senderUserId);
+        String content = resolveUserMessageContent(request);
+        saveUserMessageAndMaybeActivate(room, sender, request.messageType(), content);
+    }
+
+    private void checkSenderIsMember(Long senderUserId, Long roomId) {
+        if (!chatRoomMemberRepository.existsByChatRoom_IdAndUser_Id(roomId, senderUserId)) {
+            throw new ChatAccessDeniedException();
+        }
+    }
+
+    private void saveUserMessageAndMaybeActivate(ChatRoom room, User sender, ChatMessageType messageType, String content) {
+        long beforeCount = chatMessageRepository.countByRoom_Id(room.getId());
+        ChatMessage saved = chatMessageRepository.save(ChatMessage.builder()
+                .room(room)
+                .sender(sender)
+                .messageType(messageType)
+                .content(content)
+                .build());
+        chatMessageRepository.flush();
+        if (beforeCount == 0) {
+            groupChatRoomService.activateChatOnFirstMessage(room);
+        }
+        scheduleBroadcastAfterCommit(toPayload(saved), room.getId());
+    }
+
+    private ChatMessageBroadcastPayload toPayload(ChatMessage saved) {
+        Post post = saved.getRoom().getPost();
+
+        return new ChatMessageBroadcastPayload(
+                saved.getId(),
+                saved.getRoom().getId(),
+                post.getTitle(),
+                post.getRecruitCount(),
+                post.getRecruitCapacity(),
+                saved.getMessageType(),
+                null,
+                saved.getCreatedAt()
+        );
+    }
+
+    private static String resolveUserMessageContent(ChatMessageSendRequest request) {
+        return switch (request.messageType()) {
+            case TEXT -> ChatTextValidator.validateAndNormalize(request.content());
+            case IMAGE -> ChatImageUrlValidator.validateAndNormalize(request.content());
+            case SYSTEM -> throw new ChatSystemMessageSendAccessDeniedException();
+        };
+    }
+
+    private static void validateRoomOpen(ChatRoom room) {
+        if (room.getStatus() == ChatRoomStatus.CLOSED || room.getStatus() == ChatRoomStatus.DELETED) {
+            throw new ChatRoomClosedException();
+        }
+    }
+
+    /**
+     * 트랜잭션이 커밋된 뒤에만 브로드캐스트해서, 롤백 시 잘못된 실시간 메시지가 나가지 않게 한다.
+     * 테스트 등 비트랜잭션 호출에서는 즉시 전송한다.
+     */
+    private void scheduleBroadcastAfterCommit(ChatMessageBroadcastPayload payload, Long roomId) {
+        String destination = ChatDestinationPaths.topicRoom(roomId);
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.registerSynchronization(
+                    new TransactionSynchronization() {
+                        @Override
+                        public void afterCommit() {
+                            simpMessagingTemplate.convertAndSend(destination, payload);
+                        }
+                    });
+        } else {
+            simpMessagingTemplate.convertAndSend(destination, payload);
+        }
+    }
+}

--- a/src/main/java/com/dduru/gildongmu/chat/service/ChatMessageSendService.java
+++ b/src/main/java/com/dduru/gildongmu/chat/service/ChatMessageSendService.java
@@ -8,12 +8,15 @@ import com.dduru.gildongmu.chat.domain.enums.ChatRoomStatus;
 import com.dduru.gildongmu.chat.dto.ws.ChatMessageBroadcastPayload;
 import com.dduru.gildongmu.chat.dto.ws.ChatMessageSenderPayload;
 import com.dduru.gildongmu.chat.dto.ws.ChatMessageSendRequest;
+import com.dduru.gildongmu.chat.dto.ws.ChatSystemMessagePayload;
+import com.dduru.gildongmu.chat.dto.ws.ChatUserMessagePayload;
 import com.dduru.gildongmu.chat.exception.ChatAccessDeniedException;
 import com.dduru.gildongmu.chat.exception.ChatRoomClosedException;
 import com.dduru.gildongmu.chat.exception.ChatSystemMessageSendAccessDeniedException;
 import com.dduru.gildongmu.chat.repository.ChatMessageRepository;
 import com.dduru.gildongmu.chat.repository.ChatRoomMemberRepository;
 import com.dduru.gildongmu.chat.repository.ChatRoomRepository;
+import com.dduru.gildongmu.chat.system.ChatSystemMessageFactory;
 import com.dduru.gildongmu.chat.validation.ChatImageUrlValidator;
 import com.dduru.gildongmu.chat.validation.ChatTextValidator;
 import com.dduru.gildongmu.post.domain.Post;
@@ -40,6 +43,7 @@ public class ChatMessageSendService {
     private final GroupChatRoomService groupChatRoomService;
     private final ProfileImageResolver profileImageResolver;
     private final SimpMessagingTemplate simpMessagingTemplate;
+    private final ChatSystemMessageFactory chatSystemMessageFactory;
 
     public void sendUserMessage(Long senderUserId, Long roomId, ChatMessageSendRequest request) {
         ChatRoom room = chatRoomRepository.getByIdOrThrow(roomId);
@@ -49,6 +53,36 @@ public class ChatMessageSendService {
         User sender = userRepository.getWithProfileByIdOrThrow(senderUserId);
         String content = resolveUserMessageContent(request);
         saveUserMessageAndMaybeActivate(room, sender, request.messageType(), content);
+    }
+
+    /**
+     * 멤버 초대 성공 등 서버 전용 시스템 메시지를 저장하고 브로드캐스트한다.
+     */
+    public void publishUserInvited(Long roomId, long inviteeUserId, long actorUserId) {
+        saveSystemMessageAndBroadcast(
+                roomId,
+                chatSystemMessageFactory.userInvited(inviteeUserId, actorUserId)
+        );
+    }
+
+    /**
+     * 서버에서 생성한 시스템 메시지를 JSON content로 저장하고 typed payload로 동일 토픽에 전달한다.
+     */
+    public void saveSystemMessageAndBroadcast(Long roomId, ChatSystemMessagePayload systemMessage) {
+        ChatRoom room = chatRoomRepository.getByIdOrThrow(roomId);
+        validateRoomOpen(room);
+        long beforeCount = chatMessageRepository.countByRoom_Id(roomId);
+        ChatMessage saved = chatMessageRepository.save(ChatMessage.builder()
+                .room(room)
+                .sender(null)
+                .messageType(ChatMessageType.SYSTEM)
+                .content(chatSystemMessageFactory.serialize(systemMessage))
+                .build());
+        chatMessageRepository.flush();
+        if (beforeCount == 0) {
+            groupChatRoomService.activateChatOnFirstMessage(room);
+        }
+        scheduleBroadcastAfterCommit(toPayload(saved), roomId);
     }
 
     private void checkSenderIsMember(Long senderUserId, Long roomId) {
@@ -74,6 +108,22 @@ public class ChatMessageSendService {
 
     private ChatMessageBroadcastPayload toPayload(ChatMessage saved) {
         Post post = saved.getRoom().getPost();
+
+        if (saved.getMessageType() == ChatMessageType.SYSTEM) {
+            return new ChatMessageBroadcastPayload(
+                    saved.getId(),
+                    saved.getRoom().getId(),
+                    post.getTitle(),
+                    post.getRecruitCount(),
+                    post.getRecruitCapacity(),
+                    saved.getMessageType(),
+                    null,
+                    null,
+                    chatSystemMessageFactory.deserialize(saved.getContent()),
+                    saved.getCreatedAt()
+            );
+        }
+
         User sender = requireSender(saved);
 
         return new ChatMessageBroadcastPayload(
@@ -84,6 +134,8 @@ public class ChatMessageSendService {
                 post.getRecruitCapacity(),
                 saved.getMessageType(),
                 ChatMessageSenderPayload.from(sender, post.getUser().getId(), profileImageResolver),
+                ChatUserMessagePayload.from(saved.getMessageType(), saved.getContent()),
+                null,
                 saved.getCreatedAt()
         );
     }

--- a/src/main/java/com/dduru/gildongmu/chat/service/ChatMessageSendService.java
+++ b/src/main/java/com/dduru/gildongmu/chat/service/ChatMessageSendService.java
@@ -6,6 +6,7 @@ import com.dduru.gildongmu.chat.domain.ChatRoom;
 import com.dduru.gildongmu.chat.domain.enums.ChatMessageType;
 import com.dduru.gildongmu.chat.domain.enums.ChatRoomStatus;
 import com.dduru.gildongmu.chat.dto.ws.ChatMessageBroadcastPayload;
+import com.dduru.gildongmu.chat.dto.ws.ChatMessageSenderPayload;
 import com.dduru.gildongmu.chat.dto.ws.ChatMessageSendRequest;
 import com.dduru.gildongmu.chat.exception.ChatAccessDeniedException;
 import com.dduru.gildongmu.chat.exception.ChatRoomClosedException;
@@ -45,7 +46,7 @@ public class ChatMessageSendService {
         validateRoomOpen(room);
         checkSenderIsMember(senderUserId, roomId);
 
-        User sender = userRepository.getByIdOrThrow(senderUserId);
+        User sender = userRepository.getWithProfileByIdOrThrow(senderUserId);
         String content = resolveUserMessageContent(request);
         saveUserMessageAndMaybeActivate(room, sender, request.messageType(), content);
     }
@@ -73,6 +74,7 @@ public class ChatMessageSendService {
 
     private ChatMessageBroadcastPayload toPayload(ChatMessage saved) {
         Post post = saved.getRoom().getPost();
+        User sender = requireSender(saved);
 
         return new ChatMessageBroadcastPayload(
                 saved.getId(),
@@ -81,9 +83,17 @@ public class ChatMessageSendService {
                 post.getRecruitCount(),
                 post.getRecruitCapacity(),
                 saved.getMessageType(),
-                null,
+                ChatMessageSenderPayload.from(sender, post.getUser().getId(), profileImageResolver),
                 saved.getCreatedAt()
         );
+    }
+
+    private static User requireSender(ChatMessage saved) {
+        User sender = saved.getSender();
+        if (sender == null) {
+            throw new IllegalStateException("사용자 메시지에는 sender가 필요합니다.");
+        }
+        return sender;
     }
 
     private static String resolveUserMessageContent(ChatMessageSendRequest request) {

--- a/src/main/java/com/dduru/gildongmu/chat/service/ChatMessageSendService.java
+++ b/src/main/java/com/dduru/gildongmu/chat/service/ChatMessageSendService.java
@@ -105,16 +105,7 @@ public class ChatMessageSendService {
             return ChatMessageBroadcastPayload.ofSystemMessage(message, post, chatSystemMessageFactory);
         }
 
-        User sender = requireSender(message.getSender());
-
-        return ChatMessageBroadcastPayload.ofUserMessage(message, post, sender, profileImageResolver);
-    }
-
-    private static User requireSender(User sender) {
-        if (sender == null) {
-            throw new IllegalStateException("사용자 메시지에는 sender가 필요합니다.");
-        }
-        return sender;
+        return ChatMessageBroadcastPayload.ofUserMessage(message, post, message.getSender(), profileImageResolver);
     }
 
     private static String resolveUserMessageContent(ChatMessageSendRequest request) {

--- a/src/main/java/com/dduru/gildongmu/chat/service/GroupChatRoomService.java
+++ b/src/main/java/com/dduru/gildongmu/chat/service/GroupChatRoomService.java
@@ -85,8 +85,7 @@ public class GroupChatRoomService {
     /**
      * 해당 방에 첫 메시지가 저장된 직후 호출하면 PENDING → ACTIVE 로 전환한다.
      */
-    public void activateChatOnFirstMessage(Long roomId) {
-        ChatRoom room = chatRoomRepository.getByIdOrThrow(roomId);
+    public static void activateChatOnFirstMessage(ChatRoom room) {
         if (room.getRoomType() != ChatRoomType.GROUP) {
             return;
         }

--- a/src/main/java/com/dduru/gildongmu/chat/service/GroupChatRoomService.java
+++ b/src/main/java/com/dduru/gildongmu/chat/service/GroupChatRoomService.java
@@ -16,8 +16,8 @@ import com.dduru.gildongmu.chat.repository.ChatRoomRepository;
 import com.dduru.gildongmu.post.domain.Post;
 import com.dduru.gildongmu.user.domain.User;
 import com.dduru.gildongmu.user.repository.UserRepository;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -31,13 +31,25 @@ import org.springframework.transaction.annotation.Transactional;
  */
 @Slf4j
 @Service
-@RequiredArgsConstructor
 @Transactional
 public class GroupChatRoomService {
 
     private final ChatRoomRepository chatRoomRepository;
     private final ChatRoomMemberRepository chatRoomMemberRepository;
     private final UserRepository userRepository;
+    private final ChatMessageSendService chatMessageSendService;
+
+    public GroupChatRoomService(
+            ChatRoomRepository chatRoomRepository,
+            ChatRoomMemberRepository chatRoomMemberRepository,
+            UserRepository userRepository,
+            @Lazy ChatMessageSendService chatMessageSendService
+    ) {
+        this.chatRoomRepository = chatRoomRepository;
+        this.chatRoomMemberRepository = chatRoomMemberRepository;
+        this.userRepository = userRepository;
+        this.chatMessageSendService = chatMessageSendService;
+    }
 
     public GroupChatInviteMemberResponse inviteMemberOrGetRoom(Long userId, Long roomId, GroupChatInviteRequest request) {
         ChatRoom chatRoom = chatRoomRepository.getByIdAndRoomTypeWithLockOrThrow(roomId, ChatRoomType.GROUP);
@@ -65,6 +77,9 @@ public class GroupChatRoomService {
 
         validateRoomCapacity(chatRoom);
         boolean invited = saveInvitee(chatRoom, invitee);
+        if (invited) {
+            chatMessageSendService.publishUserInvited(chatRoom.getId(), invitee.getId(), userId);
+        }
 
         return new GroupChatInviteMemberResponse(chatRoom.getId(), invited);
     }

--- a/src/main/java/com/dduru/gildongmu/chat/service/GroupChatRoomService.java
+++ b/src/main/java/com/dduru/gildongmu/chat/service/GroupChatRoomService.java
@@ -16,8 +16,8 @@ import com.dduru.gildongmu.chat.repository.ChatRoomRepository;
 import com.dduru.gildongmu.post.domain.Post;
 import com.dduru.gildongmu.user.domain.User;
 import com.dduru.gildongmu.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.context.annotation.Lazy;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -32,24 +32,13 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 @Service
 @Transactional
+@RequiredArgsConstructor
 public class GroupChatRoomService {
 
     private final ChatRoomRepository chatRoomRepository;
     private final ChatRoomMemberRepository chatRoomMemberRepository;
     private final UserRepository userRepository;
     private final ChatMessageSendService chatMessageSendService;
-
-    public GroupChatRoomService(
-            ChatRoomRepository chatRoomRepository,
-            ChatRoomMemberRepository chatRoomMemberRepository,
-            UserRepository userRepository,
-            @Lazy ChatMessageSendService chatMessageSendService
-    ) {
-        this.chatRoomRepository = chatRoomRepository;
-        this.chatRoomMemberRepository = chatRoomMemberRepository;
-        this.userRepository = userRepository;
-        this.chatMessageSendService = chatMessageSendService;
-    }
 
     public GroupChatInviteMemberResponse inviteMemberOrGetRoom(Long userId, Long roomId, GroupChatInviteRequest request) {
         ChatRoom chatRoom = chatRoomRepository.getByIdAndRoomTypeWithLockOrThrow(roomId, ChatRoomType.GROUP);
@@ -69,7 +58,7 @@ public class GroupChatRoomService {
 
         validateHostAuthority(chatRoom.getPost().getUser().getId(), userId);
         validateNotSelfChat(userId, inviteeUserId);
-        validateRoomIsActive(chatRoom);
+        validateRoomOpen(chatRoom);
 
         if (isAlreadyMember(chatRoom, inviteeUserId)) {
             return new GroupChatInviteMemberResponse(chatRoom.getId(), false);
@@ -78,7 +67,7 @@ public class GroupChatRoomService {
         validateRoomCapacity(chatRoom);
         boolean invited = saveInvitee(chatRoom, invitee);
         if (invited) {
-            chatMessageSendService.publishUserInvited(chatRoom.getId(), invitee.getId(), userId);
+            chatMessageSendService.publishUserInvited(chatRoom, invitee.getId(), userId);
         }
 
         return new GroupChatInviteMemberResponse(chatRoom.getId(), invited);
@@ -97,17 +86,7 @@ public class GroupChatRoomService {
         log.info("그룹 채팅방 생성 - roomId={}, postId={}, hostId={}", room.getId(), post.getId(), author.getId());
     }
 
-    /**
-     * 해당 방에 첫 메시지가 저장된 직후 호출하면 PENDING → ACTIVE 로 전환한다.
-     */
-    public static void activateChatOnFirstMessage(ChatRoom room) {
-        if (room.getRoomType() != ChatRoomType.GROUP) {
-            return;
-        }
-        room.activateIfPending();
-    }
-
-    private static void validateRoomIsActive(ChatRoom room) {
+    private static void validateRoomOpen(ChatRoom room) {
         if (room.getStatus() == ChatRoomStatus.CLOSED || room.getStatus() == ChatRoomStatus.DELETED) {
             throw new ChatRoomClosedException();
         }

--- a/src/main/java/com/dduru/gildongmu/chat/system/ChatSystemMessageFactory.java
+++ b/src/main/java/com/dduru/gildongmu/chat/system/ChatSystemMessageFactory.java
@@ -1,0 +1,51 @@
+package com.dduru.gildongmu.chat.system;
+
+import com.dduru.gildongmu.chat.dto.ws.ChatSystemMessagePayload;
+import com.dduru.gildongmu.common.exception.JsonConvertException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ChatSystemMessageFactory {
+
+    private final ObjectMapper objectMapper;
+
+    public ChatSystemMessagePayload userInvited(long inviteeUserId, long actorUserId) {
+        return ChatSystemMessagePayload.userInvited(inviteeUserId, actorUserId);
+    }
+
+    public ChatSystemMessagePayload userLeft(long userId) {
+        return ChatSystemMessagePayload.userLeft(userId);
+    }
+
+    public ChatSystemMessagePayload userKicked(long targetUserId, long actorUserId) {
+        return ChatSystemMessagePayload.userKicked(targetUserId, actorUserId);
+    }
+
+    public ChatSystemMessagePayload roomClosed() {
+        return ChatSystemMessagePayload.roomClosed();
+    }
+
+    public String serialize(ChatSystemMessagePayload payload) {
+        try {
+            return objectMapper.writeValueAsString(payload);
+        } catch (JsonProcessingException e) {
+            log.error("시스템 메시지 직렬화 실패 - payload={}", payload, e);
+            throw new JsonConvertException();
+        }
+    }
+
+    public ChatSystemMessagePayload deserialize(String content) {
+        try {
+            return objectMapper.readValue(content, ChatSystemMessagePayload.class);
+        } catch (JsonProcessingException e) {
+            log.error("시스템 메시지 역직렬화 실패 - content={}", content, e);
+            throw new JsonConvertException();
+        }
+    }
+}

--- a/src/main/java/com/dduru/gildongmu/chat/system/ChatSystemMessageType.java
+++ b/src/main/java/com/dduru/gildongmu/chat/system/ChatSystemMessageType.java
@@ -1,0 +1,8 @@
+package com.dduru.gildongmu.chat.system;
+
+public enum ChatSystemMessageType {
+    USER_INVITED,
+    USER_LEFT,
+    USER_KICKED,
+    ROOM_CLOSED
+}

--- a/src/main/java/com/dduru/gildongmu/chat/validation/ChatImageUrlValidator.java
+++ b/src/main/java/com/dduru/gildongmu/chat/validation/ChatImageUrlValidator.java
@@ -1,0 +1,42 @@
+package com.dduru.gildongmu.chat.validation;
+
+import com.dduru.gildongmu.chat.constants.ChatMessageConstants;
+import com.dduru.gildongmu.chat.exception.InvalidChatImageUrlException;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class ChatImageUrlValidator {
+
+    /**
+     * 채팅 이미지 URL 검증: 비어 있지 않고, 길이 제한 내이며, 절대 URI이고 스킴은 https 만 허용한다.
+     */
+    public static String validateAndNormalize(String raw) {
+        if (raw == null) {
+            throw InvalidChatImageUrlException.missing();
+        }
+        String url = raw.trim();
+        if (url.isEmpty()) {
+            throw InvalidChatImageUrlException.blank();
+        }
+        if (url.length() > ChatMessageConstants.MAX_IMAGE_URL_LENGTH) {
+            throw InvalidChatImageUrlException.tooLong();
+        }
+        URI uri;
+        try {
+            uri = new URI(url);
+        } catch (URISyntaxException e) {
+            throw InvalidChatImageUrlException.invalidFormat();
+        }
+        if (!uri.isAbsolute()) {
+            throw InvalidChatImageUrlException.notAbsolute();
+        }
+        if (uri.getScheme() == null || !"https".equalsIgnoreCase(uri.getScheme())) {
+            throw InvalidChatImageUrlException.nonHttpsScheme();
+        }
+        return url;
+    }
+}

--- a/src/main/java/com/dduru/gildongmu/chat/validation/ChatTextValidator.java
+++ b/src/main/java/com/dduru/gildongmu/chat/validation/ChatTextValidator.java
@@ -1,0 +1,25 @@
+package com.dduru.gildongmu.chat.validation;
+
+import com.dduru.gildongmu.chat.constants.ChatMessageConstants;
+import com.dduru.gildongmu.chat.exception.InvalidChatTextException;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class ChatTextValidator {
+
+    public static String validateAndNormalize(String raw) {
+        if (raw == null) {
+            throw InvalidChatTextException.missing();
+        }
+
+        String text = raw.trim();
+        if (text.isEmpty()) {
+            throw InvalidChatTextException.blank();
+        }
+        if (text.length() > ChatMessageConstants.MAX_TEXT_LENGTH) {
+            throw InvalidChatTextException.tooLong();
+        }
+        return text;
+    }
+}

--- a/src/main/java/com/dduru/gildongmu/common/config/WebSocketStompConfig.java
+++ b/src/main/java/com/dduru/gildongmu/common/config/WebSocketStompConfig.java
@@ -30,7 +30,7 @@ public class WebSocketStompConfig implements WebSocketMessageBrokerConfigurer {
     public void configureMessageBroker(MessageBrokerRegistry registry) {
         // 단일 인스턴스 기준 기본 브로커. 확장 시 broker relay 또는 Redis 기반 fan-out으로 교체한다.
         registry.enableSimpleBroker("/topic", "/queue");
-        registry.setApplicationDestinationPrefixes("/pub");
+        registry.setApplicationDestinationPrefixes("/app");
         registry.setUserDestinationPrefix("/user");
     }
 

--- a/src/main/java/com/dduru/gildongmu/common/exception/ErrorCode.java
+++ b/src/main/java/com/dduru/gildongmu/common/exception/ErrorCode.java
@@ -113,7 +113,17 @@ public enum ErrorCode {
     CHAT_ROOM_INVITE_ACCESS_DENIED(HttpStatus.FORBIDDEN, "게시글 작성자만 그룹 채팅 멤버를 추가할 수 있습니다."),
     GROUP_CHAT_ALREADY_MEMBER(HttpStatus.BAD_REQUEST, "이미 그룹 채팅방의 멤버입니다."),
 
-    ;
+    // 채팅 메세지 (CHAT MESSAGE)
+    CHAT_TEXT_REQUIRED(HttpStatus.BAD_REQUEST, "메시지 내용은 필수입니다."),
+    CHAT_TEXT_BLANK(HttpStatus.BAD_REQUEST, "공백만 있는 메시지는 전송할 수 없습니다."),
+    CHAT_TEXT_TOO_LONG(HttpStatus.BAD_REQUEST, "메시지가 너무 깁니다."),
+    CHAT_IMAGE_URL_REQUIRED(HttpStatus.BAD_REQUEST, "이미지 URL은 필수입니다."),
+    CHAT_IMAGE_URL_BLANK(HttpStatus.BAD_REQUEST, "이미지 URL은 비어 있을 수 없습니다."),
+    CHAT_IMAGE_URL_TOO_LONG(HttpStatus.BAD_REQUEST, "이미지 URL이 너무 깁니다."),
+    CHAT_IMAGE_URL_INVALID_FORMAT(HttpStatus.BAD_REQUEST, "이미지 URL 형식이 올바르지 않습니다."),
+    CHAT_IMAGE_URL_NOT_ABSOLUTE(HttpStatus.BAD_REQUEST, "이미지 URL은 절대 경로(https)여야 합니다."),
+    CHAT_IMAGE_URL_INVALID_SCHEME(HttpStatus.BAD_REQUEST, "이미지 URL은 https 만 허용됩니다."),
+    CHAT_SYSTEM_MESSAGE_SEND_ACCESS_DENIED(HttpStatus.BAD_REQUEST, "SYSTEM 은 사용자 메시지로 처리되지 않습니다.");
 
     private final int status;
     private final String message;

--- a/src/main/java/com/dduru/gildongmu/common/websocket/StompErrorHandler.java
+++ b/src/main/java/com/dduru/gildongmu/common/websocket/StompErrorHandler.java
@@ -6,6 +6,9 @@ import com.dduru.gildongmu.common.exception.ErrorData;
 import com.dduru.gildongmu.common.exception.ErrorResponse;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.lang.Nullable;
@@ -19,9 +22,12 @@ import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.stereotype.Component;
 import org.springframework.util.MimeTypeUtils;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.socket.messaging.StompSubProtocolErrorHandler;
 
 import java.nio.charset.StandardCharsets;
+import java.util.stream.Stream;
 
 @Slf4j
 @Component
@@ -56,6 +62,18 @@ public class StompErrorHandler extends StompSubProtocolErrorHandler {
         if (throwable instanceof BusinessException businessException) {
             return ErrorResponse.of(businessException.getErrorCode(), businessException.getMessage());
         }
+        if (throwable instanceof MethodArgumentNotValidException validationException) {
+            return fromMethodArgumentNotValid(validationException);
+        }
+        if (throwable instanceof ConstraintViolationException constraintViolationException) {
+            return fromConstraintViolation(constraintViolationException);
+        }
+        if (throwable instanceof InvalidFormatException invalidFormatException) {
+            return fromInvalidFormat(invalidFormatException);
+        }
+        if (throwable instanceof JsonProcessingException) {
+            return ErrorResponse.of(ErrorCode.INVALID_INPUT_VALUE, "요청 본문 형식이 올바르지 않습니다.");
+        }
         if (isAuthenticationFailure(throwable)) {
             return ErrorResponse.of(ErrorCode.UNAUTHORIZED, WEBSOCKET_AUTH_REQUIRED_MESSAGE);
         }
@@ -64,6 +82,56 @@ public class StompErrorHandler extends StompSubProtocolErrorHandler {
         }
         log.error("WebSocket 처리 중 예외 발생", throwable);
         return ErrorResponse.of(ErrorCode.INTERNAL_SERVER_ERROR, WEBSOCKET_PROCESSING_ERROR_MESSAGE);
+    }
+
+    private ErrorResponse fromMethodArgumentNotValid(MethodArgumentNotValidException exception) {
+        FieldError fieldError = exception.getBindingResult().getFieldErrors().stream()
+                .findFirst()
+                .orElse(null);
+        if (fieldError == null) {
+            return ErrorResponse.of(ErrorCode.INVALID_INPUT_VALUE, "잘못된 요청입니다.");
+        }
+        return ErrorResponse.ofField(
+                ErrorCode.INVALID_INPUT_VALUE,
+                fieldError.getField(),
+                fieldError.getDefaultMessage()
+        );
+    }
+
+    private ErrorResponse fromConstraintViolation(ConstraintViolationException exception) {
+        ConstraintViolation<?> violation = exception.getConstraintViolations().stream()
+                .findFirst()
+                .orElse(null);
+
+        String field = null;
+        String message = "잘못된 요청입니다.";
+        if (violation != null) {
+            String path = violation.getPropertyPath().toString();
+            field = path.contains(".") ? path.substring(path.lastIndexOf('.') + 1) : path;
+            message = violation.getMessage();
+        }
+        return ErrorResponse.ofField(ErrorCode.INVALID_INPUT_VALUE, field, message);
+    }
+
+    private ErrorResponse fromInvalidFormat(InvalidFormatException exception) {
+        String fieldName = exception.getPath().isEmpty()
+                ? "request"
+                : exception.getPath().get(exception.getPath().size() - 1).getFieldName();
+
+        String message;
+        if (exception.getTargetType().isEnum()) {
+            String allowed = Stream.of(exception.getTargetType().getEnumConstants())
+                    .map(Object::toString)
+                    .reduce((a, b) -> a + ", " + b)
+                    .orElse("");
+            message = String.format("%s은(는) [%s] 중 하나여야 합니다. 받은 값: %s",
+                    fieldName, allowed, exception.getValue());
+        } else {
+            message = String.format("필드 '%s'의 값 '%s' 형식이 올바르지 않습니다.",
+                    fieldName, exception.getValue());
+        }
+
+        return ErrorResponse.ofField(ErrorCode.INVALID_INPUT_VALUE, fieldName, message);
     }
 
     private byte[] serialize(ErrorResponse errorResponse) {

--- a/src/main/java/com/dduru/gildongmu/user/repository/UserRepository.java
+++ b/src/main/java/com/dduru/gildongmu/user/repository/UserRepository.java
@@ -27,6 +27,11 @@ public interface UserRepository extends JpaRepository<User, Long> {
     @Query("SELECT u FROM User u LEFT JOIN FETCH u.profile WHERE u.id = :id")
     Optional<User> findWithProfileById(@Param("id") Long id);
 
+    default User getWithProfileByIdOrThrow(Long id) {
+        return findWithProfileById(id)
+                .orElseThrow(UserNotFoundException::new);
+    }
+
     default User getByIdOrThrow(Long id) {
         return findById(id)
                 .orElseThrow(UserNotFoundException::new);


### PR DESCRIPTION
## 🔎 작업 내용
* STOMP 메시지 발행 엔드포인트 추가: `/app/chat/rooms/{roomId}/messages`, 토픽 구독: `/topic/chat/rooms/{roomId}`
* 사용자 메시지 전송 로직 추가: 채팅방 상태/멤버 권한 검증 후 TEXT/IMAGE(content) 검증 및 DB 저장
* 저장된 메시지는 트랜잭션 `afterCommit` 이후에만 브로드캐스트하도록 처리(롤백 시 실시간 메시지 전송 방지)
* 브로드캐스트 payload 구조 추가: sender(프로필 이미지/host 여부) + userMessage/systemMessage 분리 전달
* 그룹 채팅 멤버 초대 성공 시 `USER_INVITED` 시스템 메시지 저장 및 동일 토픽 브로드캐스트 연동
* STOMP 입력 오류 응답 확장: Validation/Enum 형변환/JSON 파싱/인증 실패 등을 ERROR frame JSON으로 통일
* STOMP publish prefix를 `/pub` → `/app` 으로 변경
## ➕ 이슈 링크
* Closed #219

## 📸 스크린샷
<img width="1490" height="824" alt="스크린샷 2026-04-18 오후 8 15 48" src="https://github.com/user-attachments/assets/b1ff706e-ae35-421e-ae7f-122777a2ae5a" />


## 😎 리뷰 요구사항
> FE와의 인터페이스가 맞는지 확인 부탁드립니다.
> 특히 STOMP 목적지(`/app`, `/topic`)와 `ChatMessageBroadcastPayload`의 `userMessage/systemMessage` 스펙,
> 시스템 메시지(JSON content 저장/역직렬화) 흐름, `afterCommit` 브로드캐스트 방식 위주로 봐주세요.


## 🧑‍💻 예정 작업
- #220 

## 📝 체크리스트
- [x] 브랜치 이름은 `feat/개발내용` 형식으로 작성했는가?
- [x] 커밋 메시지는 `feat(scope): 커밋 내용` 형식으로 작성했는가?
- [x] 작업 전 Issue를 작성했는가?
- [x] `dev` 브랜치로 병합을 요청했는가?
- [x] 불필요한 주석과 공백은 제거했는가?
- [ ] 코드 리뷰어의 피드백을 반영했는가?
- [x] 테스트를 진행했는가?
- [ ] 테스트 코드를 작성했는가?
