### PR TITLE
채팅 메시지 읽음 처리 및 unreadCount 조회 반영

### DIFF
--- a/docs/api/CHAT_READ_RECEIPT_API.md
+++ b/docs/api/CHAT_READ_RECEIPT_API.md
@@ -1,0 +1,451 @@
+# Chat Read Receipt API Design
+
+## 1. API 개요
+
+채팅방 메시지 읽음 위치를 갱신하고, 메시지별 `unreadCount`를 계산하기 위한 설계 문서다.
+
+기본 정책:
+
+- 읽음 위치는 `chat_room_members.last_read_message_id`로 관리한다.
+- 읽음 처리는 "해당 메시지 ID 이하를 모두 읽음"으로 본다.
+- 읽음 위치는 뒤로 가지 않는다.
+- 채팅방 진입 시 클라이언트가 조회 응답의 마지막 `messageId`로 읽음 API를 호출한다.
+- 채팅방을 보고 있는 중 새 메시지를 받으면 클라이언트가 해당 `messageId`로 읽음 API를 호출한다.
+- 메시지를 보낸 사람은 본인이 보낸 메시지를 자동으로 읽은 것으로 처리한다.
+- 읽음 위치가 실제로 앞으로 이동한 경우에만 WebSocket 읽음 이벤트를 발행한다.
+- 채팅방 목록의 안 읽은 메시지 수는 이번 범위에서 제외한다.
+
+## 2. API 명세
+
+### Endpoint
+
+```http
+PATCH /api/v1/chat-rooms/{chatRoomId}/read
+```
+
+현재 채팅 REST API 규모에서는 기존 `ChatController`에 엔드포인트를 추가하고, 비즈니스 로직은 `ChatReadService`로 분리한다.
+
+### Path Variable
+
+| 이름 | 타입 | 필수 | 설명 |
+| --- | --- | --- | --- |
+| `chatRoomId` | `Long` | Y | 읽음 처리할 채팅방 ID |
+
+### Request Body
+
+```json
+{
+  "lastReadMessageId": 123
+}
+```
+
+| 이름 | 타입 | 필수 | 설명 |
+| --- | --- | --- | --- |
+| `lastReadMessageId` | `Long` | Y | 사용자가 마지막으로 읽은 메시지 ID |
+
+`lastReadMessageId`는 `TEXT`, `IMAGE`, `SYSTEM` 메시지 모두 허용한다. 이 값은 읽음 위치 커서이므로 메시지 타입과 무관하다.
+
+### Response
+
+```json
+{
+  "status": 200,
+  "data": {
+    "chatRoomId": 1,
+    "lastReadMessageId": 123,
+    "updated": true
+  }
+}
+```
+
+| 이름 | 타입 | 설명 |
+| --- | --- | --- |
+| `chatRoomId` | `Long` | 읽음 처리한 채팅방 ID |
+| `lastReadMessageId` | `Long` | 요청 후 최종 반영된 읽음 메시지 ID |
+| `updated` | `Boolean` | 읽음 위치가 실제로 앞으로 이동했는지 여부 |
+
+기존 읽음 위치보다 과거 또는 같은 메시지를 요청하면 에러를 내지 않고 `updated = false`로 응답한다.
+
+## 3. 요청/응답 예시
+
+### 채팅방 진입 후 읽음 처리
+
+1. 클라이언트가 메시지를 조회한다.
+2. 응답 메시지 중 가장 마지막 메시지 ID가 `200`이다.
+3. 렌더링 후 아래 API를 호출한다.
+
+```http
+PATCH /api/v1/chat-rooms/1/read
+Authorization: Bearer {accessToken}
+Content-Type: application/json
+```
+
+```json
+{
+  "lastReadMessageId": 200
+}
+```
+
+```json
+{
+  "status": 200,
+  "data": {
+    "chatRoomId": 1,
+    "lastReadMessageId": 200,
+    "updated": true
+  }
+}
+```
+
+### No-op 응답
+
+현재 사용자의 `last_read_message_id`가 이미 `200`인데 `150`을 요청한 경우:
+
+```json
+{
+  "status": 200,
+  "data": {
+    "chatRoomId": 1,
+    "lastReadMessageId": 200,
+    "updated": false
+  }
+}
+```
+
+## 4. 처리 흐름
+
+1. 인증된 사용자 ID를 `@CurrentUser`로 받는다.
+2. `chatRoomId`로 `ChatRoom`을 조회한다.
+3. 방이 없거나 `DELETED` 상태면 `CHAT_ROOM_NOT_FOUND`를 반환한다.
+4. 현재 사용자의 `ChatRoomMember`를 조회한다.
+5. 멤버 row가 없으면 `CHAT_ACCESS_DENIED`를 반환한다.
+6. 그룹 채팅방이면 `JourneyMember`가 `ACTIVE` 상태인지 추가 확인한다.
+7. `lastReadMessageId`에 해당하는 메시지를 조회한다.
+8. 메시지가 해당 채팅방에 속하지 않으면 `CHAT_MESSAGE_NOT_FOUND`를 반환한다.
+9. 메시지가 현재 사용자의 조회 가능 시점보다 이전이면 `CHAT_ACCESS_DENIED`를 반환한다.
+10. 현재 `last_read_message_id`가 요청 메시지 ID 이상이면 갱신하지 않고 `updated = false`를 반환한다.
+11. 요청 메시지가 더 최신이면 `chat_room_members.last_read_message_id`를 갱신한다.
+12. 트랜잭션 커밋 후 기존 채팅방 topic으로 READ 이벤트를 발행한다.
+13. `ApiResult.ok(response)`로 반환한다.
+
+조회 가능 시점은 현재 `ChatRoomMember.createdAt` 기준이다. 그룹 채팅방 신규 참여자와 재참여자는 참여 이후 메시지만 읽음 처리할 수 있다.
+
+## 5. 검증 조건
+
+### Request 검증
+
+- `lastReadMessageId`는 필수다.
+- `lastReadMessageId`는 양수여야 한다.
+- 요청 메시지는 해당 `chatRoomId`에 속해야 한다.
+- 요청 메시지는 현재 사용자가 볼 수 있는 메시지여야 한다.
+
+### 방 상태 검증
+
+- `ACTIVE`: 읽음 처리 가능
+- `CLOSED`: 읽음 처리 가능
+- `DELETED`: 읽음 처리 불가, `CHAT_ROOM_NOT_FOUND`
+
+`CLOSED` 방은 메시지 조회가 가능하므로 읽음 처리도 허용한다. 메시지 전송만 불가하다.
+
+### 권한 검증
+
+- 1:1 채팅방
+  - 현재 사용자가 `ChatRoomMember`에 존재해야 한다.
+- 그룹 채팅방
+  - 현재 사용자가 `ChatRoomMember`에 존재해야 한다.
+  - 현재 사용자가 해당 `Journey`의 `ACTIVE` 멤버여야 한다.
+- 나간 사용자 또는 내보내진 사용자는 현재 멤버 row가 없으므로 읽음 처리할 수 없다.
+
+### No-op 조건
+
+아래 경우는 에러가 아니다.
+
+- 현재 `last_read_message_id`와 같은 메시지를 요청
+- 현재 `last_read_message_id`보다 과거 메시지를 요청
+
+이 경우 읽음 위치는 변경하지 않고 `updated = false`로 응답한다. WebSocket READ 이벤트도 발행하지 않는다.
+
+## 6. 예외 처리
+
+기존 프로젝트의 `ErrorResponse` 포맷을 따른다.
+
+```json
+{
+  "status": 403,
+  "data": {
+    "errorCode": "CHAT_ACCESS_DENIED",
+    "field": null,
+    "message": "채팅방 접근 권한이 없습니다."
+  }
+}
+```
+
+주요 에러:
+
+| HTTP Status | ErrorCode | 발생 조건 |
+| --- | --- | --- |
+| `400` | `INVALID_INPUT_VALUE` | `lastReadMessageId`가 없거나 양수가 아님 |
+| `401` | `UNAUTHORIZED` | 인증되지 않은 사용자 |
+| `403` | `CHAT_ACCESS_DENIED` | 채팅방 멤버가 아니거나 볼 수 없는 메시지를 읽음 처리 요청 |
+| `404` | `CHAT_ROOM_NOT_FOUND` | 채팅방이 없거나 `DELETED` 상태 |
+| `404` | `CHAT_MESSAGE_NOT_FOUND` | 메시지가 없거나 해당 채팅방 메시지가 아님 |
+
+`lastReadMessageId`가 현재 사용자의 `visibleFrom` 이전 메시지이면 `CHAT_ACCESS_DENIED`를 반환한다. 존재 여부보다 접근 가능 여부가 핵심이기 때문이다.
+
+## 7. DB 및 도메인 설계
+
+### ChatRoomMember
+
+읽음 위치는 기존 컬럼을 사용한다.
+
+```text
+chat_room_members
+id
+room_id
+user_id
+role
+last_read_message_id nullable
+created_at
+modified_at
+```
+
+권장 도메인 메서드:
+
+```java
+public boolean readUpTo(ChatMessage message) {
+    if (lastReadMessage != null && lastReadMessage.getId() >= message.getId()) {
+        return false;
+    }
+    this.lastReadMessage = message;
+    return true;
+}
+```
+
+`readUpTo`는 읽음 위치가 앞으로 이동했는지 여부를 반환한다.
+
+### 메시지 전송자 자동 읽음 처리
+
+메시지를 보낸 사람은 본인이 보낸 메시지를 자동으로 읽은 것으로 처리한다.
+
+처리 위치:
+
+- `ChatMessageSendService.saveUserMessageAndBroadcast`
+- 메시지 저장 및 flush 후 sender의 `ChatRoomMember.lastReadMessage`를 방금 저장한 메시지로 갱신
+
+정책:
+
+- sender 자동 읽음 처리에는 별도 READ WebSocket 이벤트를 발행하지 않는다.
+- 추후 채팅방 목록 unread count를 구현할 때 sender가 자기 메시지를 안 읽은 것으로 계산되는 문제를 방지한다.
+
+### unreadCount 계산
+
+`ChatMessageRetrieve API`의 메시지별 `unreadCount`는 읽음 처리 구현 후 아래 기준으로 계산한다.
+
+대상 메시지:
+
+- `TEXT`
+- `IMAGE`
+
+제외 메시지:
+
+- `SYSTEM`: `unreadCount = null`
+
+계산 대상 멤버:
+
+- 현재 채팅방 멤버
+- 메시지 sender 제외
+- 메시지 생성 시점에 이미 참여 중인 멤버만 포함
+- 나간 사람/내보내진 사람 제외
+
+계산식:
+
+```text
+unreadCount =
+  count(chat_room_members)
+  where room_id = message.room_id
+    and user_id != message.sender_id
+    and created_at <= message.created_at
+    and (
+      last_read_message_id is null
+      or last_read_message_id < message.id
+    )
+```
+
+현재 설계는 "row 존재 = 현재 채팅방 멤버" 정책이므로, 나간 사람과 내보내진 사람은 자동으로 계산 대상에서 제외된다.
+
+## 8. 트랜잭션 설계
+
+읽음 처리 API는 쓰기 트랜잭션으로 처리한다.
+
+```java
+@Transactional
+public ChatReadResponse read(Long userId, Long roomId, ChatReadRequest request)
+```
+
+트랜잭션 내부:
+
+1. 채팅방 조회 및 상태 검증
+2. 멤버십 검증
+3. 메시지 조회 및 접근 가능 여부 검증
+4. `last_read_message_id` 갱신
+
+트랜잭션 커밋 후:
+
+- `updated = true`인 경우에만 WebSocket READ 이벤트 발행
+- 커밋 전 이벤트 발행 금지
+
+기존 `ChatMessageSendService`가 메시지 브로드캐스트를 `afterCommit`으로 처리하고 있으므로, 읽음 이벤트도 같은 방식으로 맞춘다.
+
+## 9. 보안 고려사항
+
+- 숫자 ID 기반 API이므로 `chatRoomId`, `lastReadMessageId` 모두 서버에서 소유 관계를 검증한다.
+- 다른 방의 메시지 ID로 읽음 처리할 수 없어야 한다.
+- 현재 사용자가 볼 수 없는 과거 메시지로 읽음 처리할 수 없어야 한다.
+- 그룹 채팅방은 `ChatRoomMember`뿐 아니라 `JourneyMember ACTIVE` 여부도 검증한다.
+- `DELETED` 방은 존재하지 않는 것처럼 처리한다.
+- `CLOSED` 방은 조회와 읽음 처리를 허용하되 전송은 금지한다.
+
+## 10. 성능 고려사항
+
+### 읽음 API
+
+- 단일 `ChatRoomMember` row 업데이트만 수행한다.
+- 같은 사용자가 같은 메시지로 여러 번 요청할 수 있으므로 no-op 경로가 가볍게 동작해야 한다.
+- 읽음 위치 갱신은 id 비교로 판단한다.
+
+### unreadCount 계산
+
+메시지 목록 조회 시 각 메시지마다 멤버 수를 별도 쿼리로 계산하면 N+1 문제가 발생한다.
+
+권장 방식:
+
+- 조회된 메시지 목록의 최소/최대 ID를 기준으로 현재 멤버들의 `last_read_message_id`, `created_at`을 한 번에 조회한다.
+- 애플리케이션 메모리에서 메시지별 `unreadCount`를 계산한다.
+- 그룹 규모가 커지고 메시지 수가 많아지면 QueryDSL 집계 쿼리 또는 read model을 검토한다.
+
+현재 예상 규모에서는 메시지 페이지 크기 최대 50개, 그룹 인원은 모집 정원 수준이므로 애플리케이션 계산이 단순하고 충분하다.
+
+## 11. 테스트 케이스
+
+### 읽음 API 성공 케이스
+
+- 현재 멤버가 최신 메시지 ID로 읽음 처리하면 `last_read_message_id`가 갱신된다.
+- 기존 읽음 위치보다 과거 메시지를 요청하면 `updated = false`를 반환한다.
+- 기존 읽음 위치와 같은 메시지를 요청하면 `updated = false`를 반환한다.
+- `SYSTEM` 메시지 ID로 읽음 처리를 요청해도 성공한다.
+- `CLOSED` 방에서도 읽음 처리가 가능하다.
+- `updated = true`인 경우 WebSocket READ 이벤트가 발행된다.
+- `updated = false`인 경우 WebSocket READ 이벤트가 발행되지 않는다.
+
+### 읽음 API 실패 케이스
+
+- 인증되지 않은 사용자는 `UNAUTHORIZED`를 반환한다.
+- 존재하지 않는 방은 `CHAT_ROOM_NOT_FOUND`를 반환한다.
+- `DELETED` 방은 `CHAT_ROOM_NOT_FOUND`를 반환한다.
+- 채팅방 멤버가 아닌 사용자는 `CHAT_ACCESS_DENIED`를 반환한다.
+- 그룹방의 `JourneyMember`가 `ACTIVE`가 아니면 `CHAT_ACCESS_DENIED`를 반환한다.
+- 다른 방 메시지 ID로 요청하면 `CHAT_MESSAGE_NOT_FOUND`를 반환한다.
+- 현재 사용자의 참여 시점 이전 메시지로 요청하면 `CHAT_ACCESS_DENIED`를 반환한다.
+- `lastReadMessageId`가 없거나 양수가 아니면 `INVALID_INPUT_VALUE`를 반환한다.
+
+### unreadCount 계산 케이스
+
+- 1:1에서 상대가 안 읽은 내 메시지는 `unreadCount = 1`이다.
+- 1:1에서 상대가 읽은 내 메시지는 `unreadCount = 0`이다.
+- 그룹 3명 중 sender를 제외한 2명 모두 안 읽으면 `unreadCount = 2`이다.
+- 그룹 3명 중 sender를 제외한 2명 중 1명만 읽으면 `unreadCount = 1`이다.
+- 그룹 신규 참여자는 참여 이전 메시지의 `unreadCount` 계산 대상이 아니다.
+- 나간 멤버는 `unreadCount` 계산 대상이 아니다.
+- `SYSTEM` 메시지는 `unreadCount = null`이다.
+
+### 메시지 전송자 자동 읽음 케이스
+
+- 사용자가 메시지를 보내면 sender의 `last_read_message_id`가 새 메시지로 갱신된다.
+- sender 자동 읽음 처리로 별도 READ 이벤트는 발행되지 않는다.
+
+## 12. 구현 체크리스트
+
+### Controller / Docs
+
+- `PATCH /api/v1/chat-rooms/{chatRoomId}/read` 추가
+- `ChatApiDocs` 또는 별도 API docs에 Swagger 문서 추가
+- `@ApiErrorResponses`에 `UNAUTHORIZED`, `INVALID_INPUT_VALUE`, `CHAT_ROOM_NOT_FOUND`, `CHAT_MESSAGE_NOT_FOUND`, `CHAT_ACCESS_DENIED` 반영
+
+### DTO
+
+- `ChatReadRequest`
+  - `lastReadMessageId`
+- `ChatReadResponse`
+  - `chatRoomId`
+  - `lastReadMessageId`
+  - `updated`
+- `ChatReadEventPayload`
+  - `eventType`
+  - `roomId`
+  - `readerUserId`
+  - `lastReadMessageId`
+  - `readAt`
+
+### Service
+
+- `ChatReadService` 추가
+- 채팅방 조회 및 `DELETED` 검증
+- 현재 `ChatRoomMember` 조회
+- 그룹방 `JourneyMember ACTIVE` 검증
+- 요청 메시지 조회 및 room 검증
+- `visibleFrom` 이전 메시지 접근 차단
+- `last_read_message_id` 갱신
+- `updated = true`일 때만 커밋 후 READ 이벤트 발행
+
+### WebSocket
+
+- 기존 destination 재사용
+
+```text
+/topic/chat/rooms/{chatRoomId}
+```
+
+- READ 이벤트 payload:
+
+```json
+{
+  "eventType": "READ",
+  "roomId": 1,
+  "readerUserId": 10,
+  "lastReadMessageId": 123,
+  "readAt": "2026-05-09T12:30:00"
+}
+```
+
+기존 메시지 브로드캐스트 payload에는 `eventType`이 없으므로, 클라이언트는 같은 topic에서 payload shape 또는 `eventType` 존재 여부로 READ 이벤트를 구분한다.
+
+### Domain / Repository
+
+- `ChatRoomMember.readUpTo(ChatMessage message)` 추가
+- `ChatRoomMemberRepository`
+  - `Optional<ChatRoomMember> findByRoomIdAndUserId(Long roomId, Long userId)`
+  - 메시지 조회 unreadCount 계산용 room members 조회 메서드
+- `ChatMessageRepository`
+  - `Optional<ChatMessage> findByIdAndRoomId(Long messageId, Long roomId)`
+- `JourneyMemberRepository`
+  - 기존 `existsByJourneyIdAndUserIdAndStatus(...)` 활용
+
+### Message Send 연동
+
+- `ChatMessageSendService`에서 user message 저장 후 sender 자동 읽음 처리 추가
+- sender 자동 읽음은 READ 이벤트를 발행하지 않음
+
+### Message Retrieve 연동
+
+- `ChatMessageRetrieve API`의 `unreadCount = null` 임시 정책 제거
+- `TEXT`, `IMAGE` 메시지에 `unreadCount` 계산 반영
+- `SYSTEM` 메시지는 `unreadCount = null` 유지
+
+### Tests
+
+- `ChatReadServiceTest`
+- `ChatReadControllerTest` 또는 통합 테스트
+- WebSocket READ 이벤트 발행 테스트
+- sender 자동 읽음 처리 테스트
+- 메시지 조회 `unreadCount` 계산 테스트
+

--- a/src/main/java/com/dduru/gildongmu/chat/controller/ChatApiDocs.java
+++ b/src/main/java/com/dduru/gildongmu/chat/controller/ChatApiDocs.java
@@ -1,7 +1,9 @@
 package com.dduru.gildongmu.chat.controller;
 
 import com.dduru.gildongmu.chat.dto.request.ChatMessageRetrieveRequest;
+import com.dduru.gildongmu.chat.dto.request.ChatReadRequest;
 import com.dduru.gildongmu.chat.dto.response.ChatMessagesResponse;
+import com.dduru.gildongmu.chat.dto.response.ChatReadResponse;
 import com.dduru.gildongmu.chat.dto.response.PrivateChatRoomCreateResponse;
 import com.dduru.gildongmu.common.annotation.ApiErrorResponses;
 import com.dduru.gildongmu.common.dto.ApiResult;
@@ -15,6 +17,7 @@ import jakarta.validation.Valid;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "Chat", description = "채팅 API")
 @SecurityRequirement(name = "JWT")
@@ -51,5 +54,23 @@ public interface ChatApiDocs {
             @Parameter(hidden = true) Long userId,
             @Parameter(description = "채팅방 ID", required = true) Long chatRoomId,
             @Valid @ParameterObject ChatMessageRetrieveRequest request
+    );
+
+    @Operation(
+            summary = "채팅방 메시지 읽음 처리",
+            description = "현재 사용자의 채팅방 읽음 위치를 lastReadMessageId까지 갱신합니다. 기존 읽음 위치보다 같거나 과거인 경우 updated=false로 응답합니다."
+    )
+    @ApiResponse(responseCode = "200", description = "읽음 처리 성공")
+    @ApiErrorResponses({
+            ErrorCode.UNAUTHORIZED,
+            ErrorCode.INVALID_INPUT_VALUE,
+            ErrorCode.CHAT_ROOM_NOT_FOUND,
+            ErrorCode.CHAT_MESSAGE_NOT_FOUND,
+            ErrorCode.CHAT_ACCESS_DENIED
+    })
+    ResponseEntity<ApiResult<ChatReadResponse>> readMessages(
+            @Parameter(hidden = true) Long userId,
+            @Parameter(description = "채팅방 ID", required = true) Long chatRoomId,
+            @Valid @RequestBody ChatReadRequest request
     );
 }

--- a/src/main/java/com/dduru/gildongmu/chat/controller/ChatController.java
+++ b/src/main/java/com/dduru/gildongmu/chat/controller/ChatController.java
@@ -1,9 +1,12 @@
 package com.dduru.gildongmu.chat.controller;
 
 import com.dduru.gildongmu.chat.dto.request.ChatMessageRetrieveRequest;
+import com.dduru.gildongmu.chat.dto.request.ChatReadRequest;
 import com.dduru.gildongmu.chat.dto.response.ChatMessagesResponse;
+import com.dduru.gildongmu.chat.dto.response.ChatReadResponse;
 import com.dduru.gildongmu.chat.dto.response.PrivateChatRoomCreateResponse;
 import com.dduru.gildongmu.chat.service.ChatMessageQueryService;
+import com.dduru.gildongmu.chat.service.ChatReadService;
 import com.dduru.gildongmu.chat.service.PrivateChatRoomService;
 import com.dduru.gildongmu.common.annotation.CurrentUser;
 import com.dduru.gildongmu.common.dto.ApiResult;
@@ -13,8 +16,10 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -25,6 +30,7 @@ public class ChatController implements ChatApiDocs {
 
     private final PrivateChatRoomService privateChatRoomService;
     private final ChatMessageQueryService chatMessageQueryService;
+    private final ChatReadService chatReadService;
 
     @Override
     @PostMapping("/posts/{postId}/chats/private")
@@ -47,6 +53,17 @@ public class ChatController implements ChatApiDocs {
             @Valid @ModelAttribute ChatMessageRetrieveRequest request
     ) {
         ChatMessagesResponse response = chatMessageQueryService.retrieveMessages(userId, chatRoomId, request);
+        return ResponseEntity.ok(ApiResult.ok(response));
+    }
+
+    @Override
+    @PatchMapping("/chat-rooms/{chatRoomId}/read")
+    public ResponseEntity<ApiResult<ChatReadResponse>> readMessages(
+            @CurrentUser Long userId,
+            @PathVariable Long chatRoomId,
+            @Valid @RequestBody ChatReadRequest request
+    ) {
+        ChatReadResponse response = chatReadService.read(userId, chatRoomId, request);
         return ResponseEntity.ok(ApiResult.ok(response));
     }
 }

--- a/src/main/java/com/dduru/gildongmu/chat/domain/ChatRoomMember.java
+++ b/src/main/java/com/dduru/gildongmu/chat/domain/ChatRoomMember.java
@@ -51,4 +51,13 @@ public class ChatRoomMember extends BaseTimeEntity {
                 .role(role)
                 .build();
     }
+
+    public boolean readUpTo(ChatMessage message) {
+        if (lastReadMessage != null && lastReadMessage.getId() >= message.getId()) {
+            return false;
+        }
+
+        this.lastReadMessage = message;
+        return true;
+    }
 }

--- a/src/main/java/com/dduru/gildongmu/chat/dto/request/ChatReadRequest.java
+++ b/src/main/java/com/dduru/gildongmu/chat/dto/request/ChatReadRequest.java
@@ -1,0 +1,11 @@
+package com.dduru.gildongmu.chat.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+public record ChatReadRequest(
+        @NotNull(message = "lastReadMessageId는 필수입니다.")
+        @Positive(message = "lastReadMessageId는 1 이상이어야 합니다.")
+        Long lastReadMessageId
+) {
+}

--- a/src/main/java/com/dduru/gildongmu/chat/dto/response/ChatMessageItemResponse.java
+++ b/src/main/java/com/dduru/gildongmu/chat/dto/response/ChatMessageItemResponse.java
@@ -20,7 +20,12 @@ public record ChatMessageItemResponse(
         Integer unreadCount,
         LocalDateTime createdAt
 ) {
-    public static ChatMessageItemResponse forText(ChatMessage message, Long hostUserId, Long currentUserId) {
+    public static ChatMessageItemResponse forText(
+            ChatMessage message,
+            Long hostUserId,
+            Long currentUserId,
+            Integer unreadCount
+    ) {
         return new ChatMessageItemResponse(
                 message.getId(),
                 message.getMessageType(),
@@ -29,12 +34,17 @@ public record ChatMessageItemResponse(
                 message.getContent(),
                 List.of(),
                 null,
-                null,
+                unreadCount,
                 message.getCreatedAt()
         );
     }
 
-    public static ChatMessageItemResponse forImage(ChatMessage message, Long hostUserId, Long currentUserId) {
+    public static ChatMessageItemResponse forImage(
+            ChatMessage message,
+            Long hostUserId,
+            Long currentUserId,
+            Integer unreadCount
+    ) {
         return new ChatMessageItemResponse(
                 message.getId(),
                 message.getMessageType(),
@@ -43,7 +53,7 @@ public record ChatMessageItemResponse(
                 null,
                 List.of(ChatMessageImageResponse.from(message.getContent())),
                 null,
-                null,
+                unreadCount,
                 message.getCreatedAt()
         );
     }

--- a/src/main/java/com/dduru/gildongmu/chat/dto/response/ChatReadResponse.java
+++ b/src/main/java/com/dduru/gildongmu/chat/dto/response/ChatReadResponse.java
@@ -1,0 +1,8 @@
+package com.dduru.gildongmu.chat.dto.response;
+
+public record ChatReadResponse(
+        Long chatRoomId,
+        Long lastReadMessageId,
+        Boolean updated
+) {
+}

--- a/src/main/java/com/dduru/gildongmu/chat/dto/ws/ChatReadEventPayload.java
+++ b/src/main/java/com/dduru/gildongmu/chat/dto/ws/ChatReadEventPayload.java
@@ -1,0 +1,28 @@
+package com.dduru.gildongmu.chat.dto.ws;
+
+import java.time.LocalDateTime;
+
+public record ChatReadEventPayload(
+        String eventType,
+        Long roomId,
+        Long readerUserId,
+        Long lastReadMessageId,
+        LocalDateTime readAt
+) {
+    private static final String READ_EVENT_TYPE = "READ";
+
+    public static ChatReadEventPayload of(
+            Long roomId,
+            Long readerUserId,
+            Long lastReadMessageId,
+            LocalDateTime readAt
+    ) {
+        return new ChatReadEventPayload(
+                READ_EVENT_TYPE,
+                roomId,
+                readerUserId,
+                lastReadMessageId,
+                readAt
+        );
+    }
+}

--- a/src/main/java/com/dduru/gildongmu/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/dduru/gildongmu/chat/repository/ChatMessageRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
     @Query("""
@@ -28,4 +29,15 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
     );
 
     boolean existsByIdAndRoom_Id(Long messageId, Long roomId);
+
+    @Query("""
+            SELECT m
+            FROM ChatMessage m
+            WHERE m.id = :messageId
+              AND m.room.id = :roomId
+            """)
+    Optional<ChatMessage> findByIdAndRoomId(
+            @Param("messageId") Long messageId,
+            @Param("roomId") Long roomId
+    );
 }

--- a/src/main/java/com/dduru/gildongmu/chat/repository/ChatRoomMemberRepository.java
+++ b/src/main/java/com/dduru/gildongmu/chat/repository/ChatRoomMemberRepository.java
@@ -2,7 +2,9 @@ package com.dduru.gildongmu.chat.repository;
 
 import com.dduru.gildongmu.chat.domain.ChatRoom;
 import com.dduru.gildongmu.chat.domain.ChatRoomMember;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -17,10 +19,24 @@ public interface ChatRoomMemberRepository extends JpaRepository<ChatRoomMember, 
             FROM ChatRoomMember m
             JOIN FETCH m.user u
             LEFT JOIN FETCH u.profile
+            LEFT JOIN FETCH m.lastReadMessage
             WHERE m.room.id = :roomId
               AND m.user.id = :userId
             """)
     Optional<ChatRoomMember> findByRoomIdAndUserId(
+            @Param("roomId") Long roomId,
+            @Param("userId") Long userId
+    );
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("""
+            SELECT m
+            FROM ChatRoomMember m
+            LEFT JOIN FETCH m.lastReadMessage
+            WHERE m.room.id = :roomId
+              AND m.user.id = :userId
+            """)
+    Optional<ChatRoomMember> findByRoomIdAndUserIdForUpdate(
             @Param("roomId") Long roomId,
             @Param("userId") Long userId
     );
@@ -33,6 +49,15 @@ public interface ChatRoomMemberRepository extends JpaRepository<ChatRoomMember, 
             WHERE m.room.id = :roomId
             """)
     List<ChatRoomMember> findByRoomIdWithUserProfile(@Param("roomId") Long roomId);
+
+    @Query("""
+            SELECT m
+            FROM ChatRoomMember m
+            JOIN FETCH m.user
+            LEFT JOIN FETCH m.lastReadMessage
+            WHERE m.room.id = :roomId
+            """)
+    List<ChatRoomMember> findByRoomIdWithLastReadMessage(@Param("roomId") Long roomId);
 
     @Query("""
             SELECT COUNT(m) > 0

--- a/src/main/java/com/dduru/gildongmu/chat/repository/ChatRoomMemberRepository.java
+++ b/src/main/java/com/dduru/gildongmu/chat/repository/ChatRoomMemberRepository.java
@@ -36,7 +36,7 @@ public interface ChatRoomMemberRepository extends JpaRepository<ChatRoomMember, 
             WHERE m.room.id = :roomId
               AND m.user.id = :userId
             """)
-    Optional<ChatRoomMember> findByRoomIdAndUserIdForUpdate(
+    Optional<ChatRoomMember> findByRoomIdAndUserIdWithLock(
             @Param("roomId") Long roomId,
             @Param("userId") Long userId
     );

--- a/src/main/java/com/dduru/gildongmu/chat/service/ChatMessageQueryService.java
+++ b/src/main/java/com/dduru/gildongmu/chat/service/ChatMessageQueryService.java
@@ -86,11 +86,12 @@ public class ChatMessageQueryService {
 
         Map<Long, ChatSystemMessagePayload> systemPayloads = deserializeSystemPayloads(orderedMessages);
         Map<Long, User> systemUsers = loadUsersForSystemMessages(systemPayloads.values());
+        Map<Long, Integer> unreadCounts = calculateUnreadCounts(roomId, orderedMessages);
 
         return new ChatMessagesResponse(
                 toRoomInfo(room, userId),
                 new ChatMessagePageResponse(size, hasNext, nextCursor),
-                toMessageResponses(orderedMessages, room, userId, systemPayloads, systemUsers)
+                toMessageResponses(orderedMessages, room, userId, systemPayloads, systemUsers, unreadCounts)
         );
     }
 
@@ -162,6 +163,49 @@ public class ChatMessageQueryService {
         List<ChatMessage> orderedMessages = new ArrayList<>(pageMessages);
         reverse(orderedMessages);
         return orderedMessages;
+    }
+
+    private Map<Long, Integer> calculateUnreadCounts(Long roomId, List<ChatMessage> messages) {
+        boolean hasUnreadCountTarget = messages.stream()
+                .anyMatch(message -> message.getMessageType() != ChatMessageType.SYSTEM);
+        if (!hasUnreadCountTarget) {
+            return Map.of();
+        }
+
+        List<ChatRoomMember> members = chatRoomMemberRepository.findByRoomIdWithLastReadMessage(roomId);
+        Map<Long, Integer> unreadCounts = new HashMap<>();
+
+        for (ChatMessage message : messages) {
+            if (message.getMessageType() == ChatMessageType.SYSTEM) {
+                continue;
+            }
+            unreadCounts.put(message.getId(), calculateUnreadCount(message, members));
+        }
+        return unreadCounts;
+    }
+
+    private static int calculateUnreadCount(ChatMessage message, List<ChatRoomMember> members) {
+        int unreadCount = 0;
+        for (ChatRoomMember member : members) {
+            if (isSender(message, member) || joinedAfterMessage(member, message) || hasReadMessage(member, message)) {
+                continue;
+            }
+            unreadCount++;
+        }
+        return unreadCount;
+    }
+
+    private static boolean isSender(ChatMessage message, ChatRoomMember member) {
+        return message.getSender() != null && message.getSender().getId().equals(member.getUser().getId());
+    }
+
+    private static boolean joinedAfterMessage(ChatRoomMember member, ChatMessage message) {
+        return member.getCreatedAt().isAfter(message.getCreatedAt());
+    }
+
+    private static boolean hasReadMessage(ChatRoomMember member, ChatMessage message) {
+        ChatMessage lastReadMessage = member.getLastReadMessage();
+        return lastReadMessage != null && lastReadMessage.getId() >= message.getId();
     }
 
     private ChatRoomInfoResponse toRoomInfo(ChatRoom room, Long userId) {
@@ -249,11 +293,19 @@ public class ChatMessageQueryService {
             ChatRoom room,
             Long currentUserId,
             Map<Long, ChatSystemMessagePayload> systemPayloads,
-            Map<Long, User> systemUsers
+            Map<Long, User> systemUsers,
+            Map<Long, Integer> unreadCounts
     ) {
         Long hostUserId = room.getContextPost().getUser().getId();
         return messages.stream()
-                .map(message -> toMessageResponse(message, hostUserId, currentUserId, systemPayloads, systemUsers))
+                .map(message -> toMessageResponse(
+                        message,
+                        hostUserId,
+                        currentUserId,
+                        systemPayloads,
+                        systemUsers,
+                        unreadCounts
+                ))
                 .toList();
     }
 
@@ -262,11 +314,22 @@ public class ChatMessageQueryService {
             Long hostUserId,
             Long currentUserId,
             Map<Long, ChatSystemMessagePayload> systemPayloads,
-            Map<Long, User> systemUsers
+            Map<Long, User> systemUsers,
+            Map<Long, Integer> unreadCounts
     ) {
         return switch (message.getMessageType()) {
-            case TEXT -> ChatMessageItemResponse.forText(message, hostUserId, currentUserId);
-            case IMAGE -> ChatMessageItemResponse.forImage(message, hostUserId, currentUserId);
+            case TEXT -> ChatMessageItemResponse.forText(
+                    message,
+                    hostUserId,
+                    currentUserId,
+                    unreadCounts.get(message.getId())
+            );
+            case IMAGE -> ChatMessageItemResponse.forImage(
+                    message,
+                    hostUserId,
+                    currentUserId,
+                    unreadCounts.get(message.getId())
+            );
             case SYSTEM -> ChatMessageItemResponse.forSystem(
                     message,
                     systemPayloads.get(message.getId()),

--- a/src/main/java/com/dduru/gildongmu/chat/service/ChatMessageSendService.java
+++ b/src/main/java/com/dduru/gildongmu/chat/service/ChatMessageSendService.java
@@ -68,7 +68,7 @@ public class ChatMessageSendService {
     }
 
     private ChatRoomMember getSenderMember(Long senderUserId, Long roomId) {
-        return chatRoomMemberRepository.findByRoomIdAndUserIdForUpdate(roomId, senderUserId)
+        return chatRoomMemberRepository.findByRoomIdAndUserIdWithLock(roomId, senderUserId)
                 .orElseThrow(ChatAccessDeniedException::new);
     }
 

--- a/src/main/java/com/dduru/gildongmu/chat/service/ChatMessageSendService.java
+++ b/src/main/java/com/dduru/gildongmu/chat/service/ChatMessageSendService.java
@@ -4,6 +4,7 @@ import com.dduru.gildongmu.chat.constants.ChatDestinationPaths;
 import com.dduru.gildongmu.chat.constants.ChatMessageConstants;
 import com.dduru.gildongmu.chat.domain.ChatMessage;
 import com.dduru.gildongmu.chat.domain.ChatRoom;
+import com.dduru.gildongmu.chat.domain.ChatRoomMember;
 import com.dduru.gildongmu.chat.domain.enums.ChatMessageType;
 import com.dduru.gildongmu.chat.domain.enums.ChatRoomStatus;
 import com.dduru.gildongmu.chat.dto.ws.ChatMessageBroadcastPayload;
@@ -48,11 +49,11 @@ public class ChatMessageSendService {
     public void sendUserMessage(Long senderUserId, Long roomId, ChatMessageSendRequest request) {
         ChatRoom room = chatRoomRepository.getByIdOrThrow(roomId);
         validateRoomOpen(room);
-        checkSenderIsMember(senderUserId, roomId);
+        ChatRoomMember senderMember = getSenderMember(senderUserId, roomId);
 
         User sender = userRepository.getWithProfileByIdOrThrow(senderUserId);
         String content = resolveUserMessageContent(request);
-        saveUserMessageAndBroadcast(room, sender, request.messageType(), content);
+        saveUserMessageAndBroadcast(room, sender, senderMember, request.messageType(), content);
     }
 
     public void publishUserInvited(ChatRoom room, long inviteeUserId, long actorUserId) {
@@ -66,14 +67,20 @@ public class ChatMessageSendService {
         broadcastAfterCommit(toPayload(chatMessage), room.getId());
     }
 
-    private void checkSenderIsMember(Long senderUserId, Long roomId) {
-        if (!chatRoomMemberRepository.existsByChatRoom_IdAndUser_Id(roomId, senderUserId)) {
-            throw new ChatAccessDeniedException();
-        }
+    private ChatRoomMember getSenderMember(Long senderUserId, Long roomId) {
+        return chatRoomMemberRepository.findByRoomIdAndUserIdForUpdate(roomId, senderUserId)
+                .orElseThrow(ChatAccessDeniedException::new);
     }
 
-    private void saveUserMessageAndBroadcast(ChatRoom room, User sender, ChatMessageType messageType, String content) {
+    private void saveUserMessageAndBroadcast(
+            ChatRoom room,
+            User sender,
+            ChatRoomMember senderMember,
+            ChatMessageType messageType,
+            String content
+    ) {
         ChatMessage chatMessage = saveAndFlushMessage(room, sender, messageType, content);
+        senderMember.readUpTo(chatMessage);
         broadcastAfterCommit(toPayload(chatMessage), room.getId());
     }
 

--- a/src/main/java/com/dduru/gildongmu/chat/service/ChatReadService.java
+++ b/src/main/java/com/dduru/gildongmu/chat/service/ChatReadService.java
@@ -1,0 +1,110 @@
+package com.dduru.gildongmu.chat.service;
+
+import com.dduru.gildongmu.chat.constants.ChatDestinationPaths;
+import com.dduru.gildongmu.chat.domain.ChatMessage;
+import com.dduru.gildongmu.chat.domain.ChatRoom;
+import com.dduru.gildongmu.chat.domain.ChatRoomMember;
+import com.dduru.gildongmu.chat.domain.enums.ChatRoomStatus;
+import com.dduru.gildongmu.chat.domain.enums.ChatRoomType;
+import com.dduru.gildongmu.chat.dto.request.ChatReadRequest;
+import com.dduru.gildongmu.chat.dto.response.ChatReadResponse;
+import com.dduru.gildongmu.chat.dto.ws.ChatReadEventPayload;
+import com.dduru.gildongmu.chat.exception.ChatAccessDeniedException;
+import com.dduru.gildongmu.chat.exception.ChatMessageNotFoundException;
+import com.dduru.gildongmu.chat.exception.ChatRoomNotFoundException;
+import com.dduru.gildongmu.chat.repository.ChatMessageRepository;
+import com.dduru.gildongmu.chat.repository.ChatRoomMemberRepository;
+import com.dduru.gildongmu.chat.repository.ChatRoomRepository;
+import com.dduru.gildongmu.journey.domain.enums.JourneyMemberStatus;
+import com.dduru.gildongmu.journey.repository.JourneyMemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class ChatReadService {
+
+    private final ChatRoomRepository chatRoomRepository;
+    private final ChatRoomMemberRepository chatRoomMemberRepository;
+    private final ChatMessageRepository chatMessageRepository;
+    private final JourneyMemberRepository journeyMemberRepository;
+    private final SimpMessagingTemplate simpMessagingTemplate;
+
+    @Transactional
+    public ChatReadResponse read(Long userId, Long roomId, ChatReadRequest request) {
+        ChatRoom room = chatRoomRepository.getByIdWithContextOrThrow(roomId);
+        validateRoomReadable(room);
+
+        ChatRoomMember currentMember = chatRoomMemberRepository.findByRoomIdAndUserIdForUpdate(roomId, userId)
+                .orElseThrow(ChatAccessDeniedException::new);
+        validateGroupAccess(room, userId);
+
+        ChatMessage message = chatMessageRepository.findByIdAndRoomId(request.lastReadMessageId(), roomId)
+                .orElseThrow(ChatMessageNotFoundException::new);
+        validateMessageVisible(message, currentMember);
+
+        boolean updated = currentMember.readUpTo(message);
+        Long reflectedLastReadMessageId = currentMember.getLastReadMessage().getId();
+
+        if (updated) {
+            publishReadEventAfterCommit(roomId, userId, reflectedLastReadMessageId);
+        }
+
+        return new ChatReadResponse(roomId, reflectedLastReadMessageId, updated);
+    }
+
+    private static void validateRoomReadable(ChatRoom room) {
+        if (room.getStatus() == ChatRoomStatus.DELETED) {
+            throw new ChatRoomNotFoundException();
+        }
+    }
+
+    private void validateGroupAccess(ChatRoom room, Long userId) {
+        if (room.getRoomType() != ChatRoomType.GROUP) {
+            return;
+        }
+
+        boolean activeJourneyMember = journeyMemberRepository.existsByJourneyIdAndUserIdAndStatus(
+                room.getJourney().getId(),
+                userId,
+                JourneyMemberStatus.ACTIVE
+        );
+        if (!activeJourneyMember) {
+            throw new ChatAccessDeniedException();
+        }
+    }
+
+    private static void validateMessageVisible(ChatMessage message, ChatRoomMember currentMember) {
+        if (message.getCreatedAt().isBefore(currentMember.getCreatedAt())) {
+            throw new ChatAccessDeniedException();
+        }
+    }
+
+    private void publishReadEventAfterCommit(Long roomId, Long readerUserId, Long lastReadMessageId) {
+        ChatReadEventPayload payload = ChatReadEventPayload.of(
+                roomId,
+                readerUserId,
+                lastReadMessageId,
+                LocalDateTime.now()
+        );
+        String destination = ChatDestinationPaths.topicRoom(roomId);
+
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.registerSynchronization(
+                    new TransactionSynchronization() {
+                        @Override
+                        public void afterCommit() {
+                            simpMessagingTemplate.convertAndSend(destination, payload);
+                        }
+                    });
+        } else {
+            simpMessagingTemplate.convertAndSend(destination, payload);
+        }
+    }
+}

--- a/src/main/java/com/dduru/gildongmu/chat/service/ChatReadService.java
+++ b/src/main/java/com/dduru/gildongmu/chat/service/ChatReadService.java
@@ -41,7 +41,7 @@ public class ChatReadService {
         ChatRoom room = chatRoomRepository.getByIdWithContextOrThrow(roomId);
         validateRoomReadable(room);
 
-        ChatRoomMember currentMember = chatRoomMemberRepository.findByRoomIdAndUserIdForUpdate(roomId, userId)
+        ChatRoomMember currentMember = chatRoomMemberRepository.findByRoomIdAndUserIdWithLock(roomId, userId)
                 .orElseThrow(ChatAccessDeniedException::new);
         validateGroupAccess(room, userId);
 

--- a/src/test/java/com/dduru/gildongmu/chat/controller/ChatControllerTest.java
+++ b/src/test/java/com/dduru/gildongmu/chat/controller/ChatControllerTest.java
@@ -4,12 +4,15 @@ import com.dduru.gildongmu.auth.exception.UnauthorizedException;
 import com.dduru.gildongmu.chat.domain.enums.ChatMessageType;
 import com.dduru.gildongmu.chat.domain.enums.ChatRoomType;
 import com.dduru.gildongmu.chat.dto.request.ChatMessageRetrieveRequest;
+import com.dduru.gildongmu.chat.dto.request.ChatReadRequest;
 import com.dduru.gildongmu.chat.dto.response.ChatMessageItemResponse;
 import com.dduru.gildongmu.chat.dto.response.ChatMessagePageResponse;
 import com.dduru.gildongmu.chat.dto.response.ChatMessageSenderResponse;
 import com.dduru.gildongmu.chat.dto.response.ChatMessagesResponse;
+import com.dduru.gildongmu.chat.dto.response.ChatReadResponse;
 import com.dduru.gildongmu.chat.dto.response.ChatRoomInfoResponse;
 import com.dduru.gildongmu.chat.service.ChatMessageQueryService;
+import com.dduru.gildongmu.chat.service.ChatReadService;
 import com.dduru.gildongmu.chat.service.PrivateChatRoomService;
 import com.dduru.gildongmu.common.annotation.CurrentUser;
 import com.dduru.gildongmu.common.exception.GlobalExceptionHandler;
@@ -21,6 +24,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.core.MethodParameter;
+import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
@@ -35,6 +39,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
@@ -48,6 +53,9 @@ class ChatControllerTest {
 
     @Mock
     private ChatMessageQueryService chatMessageQueryService;
+
+    @Mock
+    private ChatReadService chatReadService;
 
     private MockMvc mockMvc;
 
@@ -120,6 +128,67 @@ class ChatControllerTest {
     }
 
     @Test
+    @DisplayName("PATCH /api/v1/chat-rooms/{chatRoomId}/read 요청을 service에 위임하고 응답한다")
+    void readMessages() throws Exception {
+        Long roomId = 1L;
+        when(chatReadService.read(eq(10L), eq(roomId), any(ChatReadRequest.class)))
+                .thenReturn(new ChatReadResponse(roomId, 123L, true));
+
+        mockMvc.perform(patch("/api/v1/chat-rooms/{chatRoomId}/read", roomId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"lastReadMessageId":123}
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.data.chatRoomId").value(1))
+                .andExpect(jsonPath("$.data.lastReadMessageId").value(123))
+                .andExpect(jsonPath("$.data.updated").value(true));
+
+        ArgumentCaptor<ChatReadRequest> requestCaptor = ArgumentCaptor.forClass(ChatReadRequest.class);
+        org.mockito.Mockito.verify(chatReadService).read(eq(10L), eq(roomId), requestCaptor.capture());
+        assertThat(requestCaptor.getValue().lastReadMessageId()).isEqualTo(123L);
+    }
+
+    @Test
+    @DisplayName("읽음 처리 인증되지 않은 사용자는 UNAUTHORIZED 응답을 받는다")
+    void readMessagesUnauthenticatedUserReturnsUnauthorized() throws Exception {
+        mockMvc = mockMvcWithUser(null);
+
+        mockMvc.perform(patch("/api/v1/chat-rooms/{chatRoomId}/read", 1L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"lastReadMessageId":123}
+                                """))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.data.errorCode").value("UNAUTHORIZED"));
+    }
+
+    @Test
+    @DisplayName("lastReadMessageId가 없거나 양수가 아니면 INVALID_INPUT_VALUE 응답을 받는다")
+    void readMessagesInvalidRequestReturnsBadRequest() throws Exception {
+        mockMvc.perform(patch("/api/v1/chat-rooms/{chatRoomId}/read", 1L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {}
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.data.errorCode").value("INVALID_INPUT_VALUE"))
+                .andExpect(jsonPath("$.data.field").value("lastReadMessageId"));
+
+        mockMvc.perform(patch("/api/v1/chat-rooms/{chatRoomId}/read", 1L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"lastReadMessageId":0}
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.data.errorCode").value("INVALID_INPUT_VALUE"))
+                .andExpect(jsonPath("$.data.field").value("lastReadMessageId"));
+
+        org.mockito.Mockito.verifyNoInteractions(chatReadService);
+    }
+
+    @Test
     @DisplayName("query type mismatch도 INVALID_INPUT_VALUE 응답을 받는다")
     void invalidQueryTypeReturnsBadRequest() throws Exception {
         mockMvc.perform(get("/api/v1/chat-rooms/{chatRoomId}/messages", 1L)
@@ -132,7 +201,7 @@ class ChatControllerTest {
     }
 
     private MockMvc mockMvcWithUser(Long userId) {
-        return standaloneSetup(new ChatController(privateChatRoomService, chatMessageQueryService))
+        return standaloneSetup(new ChatController(privateChatRoomService, chatMessageQueryService, chatReadService))
                 .setCustomArgumentResolvers(new FixedCurrentUserArgumentResolver(userId))
                 .setControllerAdvice(new GlobalExceptionHandler())
                 .build();

--- a/src/test/java/com/dduru/gildongmu/chat/repository/ChatMessageRepositoryTest.java
+++ b/src/test/java/com/dduru/gildongmu/chat/repository/ChatMessageRepositoryTest.java
@@ -71,6 +71,29 @@ class ChatMessageRepositoryTest {
                 .containsExactly(visible2.getId(), visible1.getId());
     }
 
+    @Test
+    @DisplayName("findByIdAndRoomId는 지정한 방에 속한 메시지만 조회한다")
+    void findByIdAndRoomIdReturnsOnlyMessageInRoom() {
+        User host = persistUser("host", 3);
+        User guest = persistUser("guest", 4);
+        Destination destination = persistDestination();
+        Post post = persistPost(host, destination);
+        ChatRoom room = entityManager.persist(ChatRoom.forPrivateChat(post));
+        ChatRoom otherRoom = entityManager.persist(ChatRoom.forPrivateChat(post));
+        ChatMessage message = persistMessage(room, host, "target");
+        ChatMessage otherRoomMessage = persistMessage(otherRoom, guest, "other");
+        entityManager.flush();
+        entityManager.clear();
+
+        assertThat(chatMessageRepository.findByIdAndRoomId(message.getId(), room.getId()))
+                .isPresent()
+                .get()
+                .extracting(ChatMessage::getId)
+                .isEqualTo(message.getId());
+        assertThat(chatMessageRepository.findByIdAndRoomId(otherRoomMessage.getId(), room.getId()))
+                .isEmpty();
+    }
+
     private User persistUser(String name, int suffix) {
         User user = User.builder()
                 .email(name + suffix + "@example.com")

--- a/src/test/java/com/dduru/gildongmu/chat/repository/ChatRoomMemberRepositoryTest.java
+++ b/src/test/java/com/dduru/gildongmu/chat/repository/ChatRoomMemberRepositoryTest.java
@@ -1,0 +1,120 @@
+package com.dduru.gildongmu.chat.repository;
+
+import com.dduru.gildongmu.chat.domain.ChatMessage;
+import com.dduru.gildongmu.chat.domain.ChatRoom;
+import com.dduru.gildongmu.chat.domain.ChatRoomMember;
+import com.dduru.gildongmu.chat.domain.enums.ChatMemberRole;
+import com.dduru.gildongmu.chat.domain.enums.ChatMessageType;
+import com.dduru.gildongmu.common.config.QueryDslConfig;
+import com.dduru.gildongmu.destination.domain.Destination;
+import com.dduru.gildongmu.post.domain.Post;
+import com.dduru.gildongmu.profile.domain.enums.Gender;
+import com.dduru.gildongmu.user.domain.User;
+import com.dduru.gildongmu.user.domain.enums.OauthType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDate;
+import java.util.List;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@ActiveProfiles("test")
+@Import(QueryDslConfig.class)
+@DisplayName("ChatRoomMemberRepository 테스트")
+class ChatRoomMemberRepositoryTest {
+
+    @Autowired
+    private ChatRoomMemberRepository chatRoomMemberRepository;
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    @Test
+    @DisplayName("findByRoomIdWithLastReadMessage는 현재 방 멤버와 lastReadMessage를 함께 조회한다")
+    void findByRoomIdWithLastReadMessageFetchesReadCursor() {
+        User host = persistUser("host", 1);
+        User guest = persistUser("guest", 2);
+        Destination destination = persistDestination();
+        Post post = persistPost(host, destination);
+        ChatRoom room = entityManager.persist(ChatRoom.forPrivateChat(post));
+        ChatRoom otherRoom = entityManager.persist(ChatRoom.forPrivateChat(post));
+        ChatMessage message = entityManager.persist(ChatMessage.create(room, host, ChatMessageType.TEXT, "target"));
+        ChatMessage otherMessage = entityManager.persist(ChatMessage.create(otherRoom, guest, ChatMessageType.TEXT, "other"));
+
+        ChatRoomMember hostMember = entityManager.persist(ChatRoomMember.builder()
+                .room(room)
+                .user(host)
+                .role(ChatMemberRole.HOST)
+                .lastReadMessage(message)
+                .build());
+        entityManager.persist(ChatRoomMember.builder()
+                .room(room)
+                .user(guest)
+                .role(ChatMemberRole.GUEST)
+                .build());
+        entityManager.persist(ChatRoomMember.builder()
+                .room(otherRoom)
+                .user(host)
+                .role(ChatMemberRole.HOST)
+                .lastReadMessage(otherMessage)
+                .build());
+        entityManager.flush();
+        entityManager.clear();
+
+        List<ChatRoomMember> members = chatRoomMemberRepository.findByRoomIdWithLastReadMessage(room.getId());
+
+        assertThat(members).hasSize(2);
+        assertThat(members).extracting(member -> member.getUser().getId())
+                .containsExactlyInAnyOrder(host.getId(), guest.getId());
+        ChatRoomMember foundHost = members.stream()
+                .filter(member -> member.getUser().getId().equals(hostMember.getUser().getId()))
+                .findFirst()
+                .orElseThrow();
+        assertThat(foundHost.getLastReadMessage().getId()).isEqualTo(message.getId());
+    }
+
+    private User persistUser(String name, int suffix) {
+        User user = User.builder()
+                .email(name + suffix + "@example.com")
+                .name(name)
+                .oauthId("oauth-" + suffix)
+                .oauthType(OauthType.KAKAO)
+                .build();
+        return entityManager.persist(user);
+    }
+
+    private Destination persistDestination() {
+        return entityManager.persist(Destination.builder()
+                .countryCode("KR")
+                .countryName("대한민국")
+                .city("제주")
+                .build());
+    }
+
+    private Post persistPost(User host, Destination destination) {
+        Post post = Post.createPost(
+                host,
+                destination,
+                "제주 여행",
+                "채팅방 멤버 repository 테스트용 본문입니다.",
+                LocalDate.now().plusDays(1),
+                LocalDate.now().plusDays(2),
+                4,
+                LocalDate.now().plusDays(1),
+                Gender.U,
+                true,
+                null,
+                null,
+                "https://example.com/photo.png",
+                "[]",
+                null
+        );
+        return entityManager.persist(post);
+    }
+}

--- a/src/test/java/com/dduru/gildongmu/chat/service/ChatMessageQueryServiceTest.java
+++ b/src/test/java/com/dduru/gildongmu/chat/service/ChatMessageQueryServiceTest.java
@@ -104,6 +104,7 @@ class ChatMessageQueryServiceTest {
             Post post = createPost(1L, host, "코끼리 아저씨");
             ChatRoom room = createPrivateRoom(roomId, post, ChatRoomStatus.ACTIVE);
             ChatRoomMember currentMember = createMember(room, host, ChatMemberRole.HOST, memberCreatedAt);
+            ChatRoomMember guestMember = createMember(room, guest, ChatMemberRole.GUEST, memberCreatedAt);
 
             ChatMessage oldestReturned = createMessage(102L, room, host, ChatMessageType.IMAGE,
                     "https://cdn.example.com/chats/image.jpg", memberCreatedAt.plusMinutes(2));
@@ -115,9 +116,11 @@ class ChatMessageQueryServiceTest {
             when(chatRoomRepository.getByIdWithContextOrThrow(roomId)).thenReturn(room);
             when(chatRoomMemberRepository.findByRoomIdAndUserId(roomId, currentUserId)).thenReturn(Optional.of(currentMember));
             when(chatRoomMemberRepository.findByRoomIdWithUserProfile(roomId))
-                    .thenReturn(List.of(currentMember, createMember(room, guest, ChatMemberRole.GUEST, memberCreatedAt)));
+                    .thenReturn(List.of(currentMember, guestMember));
             when(chatMessageRepository.findVisibleMessages(eq(roomId), eq(null), eq(memberCreatedAt), any(Pageable.class)))
                     .thenReturn(List.of(newestReturned, oldestReturned, lookAhead));
+            when(chatRoomMemberRepository.findByRoomIdWithLastReadMessage(roomId))
+                    .thenReturn(List.of(currentMember, guestMember));
 
             ChatMessagesResponse response = chatMessageQueryService.retrieveMessages(
                     currentUserId,
@@ -139,7 +142,9 @@ class ChatMessageQueryServiceTest {
                     .isEqualTo("https://cdn.example.com/chats/image.jpg");
             assertThat(response.messages().get(0).sender().isHost()).isTrue();
             assertThat(response.messages().get(0).isMine()).isTrue();
+            assertThat(response.messages().get(0).unreadCount()).isEqualTo(1);
             assertThat(response.messages().get(1).content()).isEqualTo("시간 다르면 다르게 뜨도록");
+            assertThat(response.messages().get(1).unreadCount()).isEqualTo(1);
 
             ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
             verify(chatMessageRepository).findVisibleMessages(eq(roomId), eq(null), eq(memberCreatedAt), pageableCaptor.capture());
@@ -191,6 +196,58 @@ class ChatMessageQueryServiceTest {
                     .isEqualTo("guestNick 님이 그룹 채팅방에 참여했습니다.");
             assertThat(response.messages().get(0).systemMessage().actorUserId()).isEqualTo(hostUserId);
             assertThat(response.messages().get(0).systemMessage().inviteeUserId()).isEqualTo(inviteeUserId);
+        }
+
+        @Test
+        @DisplayName("그룹 메시지 unreadCount는 sender, 읽은 멤버, 메시지 이후 참여자를 제외하고 계산한다")
+        void calculatesGroupUnreadCount() {
+            Long roomId = 200L;
+            Long hostUserId = 10L;
+            Long unreadUserId = 20L;
+            Long readUserId = 30L;
+            Long newcomerUserId = 40L;
+            LocalDateTime memberCreatedAt = LocalDateTime.of(2026, 5, 9, 9, 0);
+            User host = createUser(hostUserId, "host", "hostNick");
+            User unreadMemberUser = createUser(unreadUserId, "unread", "unreadNick");
+            User readMemberUser = createUser(readUserId, "read", "readNick");
+            User newcomer = createUser(newcomerUserId, "newcomer", "newcomerNick");
+            Post post = createPost(1L, host, "그룹 unreadCount");
+            Journey journey = createJourney(30L, post, "그룹 여정");
+            ChatRoom room = createGroupRoom(roomId, journey, ChatRoomStatus.ACTIVE);
+
+            ChatMessage message = createMessage(501L, room, host, ChatMessageType.TEXT,
+                    "읽음 수 계산", memberCreatedAt.plusMinutes(10));
+            ChatMessage readCursor = createMessage(600L, room, readMemberUser, ChatMessageType.TEXT,
+                    "읽은 위치", memberCreatedAt.plusMinutes(11));
+            ChatRoomMember hostMember = createMember(room, host, ChatMemberRole.HOST, memberCreatedAt);
+            ChatRoomMember unreadMember = createMember(room, unreadMemberUser, ChatMemberRole.GUEST, memberCreatedAt);
+            ChatRoomMember readMember = createMember(room, readMemberUser, ChatMemberRole.GUEST, readCursor, memberCreatedAt);
+            ChatRoomMember newcomerMember = createMember(
+                    room,
+                    newcomer,
+                    ChatMemberRole.GUEST,
+                    memberCreatedAt.plusMinutes(20)
+            );
+
+            when(chatRoomRepository.getByIdWithContextOrThrow(roomId)).thenReturn(room);
+            when(chatRoomMemberRepository.findByRoomIdAndUserId(roomId, hostUserId)).thenReturn(Optional.of(hostMember));
+            when(journeyMemberRepository.existsByJourneyIdAndUserIdAndStatus(30L, hostUserId, JourneyMemberStatus.ACTIVE))
+                    .thenReturn(true);
+            when(journeyMemberRepository.countByJourneyIdAndStatus(30L, JourneyMemberStatus.ACTIVE)).thenReturn(4);
+            when(chatMessageRepository.findVisibleMessages(eq(roomId), eq(null), eq(memberCreatedAt), any(Pageable.class)))
+                    .thenReturn(List.of(message));
+            when(chatRoomMemberRepository.findByRoomIdWithLastReadMessage(roomId))
+                    .thenReturn(List.of(hostMember, unreadMember, readMember, newcomerMember));
+
+            ChatMessagesResponse response = chatMessageQueryService.retrieveMessages(
+                    hostUserId,
+                    roomId,
+                    new ChatMessageRetrieveRequest(null, 20)
+            );
+
+            assertThat(response.messages()).hasSize(1);
+            assertThat(response.messages().get(0).messageId()).isEqualTo(message.getId());
+            assertThat(response.messages().get(0).unreadCount()).isEqualTo(1);
         }
     }
 
@@ -328,7 +385,18 @@ class ChatMessageQueryServiceTest {
     }
 
     private ChatRoomMember createMember(ChatRoom room, User user, ChatMemberRole role, LocalDateTime createdAt) {
+        return createMember(room, user, role, null, createdAt);
+    }
+
+    private ChatRoomMember createMember(
+            ChatRoom room,
+            User user,
+            ChatMemberRole role,
+            ChatMessage lastReadMessage,
+            LocalDateTime createdAt
+    ) {
         ChatRoomMember member = ChatRoomMember.create(room, user, role);
+        ReflectionTestUtils.setField(member, "lastReadMessage", lastReadMessage);
         ReflectionTestUtils.setField(member, "createdAt", createdAt);
         return member;
     }

--- a/src/test/java/com/dduru/gildongmu/chat/service/ChatReadServiceTest.java
+++ b/src/test/java/com/dduru/gildongmu/chat/service/ChatReadServiceTest.java
@@ -97,7 +97,7 @@ class ChatReadServiceTest {
                     "읽음 처리할 메시지", LocalDateTime.of(2026, 5, 9, 9, 10));
 
             when(chatRoomRepository.getByIdWithContextOrThrow(roomId)).thenReturn(room);
-            when(chatRoomMemberRepository.findByRoomIdAndUserIdForUpdate(roomId, userId)).thenReturn(Optional.of(member));
+            when(chatRoomMemberRepository.findByRoomIdAndUserIdWithLock(roomId, userId)).thenReturn(Optional.of(member));
             when(chatMessageRepository.findByIdAndRoomId(message.getId(), roomId)).thenReturn(Optional.of(message));
 
             ChatReadResponse response = chatReadService.read(userId, roomId, new ChatReadRequest(message.getId()));
@@ -131,7 +131,7 @@ class ChatReadServiceTest {
                     "읽음 처리할 메시지", LocalDateTime.of(2026, 5, 9, 9, 10));
 
             when(chatRoomRepository.getByIdWithContextOrThrow(roomId)).thenReturn(room);
-            when(chatRoomMemberRepository.findByRoomIdAndUserIdForUpdate(roomId, userId)).thenReturn(Optional.of(member));
+            when(chatRoomMemberRepository.findByRoomIdAndUserIdWithLock(roomId, userId)).thenReturn(Optional.of(member));
             when(chatMessageRepository.findByIdAndRoomId(message.getId(), roomId)).thenReturn(Optional.of(message));
 
             TransactionSynchronizationManager.initSynchronization();
@@ -167,7 +167,7 @@ class ChatReadServiceTest {
             ChatRoomMember member = createMember(room, user, currentLastRead, LocalDateTime.of(2026, 5, 9, 9, 0));
 
             when(chatRoomRepository.getByIdWithContextOrThrow(roomId)).thenReturn(room);
-            when(chatRoomMemberRepository.findByRoomIdAndUserIdForUpdate(roomId, userId)).thenReturn(Optional.of(member));
+            when(chatRoomMemberRepository.findByRoomIdAndUserIdWithLock(roomId, userId)).thenReturn(Optional.of(member));
             when(chatMessageRepository.findByIdAndRoomId(oldMessage.getId(), roomId)).thenReturn(Optional.of(oldMessage));
 
             ChatReadResponse response = chatReadService.read(userId, roomId, new ChatReadRequest(oldMessage.getId()));
@@ -190,7 +190,7 @@ class ChatReadServiceTest {
             ChatRoomMember member = createMember(room, user, currentLastRead, LocalDateTime.of(2026, 5, 9, 9, 0));
 
             when(chatRoomRepository.getByIdWithContextOrThrow(roomId)).thenReturn(room);
-            when(chatRoomMemberRepository.findByRoomIdAndUserIdForUpdate(roomId, userId)).thenReturn(Optional.of(member));
+            when(chatRoomMemberRepository.findByRoomIdAndUserIdWithLock(roomId, userId)).thenReturn(Optional.of(member));
             when(chatMessageRepository.findByIdAndRoomId(currentLastRead.getId(), roomId))
                     .thenReturn(Optional.of(currentLastRead));
 
@@ -217,7 +217,7 @@ class ChatReadServiceTest {
                     "{}", LocalDateTime.of(2026, 5, 9, 9, 10));
 
             when(chatRoomRepository.getByIdWithContextOrThrow(roomId)).thenReturn(room);
-            when(chatRoomMemberRepository.findByRoomIdAndUserIdForUpdate(roomId, userId)).thenReturn(Optional.of(member));
+            when(chatRoomMemberRepository.findByRoomIdAndUserIdWithLock(roomId, userId)).thenReturn(Optional.of(member));
             when(chatMessageRepository.findByIdAndRoomId(message.getId(), roomId)).thenReturn(Optional.of(message));
 
             ChatReadResponse response = chatReadService.read(userId, roomId, new ChatReadRequest(message.getId()));
@@ -255,7 +255,7 @@ class ChatReadServiceTest {
             ChatRoom room = createPrivateRoom(roomId, createPost(100L, user), ChatRoomStatus.ACTIVE);
 
             when(chatRoomRepository.getByIdWithContextOrThrow(roomId)).thenReturn(room);
-            when(chatRoomMemberRepository.findByRoomIdAndUserIdForUpdate(roomId, userId)).thenReturn(Optional.empty());
+            when(chatRoomMemberRepository.findByRoomIdAndUserIdWithLock(roomId, userId)).thenReturn(Optional.empty());
 
             assertThatThrownBy(() -> chatReadService.read(userId, roomId, new ChatReadRequest(123L)))
                     .isInstanceOf(ChatAccessDeniedException.class);
@@ -274,7 +274,7 @@ class ChatReadServiceTest {
             ChatRoomMember member = createMember(room, user, null, LocalDateTime.of(2026, 5, 9, 9, 0));
 
             when(chatRoomRepository.getByIdWithContextOrThrow(roomId)).thenReturn(room);
-            when(chatRoomMemberRepository.findByRoomIdAndUserIdForUpdate(roomId, userId)).thenReturn(Optional.of(member));
+            when(chatRoomMemberRepository.findByRoomIdAndUserIdWithLock(roomId, userId)).thenReturn(Optional.of(member));
             when(journeyMemberRepository.existsByJourneyIdAndUserIdAndStatus(30L, userId, JourneyMemberStatus.ACTIVE))
                     .thenReturn(false);
 
@@ -294,7 +294,7 @@ class ChatReadServiceTest {
             ChatRoomMember member = createMember(room, user, null, LocalDateTime.of(2026, 5, 9, 9, 0));
 
             when(chatRoomRepository.getByIdWithContextOrThrow(roomId)).thenReturn(room);
-            when(chatRoomMemberRepository.findByRoomIdAndUserIdForUpdate(roomId, userId)).thenReturn(Optional.of(member));
+            when(chatRoomMemberRepository.findByRoomIdAndUserIdWithLock(roomId, userId)).thenReturn(Optional.of(member));
             when(chatMessageRepository.findByIdAndRoomId(999L, roomId)).thenReturn(Optional.empty());
 
             assertThatThrownBy(() -> chatReadService.read(userId, roomId, new ChatReadRequest(999L)))
@@ -315,7 +315,7 @@ class ChatReadServiceTest {
                     "참여 전 메시지", LocalDateTime.of(2026, 5, 9, 9, 9));
 
             when(chatRoomRepository.getByIdWithContextOrThrow(roomId)).thenReturn(room);
-            when(chatRoomMemberRepository.findByRoomIdAndUserIdForUpdate(roomId, userId)).thenReturn(Optional.of(member));
+            when(chatRoomMemberRepository.findByRoomIdAndUserIdWithLock(roomId, userId)).thenReturn(Optional.of(member));
             when(chatMessageRepository.findByIdAndRoomId(message.getId(), roomId)).thenReturn(Optional.of(message));
 
             assertThatThrownBy(() -> chatReadService.read(userId, roomId, new ChatReadRequest(message.getId())))

--- a/src/test/java/com/dduru/gildongmu/chat/service/ChatReadServiceTest.java
+++ b/src/test/java/com/dduru/gildongmu/chat/service/ChatReadServiceTest.java
@@ -1,0 +1,411 @@
+package com.dduru.gildongmu.chat.service;
+
+import com.dduru.gildongmu.chat.constants.ChatDestinationPaths;
+import com.dduru.gildongmu.chat.domain.ChatMessage;
+import com.dduru.gildongmu.chat.domain.ChatRoom;
+import com.dduru.gildongmu.chat.domain.ChatRoomMember;
+import com.dduru.gildongmu.chat.domain.enums.ChatMemberRole;
+import com.dduru.gildongmu.chat.domain.enums.ChatMessageType;
+import com.dduru.gildongmu.chat.domain.enums.ChatRoomStatus;
+import com.dduru.gildongmu.chat.dto.request.ChatReadRequest;
+import com.dduru.gildongmu.chat.dto.response.ChatReadResponse;
+import com.dduru.gildongmu.chat.dto.ws.ChatReadEventPayload;
+import com.dduru.gildongmu.chat.exception.ChatAccessDeniedException;
+import com.dduru.gildongmu.chat.exception.ChatMessageNotFoundException;
+import com.dduru.gildongmu.chat.exception.ChatRoomNotFoundException;
+import com.dduru.gildongmu.chat.repository.ChatMessageRepository;
+import com.dduru.gildongmu.chat.repository.ChatRoomMemberRepository;
+import com.dduru.gildongmu.chat.repository.ChatRoomRepository;
+import com.dduru.gildongmu.journey.domain.Journey;
+import com.dduru.gildongmu.journey.domain.enums.JourneyMemberStatus;
+import com.dduru.gildongmu.journey.repository.JourneyMemberRepository;
+import com.dduru.gildongmu.post.domain.Post;
+import com.dduru.gildongmu.profile.domain.enums.Gender;
+import com.dduru.gildongmu.user.domain.User;
+import com.dduru.gildongmu.user.domain.enums.OauthType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ChatReadService 테스트")
+class ChatReadServiceTest {
+
+    @Mock
+    private ChatRoomRepository chatRoomRepository;
+
+    @Mock
+    private ChatRoomMemberRepository chatRoomMemberRepository;
+
+    @Mock
+    private ChatMessageRepository chatMessageRepository;
+
+    @Mock
+    private JourneyMemberRepository journeyMemberRepository;
+
+    @Mock
+    private SimpMessagingTemplate simpMessagingTemplate;
+
+    private ChatReadService chatReadService;
+
+    @BeforeEach
+    void setUp() {
+        chatReadService = new ChatReadService(
+                chatRoomRepository,
+                chatRoomMemberRepository,
+                chatMessageRepository,
+                journeyMemberRepository,
+                simpMessagingTemplate
+        );
+    }
+
+    @Nested
+    @DisplayName("읽음 처리 성공")
+    class ReadSuccess {
+
+        @Test
+        @DisplayName("현재 멤버가 최신 메시지 ID로 읽음 처리하면 lastReadMessage가 갱신되고 READ 이벤트가 발행된다")
+        void updatesLastReadMessageAndPublishesReadEvent() {
+            Long roomId = 1L;
+            Long userId = 10L;
+            User user = createUser(userId, "reader");
+            ChatRoom room = createPrivateRoom(roomId, createPost(100L, user), ChatRoomStatus.ACTIVE);
+            ChatRoomMember member = createMember(room, user, null, LocalDateTime.of(2026, 5, 9, 9, 0));
+            ChatMessage message = createMessage(123L, room, user, ChatMessageType.TEXT,
+                    "읽음 처리할 메시지", LocalDateTime.of(2026, 5, 9, 9, 10));
+
+            when(chatRoomRepository.getByIdWithContextOrThrow(roomId)).thenReturn(room);
+            when(chatRoomMemberRepository.findByRoomIdAndUserIdForUpdate(roomId, userId)).thenReturn(Optional.of(member));
+            when(chatMessageRepository.findByIdAndRoomId(message.getId(), roomId)).thenReturn(Optional.of(message));
+
+            ChatReadResponse response = chatReadService.read(userId, roomId, new ChatReadRequest(message.getId()));
+
+            assertThat(response.chatRoomId()).isEqualTo(roomId);
+            assertThat(response.lastReadMessageId()).isEqualTo(message.getId());
+            assertThat(response.updated()).isTrue();
+            assertThat(member.getLastReadMessage()).isEqualTo(message);
+
+            ArgumentCaptor<ChatReadEventPayload> payloadCaptor = ArgumentCaptor.forClass(ChatReadEventPayload.class);
+            verify(simpMessagingTemplate).convertAndSend(
+                    org.mockito.ArgumentMatchers.eq(ChatDestinationPaths.topicRoom(roomId)),
+                    payloadCaptor.capture()
+            );
+            assertThat(payloadCaptor.getValue().eventType()).isEqualTo("READ");
+            assertThat(payloadCaptor.getValue().roomId()).isEqualTo(roomId);
+            assertThat(payloadCaptor.getValue().readerUserId()).isEqualTo(userId);
+            assertThat(payloadCaptor.getValue().lastReadMessageId()).isEqualTo(message.getId());
+            assertThat(payloadCaptor.getValue().readAt()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("트랜잭션 동기화가 활성화되어 있으면 READ 이벤트는 afterCommit에서 발행된다")
+        void publishesReadEventAfterCommitWhenTransactionSynchronizationActive() {
+            Long roomId = 1L;
+            Long userId = 10L;
+            User user = createUser(userId, "reader");
+            ChatRoom room = createPrivateRoom(roomId, createPost(100L, user), ChatRoomStatus.ACTIVE);
+            ChatRoomMember member = createMember(room, user, null, LocalDateTime.of(2026, 5, 9, 9, 0));
+            ChatMessage message = createMessage(123L, room, user, ChatMessageType.TEXT,
+                    "읽음 처리할 메시지", LocalDateTime.of(2026, 5, 9, 9, 10));
+
+            when(chatRoomRepository.getByIdWithContextOrThrow(roomId)).thenReturn(room);
+            when(chatRoomMemberRepository.findByRoomIdAndUserIdForUpdate(roomId, userId)).thenReturn(Optional.of(member));
+            when(chatMessageRepository.findByIdAndRoomId(message.getId(), roomId)).thenReturn(Optional.of(message));
+
+            TransactionSynchronizationManager.initSynchronization();
+            try {
+                chatReadService.read(userId, roomId, new ChatReadRequest(message.getId()));
+
+                verifyNoInteractions(simpMessagingTemplate);
+                List<TransactionSynchronization> synchronizations = TransactionSynchronizationManager.getSynchronizations();
+                assertThat(synchronizations).hasSize(1);
+
+                synchronizations.get(0).afterCommit();
+
+                verify(simpMessagingTemplate).convertAndSend(
+                        org.mockito.ArgumentMatchers.eq(ChatDestinationPaths.topicRoom(roomId)),
+                        any(ChatReadEventPayload.class)
+                );
+            } finally {
+                TransactionSynchronizationManager.clearSynchronization();
+            }
+        }
+
+        @Test
+        @DisplayName("기존 읽음 위치보다 과거 메시지를 요청하면 updated=false이고 READ 이벤트를 발행하지 않는다")
+        void oldMessageReturnsNoOp() {
+            Long roomId = 1L;
+            Long userId = 10L;
+            User user = createUser(userId, "reader");
+            ChatRoom room = createPrivateRoom(roomId, createPost(100L, user), ChatRoomStatus.ACTIVE);
+            ChatMessage oldMessage = createMessage(150L, room, user, ChatMessageType.TEXT,
+                    "과거 메시지", LocalDateTime.of(2026, 5, 9, 9, 10));
+            ChatMessage currentLastRead = createMessage(200L, room, user, ChatMessageType.TEXT,
+                    "이미 읽은 메시지", LocalDateTime.of(2026, 5, 9, 9, 20));
+            ChatRoomMember member = createMember(room, user, currentLastRead, LocalDateTime.of(2026, 5, 9, 9, 0));
+
+            when(chatRoomRepository.getByIdWithContextOrThrow(roomId)).thenReturn(room);
+            when(chatRoomMemberRepository.findByRoomIdAndUserIdForUpdate(roomId, userId)).thenReturn(Optional.of(member));
+            when(chatMessageRepository.findByIdAndRoomId(oldMessage.getId(), roomId)).thenReturn(Optional.of(oldMessage));
+
+            ChatReadResponse response = chatReadService.read(userId, roomId, new ChatReadRequest(oldMessage.getId()));
+
+            assertThat(response.lastReadMessageId()).isEqualTo(currentLastRead.getId());
+            assertThat(response.updated()).isFalse();
+            assertThat(member.getLastReadMessage()).isEqualTo(currentLastRead);
+            verifyNoInteractions(simpMessagingTemplate);
+        }
+
+        @Test
+        @DisplayName("기존 읽음 위치와 같은 메시지를 요청해도 updated=false이고 READ 이벤트를 발행하지 않는다")
+        void sameMessageReturnsNoOp() {
+            Long roomId = 1L;
+            Long userId = 10L;
+            User user = createUser(userId, "reader");
+            ChatRoom room = createPrivateRoom(roomId, createPost(100L, user), ChatRoomStatus.ACTIVE);
+            ChatMessage currentLastRead = createMessage(200L, room, user, ChatMessageType.TEXT,
+                    "이미 읽은 메시지", LocalDateTime.of(2026, 5, 9, 9, 20));
+            ChatRoomMember member = createMember(room, user, currentLastRead, LocalDateTime.of(2026, 5, 9, 9, 0));
+
+            when(chatRoomRepository.getByIdWithContextOrThrow(roomId)).thenReturn(room);
+            when(chatRoomMemberRepository.findByRoomIdAndUserIdForUpdate(roomId, userId)).thenReturn(Optional.of(member));
+            when(chatMessageRepository.findByIdAndRoomId(currentLastRead.getId(), roomId))
+                    .thenReturn(Optional.of(currentLastRead));
+
+            ChatReadResponse response = chatReadService.read(
+                    userId,
+                    roomId,
+                    new ChatReadRequest(currentLastRead.getId())
+            );
+
+            assertThat(response.lastReadMessageId()).isEqualTo(currentLastRead.getId());
+            assertThat(response.updated()).isFalse();
+            verifyNoInteractions(simpMessagingTemplate);
+        }
+
+        @Test
+        @DisplayName("SYSTEM 메시지와 CLOSED 방도 읽음 처리할 수 있다")
+        void systemMessageInClosedRoomCanBeRead() {
+            Long roomId = 1L;
+            Long userId = 10L;
+            User user = createUser(userId, "reader");
+            ChatRoom room = createPrivateRoom(roomId, createPost(100L, user), ChatRoomStatus.CLOSED);
+            ChatRoomMember member = createMember(room, user, null, LocalDateTime.of(2026, 5, 9, 9, 0));
+            ChatMessage message = createMessage(123L, room, null, ChatMessageType.SYSTEM,
+                    "{}", LocalDateTime.of(2026, 5, 9, 9, 10));
+
+            when(chatRoomRepository.getByIdWithContextOrThrow(roomId)).thenReturn(room);
+            when(chatRoomMemberRepository.findByRoomIdAndUserIdForUpdate(roomId, userId)).thenReturn(Optional.of(member));
+            when(chatMessageRepository.findByIdAndRoomId(message.getId(), roomId)).thenReturn(Optional.of(message));
+
+            ChatReadResponse response = chatReadService.read(userId, roomId, new ChatReadRequest(message.getId()));
+
+            assertThat(response.updated()).isTrue();
+            assertThat(member.getLastReadMessage()).isEqualTo(message);
+        }
+    }
+
+    @Nested
+    @DisplayName("읽음 처리 실패")
+    class ReadFailure {
+
+        @Test
+        @DisplayName("DELETED 방은 찾을 수 없는 방으로 처리한다")
+        void deletedRoomThrowsNotFound() {
+            Long roomId = 1L;
+            User user = createUser(10L, "reader");
+            ChatRoom room = createPrivateRoom(roomId, createPost(100L, user), ChatRoomStatus.DELETED);
+
+            when(chatRoomRepository.getByIdWithContextOrThrow(roomId)).thenReturn(room);
+
+            assertThatThrownBy(() -> chatReadService.read(user.getId(), roomId, new ChatReadRequest(123L)))
+                    .isInstanceOf(ChatRoomNotFoundException.class);
+
+            verifyNoInteractions(chatRoomMemberRepository, chatMessageRepository, simpMessagingTemplate);
+        }
+
+        @Test
+        @DisplayName("채팅방 멤버가 아니면 접근 예외가 발생한다")
+        void nonMemberThrowsAccessDenied() {
+            Long roomId = 1L;
+            Long userId = 10L;
+            User user = createUser(userId, "reader");
+            ChatRoom room = createPrivateRoom(roomId, createPost(100L, user), ChatRoomStatus.ACTIVE);
+
+            when(chatRoomRepository.getByIdWithContextOrThrow(roomId)).thenReturn(room);
+            when(chatRoomMemberRepository.findByRoomIdAndUserIdForUpdate(roomId, userId)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> chatReadService.read(userId, roomId, new ChatReadRequest(123L)))
+                    .isInstanceOf(ChatAccessDeniedException.class);
+
+            verifyNoInteractions(chatMessageRepository, simpMessagingTemplate);
+        }
+
+        @Test
+        @DisplayName("그룹방의 ACTIVE journey member가 아니면 접근 예외가 발생한다")
+        void inactiveJourneyMemberThrowsAccessDenied() {
+            Long roomId = 1L;
+            Long userId = 10L;
+            User user = createUser(userId, "reader");
+            Journey journey = createJourney(30L, createPost(100L, user));
+            ChatRoom room = createGroupRoom(roomId, journey, ChatRoomStatus.ACTIVE);
+            ChatRoomMember member = createMember(room, user, null, LocalDateTime.of(2026, 5, 9, 9, 0));
+
+            when(chatRoomRepository.getByIdWithContextOrThrow(roomId)).thenReturn(room);
+            when(chatRoomMemberRepository.findByRoomIdAndUserIdForUpdate(roomId, userId)).thenReturn(Optional.of(member));
+            when(journeyMemberRepository.existsByJourneyIdAndUserIdAndStatus(30L, userId, JourneyMemberStatus.ACTIVE))
+                    .thenReturn(false);
+
+            assertThatThrownBy(() -> chatReadService.read(userId, roomId, new ChatReadRequest(123L)))
+                    .isInstanceOf(ChatAccessDeniedException.class);
+
+            verifyNoInteractions(chatMessageRepository, simpMessagingTemplate);
+        }
+
+        @Test
+        @DisplayName("다른 방 메시지 ID로 요청하면 메시지 not found 예외가 발생한다")
+        void messageFromOtherRoomThrowsNotFound() {
+            Long roomId = 1L;
+            Long userId = 10L;
+            User user = createUser(userId, "reader");
+            ChatRoom room = createPrivateRoom(roomId, createPost(100L, user), ChatRoomStatus.ACTIVE);
+            ChatRoomMember member = createMember(room, user, null, LocalDateTime.of(2026, 5, 9, 9, 0));
+
+            when(chatRoomRepository.getByIdWithContextOrThrow(roomId)).thenReturn(room);
+            when(chatRoomMemberRepository.findByRoomIdAndUserIdForUpdate(roomId, userId)).thenReturn(Optional.of(member));
+            when(chatMessageRepository.findByIdAndRoomId(999L, roomId)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> chatReadService.read(userId, roomId, new ChatReadRequest(999L)))
+                    .isInstanceOf(ChatMessageNotFoundException.class);
+
+            verifyNoInteractions(simpMessagingTemplate);
+        }
+
+        @Test
+        @DisplayName("현재 사용자의 참여 시점 이전 메시지는 읽음 처리할 수 없다")
+        void messageBeforeVisibleFromThrowsAccessDenied() {
+            Long roomId = 1L;
+            Long userId = 10L;
+            User user = createUser(userId, "reader");
+            ChatRoom room = createPrivateRoom(roomId, createPost(100L, user), ChatRoomStatus.ACTIVE);
+            ChatRoomMember member = createMember(room, user, null, LocalDateTime.of(2026, 5, 9, 9, 10));
+            ChatMessage message = createMessage(123L, room, user, ChatMessageType.TEXT,
+                    "참여 전 메시지", LocalDateTime.of(2026, 5, 9, 9, 9));
+
+            when(chatRoomRepository.getByIdWithContextOrThrow(roomId)).thenReturn(room);
+            when(chatRoomMemberRepository.findByRoomIdAndUserIdForUpdate(roomId, userId)).thenReturn(Optional.of(member));
+            when(chatMessageRepository.findByIdAndRoomId(message.getId(), roomId)).thenReturn(Optional.of(message));
+
+            assertThatThrownBy(() -> chatReadService.read(userId, roomId, new ChatReadRequest(message.getId())))
+                    .isInstanceOf(ChatAccessDeniedException.class);
+
+            verify(simpMessagingTemplate, never()).convertAndSend(any(String.class), any(Object.class));
+        }
+    }
+
+    private ChatRoom createPrivateRoom(Long roomId, Post post, ChatRoomStatus status) {
+        ChatRoom room = ChatRoom.forPrivateChat(post);
+        ReflectionTestUtils.setField(room, "id", roomId);
+        ReflectionTestUtils.setField(room, "status", status);
+        return room;
+    }
+
+    private ChatRoom createGroupRoom(Long roomId, Journey journey, ChatRoomStatus status) {
+        ChatRoom room = ChatRoom.createGroupChat(journey);
+        ReflectionTestUtils.setField(room, "id", roomId);
+        ReflectionTestUtils.setField(room, "status", status);
+        return room;
+    }
+
+    private ChatRoomMember createMember(
+            ChatRoom room,
+            User user,
+            ChatMessage lastReadMessage,
+            LocalDateTime createdAt
+    ) {
+        ChatRoomMember member = ChatRoomMember.builder()
+                .room(room)
+                .user(user)
+                .role(ChatMemberRole.GUEST)
+                .lastReadMessage(lastReadMessage)
+                .build();
+        ReflectionTestUtils.setField(member, "createdAt", createdAt);
+        return member;
+    }
+
+    private ChatMessage createMessage(
+            Long messageId,
+            ChatRoom room,
+            User sender,
+            ChatMessageType messageType,
+            String content,
+            LocalDateTime createdAt
+    ) {
+        ChatMessage message = ChatMessage.create(room, sender, messageType, content);
+        ReflectionTestUtils.setField(message, "id", messageId);
+        ReflectionTestUtils.setField(message, "createdAt", createdAt);
+        return message;
+    }
+
+    private Journey createJourney(Long journeyId, Post post) {
+        Journey journey = Journey.create(post);
+        ReflectionTestUtils.setField(journey, "id", journeyId);
+        ReflectionTestUtils.setField(journey, "title", "그룹 여정");
+        return journey;
+    }
+
+    private Post createPost(Long postId, User owner) {
+        Post post = Post.createPost(
+                owner,
+                null,
+                "채팅 읽음 테스트 게시글",
+                "채팅 읽음 테스트용 본문입니다.",
+                LocalDate.now().plusDays(1),
+                LocalDate.now().plusDays(2),
+                4,
+                LocalDate.now().plusDays(1),
+                Gender.U,
+                true,
+                null,
+                null,
+                "https://example.com/photo.png",
+                "[]",
+                null
+        );
+        ReflectionTestUtils.setField(post, "id", postId);
+        return post;
+    }
+
+    private User createUser(Long userId, String name) {
+        User user = User.builder()
+                .email(name + userId + "@example.com")
+                .name(name)
+                .oauthId("oauth-" + userId)
+                .oauthType(OauthType.KAKAO)
+                .build();
+        ReflectionTestUtils.setField(user, "id", userId);
+        return user;
+    }
+}


### PR DESCRIPTION
## 🔎 작업 내용
* 채팅방 멤버의 `lastReadMessage`를 기준으로 읽음 위치를 저장하도록 구현했습니다.
* 기존 읽음 위치보다 같거나 과거 메시지를 요청하면 갱신하지 않고 `updated=false`를 반환하도록 처리했습니다.
* 읽음 처리 성공 시 READ 이벤트를 트랜잭션 커밋 이후 발행하도록 구현했습니다.
* 읽음 처리 API 문서와 서비스/컨트롤러 테스트를 추가했습니다.

## ➕ 이슈 링크
* #230

## 📸 스크린샷
x

## 😎 리뷰 요구사항
> 읽음 처리 기준이 `lastReadMessageId` 포인터 방식으로 충분한지 봐주세요. 특히 그룹 채팅에서 ACTIVE 여정 멤버 권한 검증 기준이 적절한지 확인 부탁드립니다.

## 🧑‍💻 예정 작업
- #

## 📝 체크리스트
- [x] 브랜치 이름은 `feat/개발내용` 형식으로 작성했는가?
- [x] 커밋 메시지는 `feat(scope): 커밋 내용` 형식으로 작성했는가?
- [x] 작업 전 Issue를 작성했는가?
- [ ] `dev` 브랜치로 병합을 요청했는가?
- [x] 불필요한 주석과 공백은 제거했는가?
- [ ] 코드 리뷰어의 피드백을 반영했는가?
- [x] 테스트를 진행했는가?
- [x] 테스트 코드를 작성했는가?