### PR TITLE
feat: 채팅 이미지 Presigned URL 발급 API 추가

### DIFF
--- a/src/main/java/com/dduru/gildongmu/chat/exception/InvalidChatImageUrlException.java
+++ b/src/main/java/com/dduru/gildongmu/chat/exception/InvalidChatImageUrlException.java
@@ -32,4 +32,8 @@ public class InvalidChatImageUrlException extends BusinessException {
     public static InvalidChatImageUrlException nonHttpsScheme() {
         return new InvalidChatImageUrlException(ErrorCode.CHAT_IMAGE_URL_INVALID_SCHEME);
     }
+
+    public static InvalidChatImageUrlException notAllowed() {
+        return new InvalidChatImageUrlException(ErrorCode.CHAT_IMAGE_URL_NOT_ALLOWED);
+    }
 }

--- a/src/main/java/com/dduru/gildongmu/chat/service/ChatMessageSendService.java
+++ b/src/main/java/com/dduru/gildongmu/chat/service/ChatMessageSendService.java
@@ -41,6 +41,7 @@ public class ChatMessageSendService {
     private final ProfileImageResolver profileImageResolver;
     private final SimpMessagingTemplate simpMessagingTemplate;
     private final ChatSystemMessageFactory chatSystemMessageFactory;
+    private final ChatImageUrlValidator chatImageUrlValidator;
 
     public void sendUserMessage(Long senderUserId, Long roomId, ChatMessageSendRequest request) {
         ChatRoom room = chatRoomRepository.getByIdOrThrow(roomId);
@@ -108,10 +109,10 @@ public class ChatMessageSendService {
         return ChatMessageBroadcastPayload.ofUserMessage(message, post, message.getSender(), profileImageResolver);
     }
 
-    private static String resolveUserMessageContent(ChatMessageSendRequest request) {
+    private String resolveUserMessageContent(ChatMessageSendRequest request) {
         return switch (request.messageType()) {
             case TEXT -> ChatTextValidator.validateAndNormalize(request.content());
-            case IMAGE -> ChatImageUrlValidator.validateAndNormalize(request.content());
+            case IMAGE -> chatImageUrlValidator.validateAndNormalize(request.content());
             case SYSTEM -> throw new ChatSystemMessageSendAccessDeniedException();
         };
     }

--- a/src/main/java/com/dduru/gildongmu/chat/validation/ChatImageUrlValidator.java
+++ b/src/main/java/com/dduru/gildongmu/chat/validation/ChatImageUrlValidator.java
@@ -2,19 +2,28 @@ package com.dduru.gildongmu.chat.validation;
 
 import com.dduru.gildongmu.chat.constants.ChatMessageConstants;
 import com.dduru.gildongmu.chat.exception.InvalidChatImageUrlException;
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
+import com.dduru.gildongmu.common.config.S3Properties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.List;
+import java.util.Locale;
 
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
-public final class ChatImageUrlValidator {
+@Component
+@RequiredArgsConstructor
+public class ChatImageUrlValidator {
+
+    private static final String CHATS_PATH_PREFIX = "/chats/";
+    private static final List<String> ALLOWED_EXTENSIONS = List.of(".jpg", ".jpeg", ".png", ".gif");
+
+    private final S3Properties s3Properties;
 
     /**
-     * 채팅 이미지 URL 검증: 비어 있지 않고, 길이 제한 내이며, 절대 URI이고 스킴은 https 만 허용한다.
+     * 채팅 이미지 URL 검증: 비어 있지 않고, 길이 제한 내이며, 앱이 발급한 chats 경로의 https URL만 허용한다.
      */
-    public static String validateAndNormalize(String raw) {
+    public String validateAndNormalize(String raw) {
         if (raw == null) {
             throw InvalidChatImageUrlException.missing();
         }
@@ -37,6 +46,30 @@ public final class ChatImageUrlValidator {
         if (uri.getScheme() == null || !"https".equalsIgnoreCase(uri.getScheme())) {
             throw InvalidChatImageUrlException.nonHttpsScheme();
         }
+        if (!isAllowedChatImageUri(uri)) {
+            throw InvalidChatImageUrlException.notAllowed();
+        }
         return url;
+    }
+
+    private boolean isAllowedChatImageUri(URI uri) {
+        if (uri.getRawQuery() != null || uri.getRawFragment() != null) {
+            return false;
+        }
+        if (uri.getHost() == null || !expectedHost().equalsIgnoreCase(uri.getHost())) {
+            return false;
+        }
+
+        String path = uri.getPath();
+        if (path == null || !path.startsWith(CHATS_PATH_PREFIX) || path.length() == CHATS_PATH_PREFIX.length()) {
+            return false;
+        }
+
+        String lowerPath = path.toLowerCase(Locale.ROOT);
+        return ALLOWED_EXTENSIONS.stream().anyMatch(lowerPath::endsWith);
+    }
+
+    private String expectedHost() {
+        return "%s.s3.%s.amazonaws.com".formatted(s3Properties.getBucket(), s3Properties.getRegion());
     }
 }

--- a/src/main/java/com/dduru/gildongmu/common/exception/ErrorCode.java
+++ b/src/main/java/com/dduru/gildongmu/common/exception/ErrorCode.java
@@ -13,6 +13,7 @@ public enum ErrorCode {
     NOT_FOUND(HttpStatus.NOT_FOUND, "요청한 리소스를 찾을 수 없습니다."),
     ACCESS_DENIED(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
     METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "지원하지 않는 HTTP 메서드입니다."),
+    UNSUPPORTED_MEDIA_TYPE(HttpStatus.UNSUPPORTED_MEDIA_TYPE, "지원하지 않는 Content-Type입니다."),
 
     // 인증 (AUTH)
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않거나 만료된 인증 토큰입니다."),

--- a/src/main/java/com/dduru/gildongmu/common/exception/ErrorCode.java
+++ b/src/main/java/com/dduru/gildongmu/common/exception/ErrorCode.java
@@ -124,6 +124,7 @@ public enum ErrorCode {
     CHAT_IMAGE_URL_INVALID_FORMAT(HttpStatus.BAD_REQUEST, "이미지 URL 형식이 올바르지 않습니다."),
     CHAT_IMAGE_URL_NOT_ABSOLUTE(HttpStatus.BAD_REQUEST, "이미지 URL은 절대 경로(https)여야 합니다."),
     CHAT_IMAGE_URL_INVALID_SCHEME(HttpStatus.BAD_REQUEST, "이미지 URL은 https 만 허용됩니다."),
+    CHAT_IMAGE_URL_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "채팅 이미지는 업로드된 chats 경로 URL만 허용됩니다."),
     CHAT_SYSTEM_MESSAGE_SEND_ACCESS_DENIED(HttpStatus.BAD_REQUEST, "SYSTEM 은 사용자 메시지로 처리되지 않습니다.");
 
     private final int status;

--- a/src/main/java/com/dduru/gildongmu/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/dduru/gildongmu/common/exception/GlobalExceptionHandler.java
@@ -5,9 +5,11 @@ import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.FieldError;
+import org.springframework.web.HttpMediaTypeNotSupportedException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -120,6 +122,21 @@ public class GlobalExceptionHandler {
         String message = "지원하지 않는 HTTP 메서드입니다: " + e.getMethod();
         ErrorResponse response = ErrorResponse.of(ErrorCode.METHOD_NOT_ALLOWED, message);
         return ResponseEntity.status(ErrorCode.METHOD_NOT_ALLOWED.getStatus()).body(response);
+    }
+
+    @ExceptionHandler(HttpMediaTypeNotSupportedException.class)
+    public ResponseEntity<ErrorResponse> handleMediaTypeNotSupportedException(HttpMediaTypeNotSupportedException e) {
+        log.warn("Media Type Not Supported: {}", e.getMessage());
+
+        String contentType = e.getContentType() == null ? "unknown" : e.getContentType().toString();
+        String supportedTypes = e.getSupportedMediaTypes().stream()
+                .map(MediaType::toString)
+                .reduce((a, b) -> a + ", " + b)
+                .orElse(MediaType.APPLICATION_JSON_VALUE);
+        String message = "지원하지 않는 Content-Type입니다: %s. 지원 형식: %s".formatted(contentType, supportedTypes);
+
+        ErrorResponse response = ErrorResponse.of(ErrorCode.UNSUPPORTED_MEDIA_TYPE, message);
+        return ResponseEntity.status(ErrorCode.UNSUPPORTED_MEDIA_TYPE.getStatus()).body(response);
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/java/com/dduru/gildongmu/s3/controller/S3ApiDocs.java
+++ b/src/main/java/com/dduru/gildongmu/s3/controller/S3ApiDocs.java
@@ -1,7 +1,7 @@
-package com.dduru.gildongmu.S3.controller;
+package com.dduru.gildongmu.s3.controller;
 
-import com.dduru.gildongmu.S3.dto.request.ImageUploadRequest;
-import com.dduru.gildongmu.S3.dto.response.ImageUploadResponse;
+import com.dduru.gildongmu.s3.dto.request.ImageUploadRequest;
+import com.dduru.gildongmu.s3.dto.response.ImageUploadResponse;
 import com.dduru.gildongmu.common.annotation.ApiErrorResponses;
 import com.dduru.gildongmu.common.dto.ApiResult;
 import com.dduru.gildongmu.common.exception.ErrorCode;

--- a/src/main/java/com/dduru/gildongmu/s3/controller/S3ApiDocs.java
+++ b/src/main/java/com/dduru/gildongmu/s3/controller/S3ApiDocs.java
@@ -27,7 +27,8 @@ public interface S3ApiDocs {
     @ApiResponse(responseCode = "200", description = "Presigned URL 생성 성공")
     @ApiErrorResponses({
             ErrorCode.INVALID_INPUT_VALUE,
-            ErrorCode.INVALID_FILE_EXTENSION
+            ErrorCode.INVALID_FILE_EXTENSION,
+            ErrorCode.UNSUPPORTED_MEDIA_TYPE
     })
     ResponseEntity<ApiResult<List<ImageUploadResponse>>> preparePostImageUpload(
             @RequestBody ImageUploadRequest request
@@ -43,7 +44,8 @@ public interface S3ApiDocs {
     @ApiResponse(responseCode = "200", description = "Presigned URL 생성 성공")
     @ApiErrorResponses({
             ErrorCode.INVALID_INPUT_VALUE,
-            ErrorCode.INVALID_FILE_EXTENSION
+            ErrorCode.INVALID_FILE_EXTENSION,
+            ErrorCode.UNSUPPORTED_MEDIA_TYPE
     })
     ResponseEntity<ApiResult<List<ImageUploadResponse>>> prepareProfileImageUpload(
             @Valid @RequestBody ImageUploadRequest request
@@ -62,4 +64,21 @@ public interface S3ApiDocs {
             ErrorCode.INVALID_FILE_EXTENSION
     })
     ResponseEntity<ApiResult<List<ImageUploadResponse>>> prepareSurveyImageUpload(@RequestBody ImageUploadRequest request);*/
+
+    @Operation(
+            summary = "채팅 이미지 업로드를 위한 Presigned URL 생성",
+            description = "채팅으로 보낸 사진을 S3에 직접 업로드하기 위한 Presigned URL을 생성합니다. "
+                    + "여러 파일을 한 번에 요청할 수 있습니다 (최대 10개). "
+                    + "파일명은 UUID로 변환되어 중복을 방지합니다. "
+                    + "클라이언트는 각 Presigned URL로 직접 S3에 업로드한 후, 받은 fileUrl을 채팅 IMAGE 메시지의 content로 전송합니다."
+    )
+    @ApiResponse(responseCode = "200", description = "Presigned URL 생성 성공")
+    @ApiErrorResponses({
+            ErrorCode.INVALID_INPUT_VALUE,
+            ErrorCode.INVALID_FILE_EXTENSION,
+            ErrorCode.UNSUPPORTED_MEDIA_TYPE
+    })
+    ResponseEntity<ApiResult<List<ImageUploadResponse>>> prepareChatImageUpload(
+            @Valid @RequestBody ImageUploadRequest request
+    );
 }

--- a/src/main/java/com/dduru/gildongmu/s3/controller/S3Controller.java
+++ b/src/main/java/com/dduru/gildongmu/s3/controller/S3Controller.java
@@ -48,4 +48,14 @@ public class S3Controller implements S3ApiDocs {
         List<ImageUploadResponse> responses = s3Service.prepareSurveyImageUpload(request.fileNames());
         return ResponseEntity.ok(ApiResult.ok(responses));
     }*/
+
+    @Override
+    @PostMapping("/chats/presigned-url")
+    public ResponseEntity<ApiResult<List<ImageUploadResponse>>> prepareChatImageUpload(
+            @Valid @RequestBody ImageUploadRequest request
+    ) {
+        List<ImageUploadResponse> responses = s3Service.prepareChatImageUpload(request.fileNames());
+        return ResponseEntity.ok(ApiResult.ok(responses));
+    }
+
 }

--- a/src/main/java/com/dduru/gildongmu/s3/controller/S3Controller.java
+++ b/src/main/java/com/dduru/gildongmu/s3/controller/S3Controller.java
@@ -1,8 +1,8 @@
-package com.dduru.gildongmu.S3.controller;
+package com.dduru.gildongmu.s3.controller;
 
-import com.dduru.gildongmu.S3.dto.request.ImageUploadRequest;
-import com.dduru.gildongmu.S3.dto.response.ImageUploadResponse;
-import com.dduru.gildongmu.S3.service.S3Service;
+import com.dduru.gildongmu.s3.dto.request.ImageUploadRequest;
+import com.dduru.gildongmu.s3.dto.response.ImageUploadResponse;
+import com.dduru.gildongmu.s3.service.S3Service;
 import com.dduru.gildongmu.common.dto.ApiResult;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/dduru/gildongmu/s3/dto/request/ImageUploadRequest.java
+++ b/src/main/java/com/dduru/gildongmu/s3/dto/request/ImageUploadRequest.java
@@ -1,4 +1,4 @@
-package com.dduru.gildongmu.S3.dto.request;
+package com.dduru.gildongmu.s3.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;

--- a/src/main/java/com/dduru/gildongmu/s3/dto/response/ImageUploadResponse.java
+++ b/src/main/java/com/dduru/gildongmu/s3/dto/response/ImageUploadResponse.java
@@ -1,4 +1,4 @@
-package com.dduru.gildongmu.S3.dto.response;
+package com.dduru.gildongmu.s3.dto.response;
 
 public record ImageUploadResponse(
         String presignedUrl,

--- a/src/main/java/com/dduru/gildongmu/s3/exception/InvalidFileExtensionException.java
+++ b/src/main/java/com/dduru/gildongmu/s3/exception/InvalidFileExtensionException.java
@@ -1,4 +1,4 @@
-package com.dduru.gildongmu.S3.exception;
+package com.dduru.gildongmu.s3.exception;
 
 import com.dduru.gildongmu.common.exception.BusinessException;
 import com.dduru.gildongmu.common.exception.ErrorCode;

--- a/src/main/java/com/dduru/gildongmu/s3/service/S3Service.java
+++ b/src/main/java/com/dduru/gildongmu/s3/service/S3Service.java
@@ -1,7 +1,7 @@
-package com.dduru.gildongmu.S3.service;
+package com.dduru.gildongmu.s3.service;
 
-import com.dduru.gildongmu.S3.dto.response.ImageUploadResponse;
-import com.dduru.gildongmu.S3.exception.InvalidFileExtensionException;
+import com.dduru.gildongmu.s3.dto.response.ImageUploadResponse;
+import com.dduru.gildongmu.s3.exception.InvalidFileExtensionException;
 import com.dduru.gildongmu.common.config.S3Properties;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/dduru/gildongmu/s3/service/S3Service.java
+++ b/src/main/java/com/dduru/gildongmu/s3/service/S3Service.java
@@ -29,25 +29,24 @@ public class S3Service {
     private static final List<String> ALLOWED_EXTENSIONS = Arrays.asList("jpg", "jpeg", "png", "gif");
     private static final String S3_POSTS_DIR = "posts/";
     private static final String S3_PROFILES_DIR = "profiles/";
+    private static final String S3_CHATS_DIR = "chats/";
     /*private static final String S3_SURVEY_DIR = "survey/";*/
     private static final Duration PRESIGNED_URL_TTL = Duration.ofMinutes(10);
 
     public List<ImageUploadResponse> preparePostImageUpload(List<String> fileNames) {
-        log.debug("Presigned URL 생성 시작(posts) - 파일 개수: {}", fileNames.size());
         List<ImageUploadResponse> responses = fileNames.stream()
                 .map(fileName -> prepareUploadInternal(fileName, S3_POSTS_DIR))
                 .toList();
-        log.debug("Presigned URL 생성 완료(posts) - 파일 개수: {}", responses.size());
+        log.info("Presigned URL 생성 완료{} 파일 개수: {}", S3_POSTS_DIR, responses.size());
         return responses;
     }
 
 
     public List<ImageUploadResponse> prepareProfileImageUpload(List<String> fileNames) {
-        log.debug("Presigned URL 생성 시작(profiles) - 파일 개수: {}", fileNames.size());
         List<ImageUploadResponse> responses = fileNames.stream()
                 .map(fileName -> prepareUploadInternal(fileName, S3_PROFILES_DIR))
                 .toList();
-        log.debug("Presigned URL 생성 완료{} 파일 개수: {}", S3_PROFILES_DIR, responses.size());
+        log.info("Presigned URL 생성 완료{} 파일 개수: {}", S3_PROFILES_DIR, responses.size());
         return responses;
     }
 
@@ -59,6 +58,15 @@ public class S3Service {
         log.info("Presigned URL 생성 완료(survey) - 파일 개수: {}", responses.size());
         return responses;
     }*/
+
+
+    public List<ImageUploadResponse> prepareChatImageUpload(List<String> fileNames) {
+        List<ImageUploadResponse> responses = fileNames.stream()
+                .map(fileName -> prepareUploadInternal(fileName, S3_CHATS_DIR))
+                .toList();
+        log.debug("Presigned URL 생성 완료{} 파일 개수: {}", S3_CHATS_DIR, responses.size());
+        return responses;
+    }
 
     private ImageUploadResponse prepareUploadInternal(String fileName, String directory) {
         validateFileExtension(fileName);

--- a/src/test/java/com/dduru/gildongmu/chat/validation/ChatImageUrlValidatorTest.java
+++ b/src/test/java/com/dduru/gildongmu/chat/validation/ChatImageUrlValidatorTest.java
@@ -1,0 +1,57 @@
+package com.dduru.gildongmu.chat.validation;
+
+import com.dduru.gildongmu.common.config.S3Properties;
+import com.dduru.gildongmu.common.exception.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("채팅 이미지 URL validator 테스트")
+class ChatImageUrlValidatorTest {
+
+    private ChatImageUrlValidator validator;
+
+    @BeforeEach
+    void setUp() {
+        S3Properties s3Properties = new S3Properties();
+        s3Properties.setBucket("dummy-bucket");
+        s3Properties.setRegion("ap-northeast-2");
+        validator = new ChatImageUrlValidator(s3Properties);
+    }
+
+    @Test
+    @DisplayName("우리 S3 chats 경로 URL이면 허용한다")
+    void validateAndNormalize_validChatS3Url_returnsUrl() {
+        String url = "https://dummy-bucket.s3.ap-northeast-2.amazonaws.com/chats/123e4567-e89b-12d3-a456-426614174000.JPG";
+
+        String result = validator.validateAndNormalize(url);
+
+        assertThat(result).isEqualTo(url);
+    }
+
+    @Test
+    @DisplayName("외부 호스트 URL이면 거부한다")
+    void validateAndNormalize_externalHost_throwsNotAllowed() {
+        assertThatThrownBy(() -> validator.validateAndNormalize("https://example.com/chats/test.jpg"))
+                .hasMessage(ErrorCode.CHAT_IMAGE_URL_NOT_ALLOWED.getMessage());
+    }
+
+    @Test
+    @DisplayName("S3 URL여도 chats 경로가 아니면 거부한다")
+    void validateAndNormalize_nonChatsPath_throwsNotAllowed() {
+        assertThatThrownBy(() -> validator.validateAndNormalize(
+                "https://dummy-bucket.s3.ap-northeast-2.amazonaws.com/profiles/test.jpg"))
+                .hasMessage(ErrorCode.CHAT_IMAGE_URL_NOT_ALLOWED.getMessage());
+    }
+
+    @Test
+    @DisplayName("presigned URL처럼 query가 포함되면 거부한다")
+    void validateAndNormalize_presignedUrlWithQuery_throwsNotAllowed() {
+        assertThatThrownBy(() -> validator.validateAndNormalize(
+                "https://dummy-bucket.s3.ap-northeast-2.amazonaws.com/chats/test.jpg?X-Amz-Signature=abc"))
+                .hasMessage(ErrorCode.CHAT_IMAGE_URL_NOT_ALLOWED.getMessage());
+    }
+}


### PR DESCRIPTION
## 🔎 작업 내용
* 채팅 이미지 업로드용 Presigned URL 발급 API를 추가했습니다.
* S3 업로드 경로를 `posts/`, `profiles/`, `chats/`로 분리하고 채팅 이미지는 `chats/` 경로의 최종 `fileUrl`을 반환하도록 했습니다.
* 채팅 `IMAGE` 메시지 content 검증을 강화해 서버가 발급한 S3 `chats/` 경로의 `https` URL만 허용하도록 했습니다.
* 지원하지 않는 Content-Type 요청에 대한 전역 예외 응답을 추가했습니다.
* 채팅 이미지 URL 검증 테스트를 추가했습니다.

## ➕ 이슈 링크
* Closed #220

## 📸 스크린샷


## 😎 리뷰 요구사항
> 채팅 이미지 메시지에서 `presignedUrl`이 아닌 최종 `fileUrl`만 허용하도록 `query` 포함 URL을 거부하는 정책이 클라이언트 연동 흐름과 맞는지 확인 부탁드립니다.

## 🧑‍💻 예정 작업
- #229 

## 📝 체크리스트
- [x] 브랜치 이름은 `feat/개발내용` 형식으로 작성했는가?
- [x] 커밋 메시지는 `feat(scope): 커밋 내용` 형식으로 작성했는가?
- [x] 작업 전 Issue를 작성했는가?
- [x] `dev` 브랜치로 병합을 요청했는가?
- [x] 불필요한 주석과 공백은 제거했는가?
- [ ] 코드 리뷰어의 피드백을 반영했는가?
- [x] 테스트를 진행했는가?
- [x] 테스트 코드를 작성했는가?
