### PR TITLE
feat:  나의 여정 참여자 관리

### DIFF
--- a/docs/PARTICIPATION_GROUP_CHAT_FLOW.md
+++ b/docs/PARTICIPATION_GROUP_CHAT_FLOW.md
@@ -14,10 +14,12 @@
 
 - 게시글 신청 상태는 `PENDING`, `CONTACTING`, `APPROVED`, `REJECTED`만 사용한다.
 - 게시글 신청 취소 시 `Participation` row를 삭제한다.
-- 승인 후 사용자가 그룹방을 나가면 `Participation` row도 삭제한다.
-- 방장이 승인된 사용자를 그룹방에서 내보내면 `Participation` row도 삭제한다.
+- 승인 이후의 실제 여행 접근 권한은 `journey_members`로 판단한다.
+- 방장이 승인된 사용자를 내보내면 `journey_members.status = REMOVED`로 변경하고 `Participation` row는 승인 이력으로 유지한다.
+- 내보내진 사용자는 그룹 채팅방의 `ChatRoomMember` row를 삭제한다.
 - 신청이 `REJECTED` 되면 row는 유지되며 재신청할 수 없다.
 - 모집 가능 여부는 `Post.recruitCount < recruitCapacity` 기준으로 판단한다.
+- 나의 여정 접근 권한은 `journey_members.status = ACTIVE` 기준으로 판단한다.
 - 그룹방 현재 인원은 `ChatRoomMember` 기준으로 계산한다.
 - 게시글이 마감되거나 삭제되어도 그룹 채팅방은 삭제하지 않는다.
 - 정원이 가득 차면 신규 신청, 연락 시작, 승인이 모두 불가하다.
@@ -44,7 +46,7 @@
 
 ### 4.2 Participation
 
-현재 유효한 신청만 보관한다.
+참여 신청과 승인 이력을 보관한다.
 
 상태:
 
@@ -56,8 +58,8 @@
 row 삭제 이벤트:
 
 - 신청자 취소
-- 승인 후 신청자의 그룹방 자진 이탈
-- 승인 후 방장의 그룹방 내보내기
+
+승인 이후 내보내기 여부는 `participations.status`가 아니라 `journey_members.status`로 표현한다.
 
 ### 4.3 Group Chat Room
 
@@ -126,17 +128,24 @@ row 삭제 이벤트:
 
 ### 5.7 그룹방 자진 이탈
 
-1. 승인된 사용자가 그룹방을 나간다.
-2. 해당 사용자의 그룹방 멤버 row를 삭제한다.
-3. 해당 사용자의 `Participation` row도 삭제한다.
-4. 결과적으로 승인 정원 1칸이 비게 된다.
+아직 별도 API와 정책을 확정하지 않은 흐름이다.
+
+정책 후보:
+
+1. 승인된 사용자가 나의 여정을 직접 나간다.
+2. 해당 사용자의 `journey_members.status`를 `LEFT`로 변경한다.
+3. 해당 사용자의 그룹방 멤버 row를 삭제한다.
+4. `Participation` row는 승인 이력으로 유지할지 별도 확정한다.
+5. `Post.recruitCount`를 1 감소시켜 승인 정원 1칸이 비게 한다.
 
 ### 5.8 방장이 승인자 내보내기
 
-1. 방장이 승인된 사용자를 그룹방에서 내보낸다.
-2. 해당 사용자의 그룹방 멤버 row를 삭제한다.
-3. 해당 사용자의 `Participation` row도 삭제한다.
-4. 결과적으로 승인 정원 1칸이 비게 된다.
+1. 방장이 승인된 사용자를 나의 여정에서 내보낸다.
+2. 해당 사용자의 `journey_members.status`를 `REMOVED`로 변경한다.
+3. 해당 사용자의 그룹방 멤버 row를 삭제한다.
+4. 해당 사용자의 `Participation` row는 `APPROVED` 승인 이력으로 유지한다.
+5. `Post.recruitCount`를 1 감소시켜 승인 정원 1칸이 비게 한다.
+6. 내 신청 내역 응답에서는 `journey_members.status = REMOVED`를 기준으로 `REMOVED_BY_HOST`를 계산해서 내려준다.
 
 ### 5.9 정원 가득 참
 
@@ -165,8 +174,8 @@ row 삭제 이벤트:
 | `CONTACTING` | 거절하기 | `REJECTED` | row 유지 |
 | `PENDING` | 신청자 취소 | 삭제 | row 삭제 |
 | `CONTACTING` | 신청자 취소 | 삭제 | row 삭제 |
-| `APPROVED` | 신청자 그룹방 나가기 | 삭제 | row 삭제 + 그룹방 멤버 삭제 |
-| `APPROVED` | 방장 내보내기 | 삭제 | row 삭제 + 그룹방 멤버 삭제 |
+| `APPROVED` | 신청자 그룹방 나가기 | 정책 확정 필요 | `journey_members.status = LEFT` 사용 후보 |
+| `APPROVED` | 방장 내보내기 | `APPROVED` 유지 | `journey_members.status = REMOVED` + 그룹방 멤버 삭제 |
 
 ## 7. 정원 규칙
 
@@ -225,7 +234,8 @@ row 삭제 이벤트:
 이 제약을 유지하는 이유:
 
 - `REJECTED` row가 남아 있으면 재신청을 막을 수 있다.
-- 신청 취소/자진 이탈/방장 내보내기는 row 삭제이므로 다시 신청 가능하다.
+- 신청 취소는 row 삭제이므로 다시 신청 가능하다.
+- 방장 내보내기는 승인 이력을 유지하고 `journey_members.status = REMOVED`로 현재 멤버십만 차단한다.
 
 권장 인덱스:
 
@@ -287,16 +297,16 @@ row 삭제 이벤트:
 
 - 연락 시작: 1:1 채팅방 생성/재사용 + 필요 시 `CONTACTING` 전환
 - 승인: 그룹방 초대 + `Participation APPROVED` + `recruitCount` 증가
+- 방장 내보내기: `journey_members.status = REMOVED` + 그룹방 멤버 삭제 + `recruitCount` 감소
 
 후속 설계 메모:
 
-- 그룹방 자진 이탈 시 그룹방 멤버 삭제 + `Participation` 삭제
-- 그룹방 내보내기 시 그룹방 멤버 삭제 + `Participation` 삭제
+- 그룹방 자진 이탈 시 `journey_members.status = LEFT`를 사용할지 별도 확정 필요
 
 ## 10. 예외 규칙
 
 - `REJECTED` 상태면 재신청 불가
-- 그룹방을 나가거나 내보내진 경우는 row 삭제이므로 재신청 가능
+- 방장에게 내보내진 경우는 승인 이력을 유지하되 나의 여정 접근과 그룹방 접근이 차단된다.
 - 게시글 `CLOSED` 상태면 신청 생성, 연락 시작, 승인 불가
 - 정원이 가득 찬 경우 신청 생성, 연락 시작, 승인 불가
 - `APPROVED`, `REJECTED` 상태에서는 `채팅하기`, `수락하기` 불가

--- a/src/main/java/com/dduru/gildongmu/chat/dto/query/ChatRoomIdByPostIdQueryResult.java
+++ b/src/main/java/com/dduru/gildongmu/chat/dto/query/ChatRoomIdByPostIdQueryResult.java
@@ -1,0 +1,7 @@
+package com.dduru.gildongmu.chat.dto.query;
+
+public record ChatRoomIdByPostIdQueryResult(
+        Long postId,
+        Long roomId
+) {
+}

--- a/src/main/java/com/dduru/gildongmu/chat/repository/ChatRoomMemberRepository.java
+++ b/src/main/java/com/dduru/gildongmu/chat/repository/ChatRoomMemberRepository.java
@@ -6,8 +6,12 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.Optional;
+
 public interface ChatRoomMemberRepository extends JpaRepository<ChatRoomMember, Long> {
     int countByRoom(ChatRoom room);
+
+    Optional<ChatRoomMember> findByRoomIdAndUserId(Long roomId, Long userId);
 
     @Query("""
             SELECT COUNT(m) > 0

--- a/src/main/java/com/dduru/gildongmu/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/dduru/gildongmu/chat/repository/ChatRoomRepository.java
@@ -3,6 +3,7 @@ package com.dduru.gildongmu.chat.repository;
 import com.dduru.gildongmu.chat.domain.ChatRoom;
 import com.dduru.gildongmu.chat.domain.enums.ChatRoomStatus;
 import com.dduru.gildongmu.chat.domain.enums.ChatRoomType;
+import com.dduru.gildongmu.chat.dto.query.ChatRoomIdByPostIdQueryResult;
 import com.dduru.gildongmu.chat.exception.ChatRoomNotFoundException;
 import com.dduru.gildongmu.user.domain.User;
 import jakarta.persistence.LockModeType;
@@ -11,6 +12,8 @@ import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
@@ -74,6 +77,17 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
             """)
     Optional<ChatRoom> findByJourneyPostIdAndRoomType(
             @Param("postId") Long postId,
+            @Param("roomType") ChatRoomType roomType
+    );
+
+    @Query("""
+            SELECT new com.dduru.gildongmu.chat.dto.query.ChatRoomIdByPostIdQueryResult(r.journey.post.id, r.id)
+            FROM ChatRoom r
+            WHERE r.journey.post.id IN :postIds
+              AND r.roomType = :roomType
+            """)
+    List<ChatRoomIdByPostIdQueryResult> findRoomIdsByJourneyPostIdsAndRoomType(
+            @Param("postIds") Collection<Long> postIds,
             @Param("roomType") ChatRoomType roomType
     );
 

--- a/src/main/java/com/dduru/gildongmu/chat/service/ChatMessageSendService.java
+++ b/src/main/java/com/dduru/gildongmu/chat/service/ChatMessageSendService.java
@@ -59,6 +59,10 @@ public class ChatMessageSendService {
         saveSystemMessageAndBroadcast(room, chatSystemMessageFactory.userInvited(inviteeUserId, actorUserId));
     }
 
+    public void publishUserKicked(ChatRoom room, long targetUserId, long actorUserId) {
+        saveSystemMessageAndBroadcast(room, chatSystemMessageFactory.userKicked(targetUserId, actorUserId));
+    }
+
     private void saveSystemMessageAndBroadcast(ChatRoom room, ChatSystemMessagePayload systemMessage) {
         ChatMessage chatMessage = saveAndFlushMessage(room, null, ChatMessageType.SYSTEM,
                 chatSystemMessageFactory.serialize(systemMessage)

--- a/src/main/java/com/dduru/gildongmu/journey/controller/JourneyApiDocs.java
+++ b/src/main/java/com/dduru/gildongmu/journey/controller/JourneyApiDocs.java
@@ -62,4 +62,19 @@ public interface JourneyApiDocs {
             @Parameter(hidden = true) Long userId,
             JourneyUpdateRequest request
     );
+
+    @Operation(
+            summary = "나의 여정 멤버 내보내기",
+            description = "active host가 특정 나의 여정 멤버를 내보냅니다. 멤버십을 REMOVED로 변경하고 그룹 채팅방 멤버십도 함께 제거합니다."
+    )
+    @ApiResponse(responseCode = "204", description = "내보내기 성공")
+    @ApiErrorResponses({
+            ErrorCode.UNAUTHORIZED,
+            ErrorCode.JOURNEY_ACCESS_DENIED
+    })
+    ResponseEntity<ApiResult<Void>> removeJourneyMember(
+            @Parameter(description = "여정 ID") Long journeyId,
+            @Parameter(description = "내보낼 멤버의 사용자 ID") Long memberUserId,
+            @Parameter(hidden = true) Long userId
+    );
 }

--- a/src/main/java/com/dduru/gildongmu/journey/controller/JourneyController.java
+++ b/src/main/java/com/dduru/gildongmu/journey/controller/JourneyController.java
@@ -9,10 +9,12 @@ import com.dduru.gildongmu.journey.dto.response.JourneyUpdateResponse;
 import com.dduru.gildongmu.journey.service.JourneyQueryService;
 import com.dduru.gildongmu.journey.service.JourneyService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -53,5 +55,16 @@ public class JourneyController implements JourneyApiDocs {
     ) {
         JourneyUpdateResponse response = journeyService.updateBasicInfo(journeyId, userId, request);
         return ResponseEntity.ok(ApiResult.ok(response));
+    }
+
+    @Override
+    @DeleteMapping("/journeys/{journeyId}/members/{memberUserId}")
+    public ResponseEntity<ApiResult<Void>> removeJourneyMember(
+            @PathVariable Long journeyId,
+            @PathVariable Long memberUserId,
+            @CurrentUser Long userId
+    ) {
+        journeyService.removeMember(journeyId, userId, memberUserId);
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).body(ApiResult.noContent());
     }
 }

--- a/src/main/java/com/dduru/gildongmu/journey/dto/query/JourneyMemberStatusQueryResult.java
+++ b/src/main/java/com/dduru/gildongmu/journey/dto/query/JourneyMemberStatusQueryResult.java
@@ -1,0 +1,9 @@
+package com.dduru.gildongmu.journey.dto.query;
+
+import com.dduru.gildongmu.journey.domain.enums.JourneyMemberStatus;
+
+public record JourneyMemberStatusQueryResult(
+        Long postId,
+        JourneyMemberStatus status
+) {
+}

--- a/src/main/java/com/dduru/gildongmu/journey/repository/JourneyMemberRepository.java
+++ b/src/main/java/com/dduru/gildongmu/journey/repository/JourneyMemberRepository.java
@@ -1,7 +1,6 @@
 package com.dduru.gildongmu.journey.repository;
 
 import com.dduru.gildongmu.journey.domain.JourneyMember;
-import com.dduru.gildongmu.journey.domain.enums.JourneyMemberRole;
 import com.dduru.gildongmu.journey.domain.enums.JourneyMemberStatus;
 import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -19,11 +18,17 @@ public interface JourneyMemberRepository extends JpaRepository<JourneyMember, Lo
 
     boolean existsByJourneyIdAndUserIdAndStatus(Long journeyId, Long userId, JourneyMemberStatus status);
 
-    boolean existsByJourneyIdAndUserIdAndRoleAndStatus(
-            Long journeyId,
-            Long userId,
-            JourneyMemberRole role,
-            JourneyMemberStatus status
+    @Query("""
+            SELECT COUNT(jm) > 0
+            FROM JourneyMember jm
+            WHERE jm.journey.id = :journeyId
+              AND jm.user.id = :userId
+              AND jm.role = 'HOST'
+              AND jm.status = 'ACTIVE'
+            """)
+    boolean existsActiveHost(
+            @Param("journeyId") Long journeyId,
+            @Param("userId") Long userId
     );
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
@@ -39,6 +44,17 @@ public interface JourneyMemberRepository extends JpaRepository<JourneyMember, Lo
             """)
     Optional<JourneyMember> findActiveMemberForUpdate(
             @Param("journeyId") Long journeyId,
+            @Param("userId") Long userId
+    );
+
+    @Query("""
+            SELECT jm.status
+            FROM JourneyMember jm
+            WHERE jm.journey.post.id = :postId
+              AND jm.user.id = :userId
+            """)
+    Optional<JourneyMemberStatus> findStatusByJourneyPostIdAndUserId(
+            @Param("postId") Long postId,
             @Param("userId") Long userId
     );
 

--- a/src/main/java/com/dduru/gildongmu/journey/repository/JourneyMemberRepository.java
+++ b/src/main/java/com/dduru/gildongmu/journey/repository/JourneyMemberRepository.java
@@ -2,6 +2,7 @@ package com.dduru.gildongmu.journey.repository;
 
 import com.dduru.gildongmu.journey.domain.JourneyMember;
 import com.dduru.gildongmu.journey.domain.enums.JourneyMemberStatus;
+import com.dduru.gildongmu.journey.dto.query.JourneyMemberStatusQueryResult;
 import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
@@ -9,6 +10,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDate;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -57,6 +59,17 @@ public interface JourneyMemberRepository extends JpaRepository<JourneyMember, Lo
             """)
     Optional<JourneyMemberStatus> findStatusByJourneyPostIdAndUserId(
             @Param("postId") Long postId,
+            @Param("userId") Long userId
+    );
+
+    @Query("""
+            SELECT new com.dduru.gildongmu.journey.dto.query.JourneyMemberStatusQueryResult(jm.journey.post.id, jm.status)
+            FROM JourneyMember jm
+            WHERE jm.journey.post.id IN :postIds
+              AND jm.user.id = :userId
+            """)
+    List<JourneyMemberStatusQueryResult> findStatusesByJourneyPostIdsAndUserId(
+            @Param("postIds") Collection<Long> postIds,
             @Param("userId") Long userId
     );
 

--- a/src/main/java/com/dduru/gildongmu/journey/repository/JourneyMemberRepository.java
+++ b/src/main/java/com/dduru/gildongmu/journey/repository/JourneyMemberRepository.java
@@ -46,7 +46,7 @@ public interface JourneyMemberRepository extends JpaRepository<JourneyMember, Lo
               AND jm.user.id = :userId
               AND jm.status = 'ACTIVE'
             """)
-    Optional<JourneyMember> findActiveMemberForUpdate(
+    Optional<JourneyMember> findActiveMemberWithLock(
             @Param("journeyId") Long journeyId,
             @Param("userId") Long userId
     );

--- a/src/main/java/com/dduru/gildongmu/journey/repository/JourneyMemberRepository.java
+++ b/src/main/java/com/dduru/gildongmu/journey/repository/JourneyMemberRepository.java
@@ -1,8 +1,11 @@
 package com.dduru.gildongmu.journey.repository;
 
 import com.dduru.gildongmu.journey.domain.JourneyMember;
+import com.dduru.gildongmu.journey.domain.enums.JourneyMemberRole;
 import com.dduru.gildongmu.journey.domain.enums.JourneyMemberStatus;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -15,6 +18,29 @@ public interface JourneyMemberRepository extends JpaRepository<JourneyMember, Lo
     Optional<JourneyMember> findByJourneyIdAndUserId(Long journeyId, Long userId);
 
     boolean existsByJourneyIdAndUserIdAndStatus(Long journeyId, Long userId, JourneyMemberStatus status);
+
+    boolean existsByJourneyIdAndUserIdAndRoleAndStatus(
+            Long journeyId,
+            Long userId,
+            JourneyMemberRole role,
+            JourneyMemberStatus status
+    );
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("""
+            SELECT jm
+            FROM JourneyMember jm
+            JOIN FETCH jm.journey j
+            JOIN FETCH j.post
+            JOIN FETCH jm.user
+            WHERE j.id = :journeyId
+              AND jm.user.id = :userId
+              AND jm.status = 'ACTIVE'
+            """)
+    Optional<JourneyMember> findActiveMemberForUpdate(
+            @Param("journeyId") Long journeyId,
+            @Param("userId") Long userId
+    );
 
     @Query("""
             SELECT jm

--- a/src/main/java/com/dduru/gildongmu/journey/repository/JourneyRepository.java
+++ b/src/main/java/com/dduru/gildongmu/journey/repository/JourneyRepository.java
@@ -28,12 +28,11 @@ public interface JourneyRepository extends JpaRepository<Journey, Long> {
     );
 
     @Query("""
-            SELECT j
+            SELECT j.post.id
             FROM Journey j
-            JOIN FETCH j.post
             WHERE j.id = :journeyId
             """)
-    Optional<Journey> findByIdWithPost(@Param("journeyId") Long journeyId);
+    Optional<Long> findPostIdById(@Param("journeyId") Long journeyId);
 
     @Query("""
             SELECT j
@@ -52,8 +51,8 @@ public interface JourneyRepository extends JpaRepository<Journey, Long> {
         return findByPostId(postId).orElseThrow(JourneyNotFoundException::new);
     }
 
-    default Journey getByIdWithPostOrThrow(Long journeyId) {
-        return findByIdWithPost(journeyId)
+    default Long getPostIdByIdOrThrow(Long journeyId) {
+        return findPostIdById(journeyId)
                 .orElseThrow(JourneyNotFoundException::new);
     }
 

--- a/src/main/java/com/dduru/gildongmu/journey/repository/JourneyRepository.java
+++ b/src/main/java/com/dduru/gildongmu/journey/repository/JourneyRepository.java
@@ -30,6 +30,14 @@ public interface JourneyRepository extends JpaRepository<Journey, Long> {
     @Query("""
             SELECT j
             FROM Journey j
+            JOIN FETCH j.post
+            WHERE j.id = :journeyId
+            """)
+    Optional<Journey> findByIdWithPost(@Param("journeyId") Long journeyId);
+
+    @Query("""
+            SELECT j
+            FROM Journey j
             JOIN FETCH j.post p
             JOIN FETCH p.destination
             WHERE j.id = :journeyId
@@ -42,6 +50,11 @@ public interface JourneyRepository extends JpaRepository<Journey, Long> {
 
     default Journey getByPostIdOrThrow(Long postId) {
         return findByPostId(postId).orElseThrow(JourneyNotFoundException::new);
+    }
+
+    default Journey getByIdWithPostOrThrow(Long journeyId) {
+        return findByIdWithPost(journeyId)
+                .orElseThrow(JourneyNotFoundException::new);
     }
 
     default Journey getByIdWithPostContextOrThrow(Long journeyId) {

--- a/src/main/java/com/dduru/gildongmu/journey/service/JourneyService.java
+++ b/src/main/java/com/dduru/gildongmu/journey/service/JourneyService.java
@@ -67,7 +67,7 @@ public class JourneyService {
         member.remove();
         // 신청 승인 이력은 유지하고, 현재 멤버십에 맞춰 모집 인원만 줄인다.
         participationRepository.findByPostIdAndUserIdAndStatus(postId, memberUserId, ParticipationStatus.APPROVED)
-                .ifPresent(post::excludeApprovedParticipation);
+                .ifPresent(post::decrementRecruitCountIfApproved);
         findGroupChatRoomAndRemoveMember(journeyId, hostUserId, memberUserId);
 
         log.info("나의 여정 멤버 내보내기 완료 - journeyId={}, hostUserId={}, memberUserId={}",

--- a/src/main/java/com/dduru/gildongmu/journey/service/JourneyService.java
+++ b/src/main/java/com/dduru/gildongmu/journey/service/JourneyService.java
@@ -94,7 +94,7 @@ public class JourneyService {
     }
 
     private JourneyMember getActiveMemberForUpdate(Long journeyId, Long memberUserId) {
-        return journeyMemberRepository.findActiveMemberForUpdate(journeyId, memberUserId)
+        return journeyMemberRepository.findActiveMemberWithLock(journeyId, memberUserId)
                 .orElseThrow(JourneyAccessDeniedException::new);
     }
 

--- a/src/main/java/com/dduru/gildongmu/journey/service/JourneyService.java
+++ b/src/main/java/com/dduru/gildongmu/journey/service/JourneyService.java
@@ -1,14 +1,25 @@
 package com.dduru.gildongmu.journey.service;
 
+import com.dduru.gildongmu.chat.domain.ChatRoom;
+import com.dduru.gildongmu.chat.domain.enums.ChatRoomType;
+import com.dduru.gildongmu.chat.repository.ChatRoomMemberRepository;
+import com.dduru.gildongmu.chat.repository.ChatRoomRepository;
+import com.dduru.gildongmu.chat.service.ChatMessageSendService;
 import com.dduru.gildongmu.common.validation.InvalidImageUrlException;
 import com.dduru.gildongmu.common.validation.S3ImageUrlValidator;
 import com.dduru.gildongmu.journey.domain.Journey;
+import com.dduru.gildongmu.journey.domain.JourneyMember;
+import com.dduru.gildongmu.journey.domain.enums.JourneyMemberRole;
 import com.dduru.gildongmu.journey.domain.enums.JourneyMemberStatus;
 import com.dduru.gildongmu.journey.dto.request.JourneyUpdateRequest;
 import com.dduru.gildongmu.journey.dto.response.JourneyUpdateResponse;
 import com.dduru.gildongmu.journey.exception.InvalidJourneyBasicInfoException;
 import com.dduru.gildongmu.journey.exception.JourneyAccessDeniedException;
 import com.dduru.gildongmu.journey.repository.JourneyRepository;
+import com.dduru.gildongmu.journey.repository.JourneyMemberRepository;
+import com.dduru.gildongmu.participation.domain.enums.ParticipationStatus;
+import com.dduru.gildongmu.participation.repository.ParticipationRepository;
+import com.dduru.gildongmu.post.domain.Post;
 import com.dduru.gildongmu.s3.enums.S3ImageDirectory;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -25,6 +36,11 @@ public class JourneyService {
     private static final int TITLE_MAX_LENGTH = 40;
 
     private final JourneyRepository journeyRepository;
+    private final JourneyMemberRepository journeyMemberRepository;
+    private final ChatRoomRepository chatRoomRepository;
+    private final ChatRoomMemberRepository chatRoomMemberRepository;
+    private final ParticipationRepository participationRepository;
+    private final ChatMessageSendService chatMessageSendService;
     private final S3ImageUrlValidator s3ImageUrlValidator;
 
     public JourneyUpdateResponse updateBasicInfo(Long journeyId, Long userId, JourneyUpdateRequest request) {
@@ -39,9 +55,63 @@ public class JourneyService {
         return JourneyUpdateResponse.from(journey);
     }
 
+    public void removeMember(Long journeyId, Long hostUserId, Long memberUserId) {
+        validateHostAuthority(journeyId, hostUserId);
+
+        JourneyMember member = getActiveMemberForUpdate(journeyId, memberUserId);
+        validateRemovableMember(member, hostUserId);
+
+        Post post = member.getJourney().getPost();
+        member.remove();
+        // 실제 접근 권한은 journey_member에서 끊고, 참여 신청 이력은 별도 상태로 남긴다.
+        participationRepository.findByPostIdAndUserIdAndStatus(post.getId(), memberUserId, ParticipationStatus.APPROVED)
+                .ifPresent(post::removeApprovedParticipationByHost);
+        findGroupChatRoomAndRemoveMember(journeyId, hostUserId, memberUserId);
+
+        log.info("나의 여정 멤버 내보내기 완료 - journeyId={}, hostUserId={}, memberUserId={}",
+                journeyId, hostUserId, memberUserId);
+    }
+
     private Journey getUpdatableJourney(Long journeyId, Long userId) {
         return journeyRepository.findUpdatableJourneyByIdAndUserId(journeyId, userId, JourneyMemberStatus.ACTIVE)
                 .orElseThrow(JourneyAccessDeniedException::new);
+    }
+
+    private void validateHostAuthority(Long journeyId, Long hostUserId) {
+        boolean isActiveHost = journeyMemberRepository.existsByJourneyIdAndUserIdAndRoleAndStatus(
+                journeyId,
+                hostUserId,
+                JourneyMemberRole.HOST,
+                JourneyMemberStatus.ACTIVE
+        );
+        if (!isActiveHost) {
+            throw new JourneyAccessDeniedException();
+        }
+    }
+
+    private JourneyMember getActiveMemberForUpdate(Long journeyId, Long memberUserId) {
+        return journeyMemberRepository.findActiveMemberForUpdate(journeyId, memberUserId)
+                .orElseThrow(JourneyAccessDeniedException::new);
+    }
+
+    private static void validateRemovableMember(JourneyMember member, Long hostUserId) {
+        if (member.isHost() || member.getUser().getId().equals(hostUserId)) {
+            throw new JourneyAccessDeniedException();
+        }
+    }
+
+    private void findGroupChatRoomAndRemoveMember(Long journeyId, Long hostUserId, Long memberUserId) {
+        // 그룹 채팅방 멤버십은 존재할 때만 함께 정리한다.
+        chatRoomRepository.findByJourneyIdAndRoomType(journeyId, ChatRoomType.GROUP)
+                .ifPresent(chatRoom -> removeMemberFromGroupChatRoom(chatRoom, hostUserId, memberUserId));
+    }
+
+    private void removeMemberFromGroupChatRoom(ChatRoom chatRoom, Long hostUserId, Long memberUserId) {
+        chatRoomMemberRepository.findByRoomIdAndUserId(chatRoom.getId(), memberUserId)
+                .ifPresent(chatRoomMember -> {
+                    chatRoomMemberRepository.delete(chatRoomMember);
+                    chatMessageSendService.publishUserKicked(chatRoom, memberUserId, hostUserId);
+                });
     }
 
     private void validateHasAnyPatch(String title, String photoUrl) {

--- a/src/main/java/com/dduru/gildongmu/journey/service/JourneyService.java
+++ b/src/main/java/com/dduru/gildongmu/journey/service/JourneyService.java
@@ -59,11 +59,11 @@ public class JourneyService {
     public void removeMember(Long journeyId, Long hostUserId, Long memberUserId) {
         validateHostAuthority(journeyId, hostUserId);
 
+        Post post = getPostForMemberRemoval(journeyId);
         JourneyMember member = getActiveMemberForUpdate(journeyId, memberUserId);
         validateRemovableMember(member);
 
-        Long postId = member.getJourney().getPost().getId();
-        Post post = postRepository.getActiveByIdWithLockOrThrow(postId);
+        Long postId = post.getId();
         member.remove();
         // 신청 승인 이력은 유지하고, 현재 멤버십에 맞춰 모집 인원만 줄인다.
         participationRepository.findByPostIdAndUserIdAndStatus(postId, memberUserId, ParticipationStatus.APPROVED)
@@ -84,6 +84,13 @@ public class JourneyService {
         if (!isActiveHost) {
             throw new JourneyAccessDeniedException();
         }
+    }
+
+    private Post getPostForMemberRemoval(Long journeyId) {
+        Long postId = journeyRepository.getByIdWithPostOrThrow(journeyId)
+                .getPost()
+                .getId();
+        return postRepository.getActiveByIdWithLockOrThrow(postId);
     }
 
     private JourneyMember getActiveMemberForUpdate(Long journeyId, Long memberUserId) {

--- a/src/main/java/com/dduru/gildongmu/journey/service/JourneyService.java
+++ b/src/main/java/com/dduru/gildongmu/journey/service/JourneyService.java
@@ -9,7 +9,6 @@ import com.dduru.gildongmu.common.validation.InvalidImageUrlException;
 import com.dduru.gildongmu.common.validation.S3ImageUrlValidator;
 import com.dduru.gildongmu.journey.domain.Journey;
 import com.dduru.gildongmu.journey.domain.JourneyMember;
-import com.dduru.gildongmu.journey.domain.enums.JourneyMemberRole;
 import com.dduru.gildongmu.journey.domain.enums.JourneyMemberStatus;
 import com.dduru.gildongmu.journey.dto.request.JourneyUpdateRequest;
 import com.dduru.gildongmu.journey.dto.response.JourneyUpdateResponse;
@@ -20,6 +19,7 @@ import com.dduru.gildongmu.journey.repository.JourneyMemberRepository;
 import com.dduru.gildongmu.participation.domain.enums.ParticipationStatus;
 import com.dduru.gildongmu.participation.repository.ParticipationRepository;
 import com.dduru.gildongmu.post.domain.Post;
+import com.dduru.gildongmu.post.repository.PostRepository;
 import com.dduru.gildongmu.s3.enums.S3ImageDirectory;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -40,6 +40,7 @@ public class JourneyService {
     private final ChatRoomRepository chatRoomRepository;
     private final ChatRoomMemberRepository chatRoomMemberRepository;
     private final ParticipationRepository participationRepository;
+    private final PostRepository postRepository;
     private final ChatMessageSendService chatMessageSendService;
     private final S3ImageUrlValidator s3ImageUrlValidator;
 
@@ -61,11 +62,12 @@ public class JourneyService {
         JourneyMember member = getActiveMemberForUpdate(journeyId, memberUserId);
         validateRemovableMember(member, hostUserId);
 
-        Post post = member.getJourney().getPost();
+        Long postId = member.getJourney().getPost().getId();
+        Post post = postRepository.getActiveByIdWithLockOrThrow(postId);
         member.remove();
-        // 실제 접근 권한은 journey_member에서 끊고, 참여 신청 이력은 별도 상태로 남긴다.
-        participationRepository.findByPostIdAndUserIdAndStatus(post.getId(), memberUserId, ParticipationStatus.APPROVED)
-                .ifPresent(post::removeApprovedParticipationByHost);
+        // 신청 승인 이력은 유지하고, 현재 멤버십에 맞춰 모집 인원만 줄인다.
+        participationRepository.findByPostIdAndUserIdAndStatus(postId, memberUserId, ParticipationStatus.APPROVED)
+                .ifPresent(post::excludeApprovedParticipation);
         findGroupChatRoomAndRemoveMember(journeyId, hostUserId, memberUserId);
 
         log.info("나의 여정 멤버 내보내기 완료 - journeyId={}, hostUserId={}, memberUserId={}",
@@ -78,12 +80,7 @@ public class JourneyService {
     }
 
     private void validateHostAuthority(Long journeyId, Long hostUserId) {
-        boolean isActiveHost = journeyMemberRepository.existsByJourneyIdAndUserIdAndRoleAndStatus(
-                journeyId,
-                hostUserId,
-                JourneyMemberRole.HOST,
-                JourneyMemberStatus.ACTIVE
-        );
+        boolean isActiveHost = journeyMemberRepository.existsActiveHost(journeyId, hostUserId);
         if (!isActiveHost) {
             throw new JourneyAccessDeniedException();
         }

--- a/src/main/java/com/dduru/gildongmu/journey/service/JourneyService.java
+++ b/src/main/java/com/dduru/gildongmu/journey/service/JourneyService.java
@@ -87,9 +87,7 @@ public class JourneyService {
     }
 
     private Post getPostForMemberRemoval(Long journeyId) {
-        Long postId = journeyRepository.getByIdWithPostOrThrow(journeyId)
-                .getPost()
-                .getId();
+        Long postId = journeyRepository.getPostIdByIdOrThrow(journeyId);
         return postRepository.getActiveByIdWithLockOrThrow(postId);
     }
 

--- a/src/main/java/com/dduru/gildongmu/journey/service/JourneyService.java
+++ b/src/main/java/com/dduru/gildongmu/journey/service/JourneyService.java
@@ -60,7 +60,7 @@ public class JourneyService {
         validateHostAuthority(journeyId, hostUserId);
 
         JourneyMember member = getActiveMemberForUpdate(journeyId, memberUserId);
-        validateRemovableMember(member, hostUserId);
+        validateRemovableMember(member);
 
         Long postId = member.getJourney().getPost().getId();
         Post post = postRepository.getActiveByIdWithLockOrThrow(postId);
@@ -91,8 +91,8 @@ public class JourneyService {
                 .orElseThrow(JourneyAccessDeniedException::new);
     }
 
-    private static void validateRemovableMember(JourneyMember member, Long hostUserId) {
-        if (member.isHost() || member.getUser().getId().equals(hostUserId)) {
+    private static void validateRemovableMember(JourneyMember member) {
+        if (member.isHost()) {
             throw new JourneyAccessDeniedException();
         }
     }

--- a/src/main/java/com/dduru/gildongmu/participation/dto/response/MyParticipationResponse.java
+++ b/src/main/java/com/dduru/gildongmu/participation/dto/response/MyParticipationResponse.java
@@ -3,6 +3,7 @@ package com.dduru.gildongmu.participation.dto.response;
 import com.dduru.gildongmu.participation.domain.Participation;
 import com.dduru.gildongmu.participation.domain.enums.ParticipationStatus;
 import com.dduru.gildongmu.post.domain.Post;
+import com.dduru.gildongmu.post.dto.response.MyParticipationStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
@@ -17,8 +18,8 @@ public record MyParticipationResponse(
         String postTitle,
         @Schema(description = "게시글 대표 이미지 URL")
         String photoUrl,
-        @Schema(description = "신청 상태", allowableValues = {"PENDING", "CONTACTING", "APPROVED", "REJECTED"})
-        ParticipationStatus status,
+        @Schema(description = "내 신청 화면 기준 상태", allowableValues = {"PENDING", "CONTACTING", "APPROVED", "REJECTED", "REMOVED_BY_HOST"})
+        MyParticipationStatus status,
         @Schema(description = "신청 시각(상대 시각은 클라이언트에서 계산)")
         LocalDateTime appliedAt,
         @Schema(description = "대기 중일 때만 신청 취소 가능")
@@ -30,11 +31,12 @@ public record MyParticipationResponse(
 ) {
     public static MyParticipationResponse from(
             Participation participation,
+            MyParticipationStatus status,
             Long privateRoomId,
             Long groupRoomId
     ) {
         Post post = participation.getPost();
-        ParticipationStatus status = participation.getStatus();
+        ParticipationStatus participationStatus = participation.getStatus();
         return new MyParticipationResponse(
                 participation.getId(),
                 post.getId(),
@@ -42,7 +44,7 @@ public record MyParticipationResponse(
                 post.getPhotoUrl(),
                 status,
                 participation.getCreatedAt(),
-                status == ParticipationStatus.PENDING,
+                participationStatus == ParticipationStatus.PENDING,
                 privateRoomId,
                 groupRoomId
         );

--- a/src/main/java/com/dduru/gildongmu/participation/repository/ParticipationRepository.java
+++ b/src/main/java/com/dduru/gildongmu/participation/repository/ParticipationRepository.java
@@ -29,7 +29,6 @@ public interface ParticipationRepository extends JpaRepository<Participation, Lo
 
     Optional<Participation> findByPostIdAndUserId(Long postId, Long userId);
 
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
     Optional<Participation> findByPostIdAndUserIdAndStatus(Long postId, Long userId, ParticipationStatus status);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)

--- a/src/main/java/com/dduru/gildongmu/participation/repository/ParticipationRepository.java
+++ b/src/main/java/com/dduru/gildongmu/participation/repository/ParticipationRepository.java
@@ -1,6 +1,7 @@
 package com.dduru.gildongmu.participation.repository;
 
 import com.dduru.gildongmu.participation.domain.Participation;
+import com.dduru.gildongmu.participation.domain.enums.ParticipationStatus;
 import com.dduru.gildongmu.participation.exception.ParticipationNotFoundException;
 import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -27,6 +28,9 @@ public interface ParticipationRepository extends JpaRepository<Participation, Lo
     List<Participation> findMyApplicationsForVisiblePosts(@Param("userId") Long userId);
 
     Optional<Participation> findByPostIdAndUserId(Long postId, Long userId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    Optional<Participation> findByPostIdAndUserIdAndStatus(Long postId, Long userId, ParticipationStatus status);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("""

--- a/src/main/java/com/dduru/gildongmu/participation/service/ParticipationApplicantService.java
+++ b/src/main/java/com/dduru/gildongmu/participation/service/ParticipationApplicantService.java
@@ -77,7 +77,7 @@ public class ParticipationApplicantService {
             return MyParticipationStatus.NONE;
         }
         return participationRepository.findByPostIdAndUserId(postId, currentUserId)
-                .map(ParticipationApplicantService::toMyParticipationStatus)
+                .map(participation -> toMyParticipationStatus(postId, currentUserId, participation))
                 .orElse(MyParticipationStatus.NONE);
     }
 
@@ -90,13 +90,23 @@ public class ParticipationApplicantService {
         log.info("참여신청 취소(삭제) - participationId: {}, postId: {}, userId: {}", participationId, participation.getPost().getId(), userId);
     }
 
-    private static MyParticipationStatus toMyParticipationStatus(Participation participation) {
+    private MyParticipationStatus toMyParticipationStatus(Long postId, Long userId, Participation participation) {
+        if (participation.isApproved() && hasJourneyMemberStatus(postId, userId, JourneyMemberStatus.REMOVED)) {
+            return MyParticipationStatus.REMOVED_BY_HOST;
+        }
+
         return switch (participation.getStatus()) {
             case PENDING -> MyParticipationStatus.PENDING;
             case CONTACTING -> MyParticipationStatus.CONTACTING;
             case APPROVED -> MyParticipationStatus.APPROVED;
             case REJECTED -> MyParticipationStatus.REJECTED;
         };
+    }
+
+    private boolean hasJourneyMemberStatus(Long postId, Long userId, JourneyMemberStatus status) {
+        return journeyMemberRepository.findStatusByJourneyPostIdAndUserId(postId, userId)
+                .filter(status::equals)
+                .isPresent();
     }
 
     private void validateParticipationAllowed(Post post, User applicant) {
@@ -106,8 +116,10 @@ public class ParticipationApplicantService {
     }
 
     private MyParticipationResponse toApplicationResponse(Long applicantUserId, Participation participation) {
+        Long postId = participation.getPost().getId();
         ChatRoomIds roomIds = resolveChatRoomIds(applicantUserId, participation);
-        return MyParticipationResponse.from(participation, roomIds.privateRoomId(), roomIds.groupRoomId());
+        MyParticipationStatus status = toMyParticipationStatus(postId, applicantUserId, participation);
+        return MyParticipationResponse.from(participation, status, roomIds.privateRoomId(), roomIds.groupRoomId());
     }
 
     private ChatRoomIds resolveChatRoomIds(Long applicantUserId, Participation participation) {
@@ -119,7 +131,9 @@ public class ParticipationApplicantService {
             );
             case APPROVED -> new ChatRoomIds(
                     null,
-                    findGroupRoomId(post.getId())
+                    hasJourneyMemberStatus(post.getId(), applicantUserId, JourneyMemberStatus.ACTIVE)
+                            ? findGroupRoomId(post.getId())
+                            : null
             );
             case PENDING, REJECTED -> new ChatRoomIds(null, null);
         };

--- a/src/main/java/com/dduru/gildongmu/participation/service/ParticipationApplicantService.java
+++ b/src/main/java/com/dduru/gildongmu/participation/service/ParticipationApplicantService.java
@@ -1,10 +1,11 @@
 package com.dduru.gildongmu.participation.service;
 
-import com.dduru.gildongmu.chat.domain.ChatRoom;
 import com.dduru.gildongmu.chat.domain.enums.ChatRoomStatus;
 import com.dduru.gildongmu.chat.domain.enums.ChatRoomType;
+import com.dduru.gildongmu.chat.dto.query.ChatRoomIdByPostIdQueryResult;
 import com.dduru.gildongmu.chat.repository.ChatRoomRepository;
 import com.dduru.gildongmu.journey.domain.enums.JourneyMemberStatus;
+import com.dduru.gildongmu.journey.dto.query.JourneyMemberStatusQueryResult;
 import com.dduru.gildongmu.journey.repository.JourneyMemberRepository;
 import com.dduru.gildongmu.participation.domain.Participation;
 import com.dduru.gildongmu.participation.dto.request.ParticipationRequest;
@@ -29,7 +30,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -59,8 +63,12 @@ public class ParticipationApplicantService {
 
     @Transactional(readOnly = true)
     public List<MyParticipationResponse> retrieveMyApplications(Long userId) {
-        return participationRepository.findMyApplicationsForVisiblePosts(userId).stream()
-                .map(participation -> toApplicationResponse(userId, participation))
+        List<Participation> participations = participationRepository.findMyApplicationsForVisiblePosts(userId);
+        Map<Long, JourneyMemberStatus> journeyMemberStatusesByPostId = findJourneyMemberStatusesByPostId(userId, participations);
+        Map<Long, Long> groupRoomIdsByPostId = findGroupRoomIdsByPostId(journeyMemberStatusesByPostId);
+
+        return participations.stream()
+                .map(participation -> toApplicationResponse(participation, journeyMemberStatusesByPostId, groupRoomIdsByPostId))
                 .toList();
     }
 
@@ -140,21 +148,70 @@ public class ParticipationApplicantService {
         ensureNoDuplicateApplication(post.getId(), applicant.getId());
     }
 
-    private MyParticipationResponse toApplicationResponse(Long applicantUserId, Participation participation) {
+    private Map<Long, JourneyMemberStatus> findJourneyMemberStatusesByPostId(Long userId, List<Participation> participations) {
+        // 실제 여정 멤버십은 승인 이후에만 생성되므로 APPROVED 신청만 조회한다.
+        Set<Long> approvedPostIds = participations.stream()
+                .filter(Participation::isApproved)
+                .map(participation -> participation.getPost().getId())
+                .collect(Collectors.toSet());
+        if (approvedPostIds.isEmpty()) {
+            return Map.of();
+        }
+
+        return journeyMemberRepository.findStatusesByJourneyPostIdsAndUserId(approvedPostIds, userId).stream()
+                .collect(Collectors.toMap(
+                        JourneyMemberStatusQueryResult::postId,
+                        JourneyMemberStatusQueryResult::status,
+                        (first, second) -> first
+                ));
+    }
+
+    private Map<Long, Long> findGroupRoomIdsByPostId(Map<Long, JourneyMemberStatus> journeyMemberStatusesByPostId) {
+        Set<Long> activePostIds = journeyMemberStatusesByPostId.entrySet().stream()
+                .filter(entry -> entry.getValue() == JourneyMemberStatus.ACTIVE)
+                .map(Map.Entry::getKey)
+                .collect(Collectors.toSet());
+        if (activePostIds.isEmpty()) {
+            return Map.of();
+        }
+
+        return chatRoomRepository.findRoomIdsByJourneyPostIdsAndRoomType(activePostIds, ChatRoomType.GROUP).stream()
+                .collect(Collectors.toMap(
+                        ChatRoomIdByPostIdQueryResult::postId,
+                        ChatRoomIdByPostIdQueryResult::roomId,
+                        (first, second) -> first
+                ));
+    }
+
+    private MyParticipationResponse toApplicationResponse(
+            Participation participation,
+            Map<Long, JourneyMemberStatus> journeyMemberStatusesByPostId,
+            Map<Long, Long> groupRoomIdsByPostId
+    ) {
         Long postId = participation.getPost().getId();
-        Optional<JourneyMemberStatus> journeyMemberStatus = findJourneyMemberStatusIfApproved(
-                postId,
-                applicantUserId,
-                participation
+        Optional<JourneyMemberStatus> journeyMemberStatus = getJourneyMemberStatusIfApproved(
+                participation,
+                journeyMemberStatusesByPostId
         );
-        ChatRoomIds roomIds = resolveChatRoomIds(participation, journeyMemberStatus);
+        ChatRoomIds roomIds = resolveChatRoomIds(participation, journeyMemberStatus, groupRoomIdsByPostId);
         MyParticipationStatus status = toMyParticipationStatus(participation, journeyMemberStatus);
         return MyParticipationResponse.from(participation, status, roomIds.privateRoomId(), roomIds.groupRoomId());
     }
 
+    private static Optional<JourneyMemberStatus> getJourneyMemberStatusIfApproved(
+            Participation participation,
+            Map<Long, JourneyMemberStatus> journeyMemberStatusesByPostId
+    ) {
+        if (!participation.isApproved()) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(journeyMemberStatusesByPostId.get(participation.getPost().getId()));
+    }
+
     private ChatRoomIds resolveChatRoomIds(
             Participation participation,
-            Optional<JourneyMemberStatus> journeyMemberStatus
+            Optional<JourneyMemberStatus> journeyMemberStatus,
+            Map<Long, Long> groupRoomIdsByPostId
     ) {
         Post post = participation.getPost();
         return switch (participation.getStatus()) {
@@ -165,7 +222,7 @@ public class ParticipationApplicantService {
             case APPROVED -> new ChatRoomIds(
                     null,
                     hasJourneyMemberStatus(journeyMemberStatus, JourneyMemberStatus.ACTIVE)
-                            ? findGroupRoomId(post.getId())
+                            ? groupRoomIdsByPostId.get(post.getId())
                             : null
             );
             case PENDING, REJECTED -> new ChatRoomIds(null, null);
@@ -180,12 +237,6 @@ public class ParticipationApplicantService {
                 applicantUserId,
                 post.getUser().getId()
         ).orElse(null);
-    }
-
-    private Long findGroupRoomId(Long postId) {
-        return chatRoomRepository.findByJourneyPostIdAndRoomType(postId, ChatRoomType.GROUP)
-                .map(ChatRoom::getId)
-                .orElse(null);
     }
 
     private static void validateApplicantOwnership(Long userId, Participation participation) {

--- a/src/main/java/com/dduru/gildongmu/participation/service/ParticipationApplicantService.java
+++ b/src/main/java/com/dduru/gildongmu/participation/service/ParticipationApplicantService.java
@@ -29,6 +29,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 
 @Slf4j
 @Service
@@ -77,7 +78,10 @@ public class ParticipationApplicantService {
             return MyParticipationStatus.NONE;
         }
         return participationRepository.findByPostIdAndUserId(postId, currentUserId)
-                .map(participation -> toMyParticipationStatus(postId, currentUserId, participation))
+                .map(participation -> toMyParticipationStatus(
+                        participation,
+                        findJourneyMemberStatusIfApproved(postId, currentUserId, participation)
+                ))
                 .orElse(MyParticipationStatus.NONE);
     }
 
@@ -90,8 +94,12 @@ public class ParticipationApplicantService {
         log.info("참여신청 취소(삭제) - participationId: {}, postId: {}, userId: {}", participationId, participation.getPost().getId(), userId);
     }
 
-    private MyParticipationStatus toMyParticipationStatus(Long postId, Long userId, Participation participation) {
-        if (participation.isApproved() && hasJourneyMemberStatus(postId, userId, JourneyMemberStatus.REMOVED)) {
+    private MyParticipationStatus toMyParticipationStatus(
+            Participation participation,
+            Optional<JourneyMemberStatus> journeyMemberStatus
+    ) {
+        // 내보내기는 신청 상태가 아니라 현재 여정 멤버십 상태로 응답에만 표현한다.
+        if (participation.isApproved() && hasJourneyMemberStatus(journeyMemberStatus, JourneyMemberStatus.REMOVED)) {
             return MyParticipationStatus.REMOVED_BY_HOST;
         }
 
@@ -103,9 +111,26 @@ public class ParticipationApplicantService {
         };
     }
 
-    private boolean hasJourneyMemberStatus(Long postId, Long userId, JourneyMemberStatus status) {
-        return journeyMemberRepository.findStatusByJourneyPostIdAndUserId(postId, userId)
-                .filter(status::equals)
+    private Optional<JourneyMemberStatus> findJourneyMemberStatus(Long postId, Long userId) {
+        return journeyMemberRepository.findStatusByJourneyPostIdAndUserId(postId, userId);
+    }
+
+    private Optional<JourneyMemberStatus> findJourneyMemberStatusIfApproved(
+            Long postId,
+            Long userId,
+            Participation participation
+    ) {
+        if (!participation.isApproved()) {
+            return Optional.empty();
+        }
+        return findJourneyMemberStatus(postId, userId);
+    }
+
+    private static boolean hasJourneyMemberStatus(
+            Optional<JourneyMemberStatus> journeyMemberStatus,
+            JourneyMemberStatus status
+    ) {
+        return journeyMemberStatus.filter(status::equals)
                 .isPresent();
     }
 
@@ -117,21 +142,29 @@ public class ParticipationApplicantService {
 
     private MyParticipationResponse toApplicationResponse(Long applicantUserId, Participation participation) {
         Long postId = participation.getPost().getId();
-        ChatRoomIds roomIds = resolveChatRoomIds(applicantUserId, participation);
-        MyParticipationStatus status = toMyParticipationStatus(postId, applicantUserId, participation);
+        Optional<JourneyMemberStatus> journeyMemberStatus = findJourneyMemberStatusIfApproved(
+                postId,
+                applicantUserId,
+                participation
+        );
+        ChatRoomIds roomIds = resolveChatRoomIds(participation, journeyMemberStatus);
+        MyParticipationStatus status = toMyParticipationStatus(participation, journeyMemberStatus);
         return MyParticipationResponse.from(participation, status, roomIds.privateRoomId(), roomIds.groupRoomId());
     }
 
-    private ChatRoomIds resolveChatRoomIds(Long applicantUserId, Participation participation) {
+    private ChatRoomIds resolveChatRoomIds(
+            Participation participation,
+            Optional<JourneyMemberStatus> journeyMemberStatus
+    ) {
         Post post = participation.getPost();
         return switch (participation.getStatus()) {
             case CONTACTING -> new ChatRoomIds(
-                    findActivePrivateRoomId(applicantUserId, post),
+                    findActivePrivateRoomId(participation.getUser().getId(), post),
                     null
             );
             case APPROVED -> new ChatRoomIds(
                     null,
-                    hasJourneyMemberStatus(post.getId(), applicantUserId, JourneyMemberStatus.ACTIVE)
+                    hasJourneyMemberStatus(journeyMemberStatus, JourneyMemberStatus.ACTIVE)
                             ? findGroupRoomId(post.getId())
                             : null
             );

--- a/src/main/java/com/dduru/gildongmu/post/domain/Post.java
+++ b/src/main/java/com/dduru/gildongmu/post/domain/Post.java
@@ -193,7 +193,7 @@ public class Post extends BaseTimeEntity {
         incrementRecruitCount();
     }
 
-    public void removeApprovedParticipation(Participation participation) {
+    public void excludeApprovedParticipation(Participation participation) {
         if (!participation.isApproved()) {
             return;
         }

--- a/src/main/java/com/dduru/gildongmu/post/domain/Post.java
+++ b/src/main/java/com/dduru/gildongmu/post/domain/Post.java
@@ -193,7 +193,7 @@ public class Post extends BaseTimeEntity {
         incrementRecruitCount();
     }
 
-    public void excludeApprovedParticipation(Participation participation) {
+    public void decrementRecruitCountIfApproved(Participation participation) {
         if (!participation.isApproved()) {
             return;
         }

--- a/src/main/java/com/dduru/gildongmu/post/dto/response/MyParticipationStatus.java
+++ b/src/main/java/com/dduru/gildongmu/post/dto/response/MyParticipationStatus.java
@@ -5,5 +5,6 @@ public enum MyParticipationStatus {
     PENDING,
     CONTACTING,
     APPROVED,
-    REJECTED
+    REJECTED,
+    REMOVED_BY_HOST
 }

--- a/src/test/java/com/dduru/gildongmu/journey/service/JourneyServiceTest.java
+++ b/src/test/java/com/dduru/gildongmu/journey/service/JourneyServiceTest.java
@@ -250,7 +250,7 @@ class JourneyServiceTest {
             when(journeyMemberRepository.existsActiveHost(journeyId, hostUserId)).thenReturn(true);
             when(journeyRepository.getByIdWithPostOrThrow(journeyId)).thenReturn(journey);
             when(postRepository.getActiveByIdWithLockOrThrow(post.getId())).thenReturn(post);
-            when(journeyMemberRepository.findActiveMemberForUpdate(journeyId, memberUserId))
+            when(journeyMemberRepository.findActiveMemberWithLock(journeyId, memberUserId))
                     .thenReturn(Optional.of(member));
             when(participationRepository.findByPostIdAndUserIdAndStatus(post.getId(), memberUserId, ParticipationStatus.APPROVED))
                     .thenReturn(Optional.of(participation));
@@ -271,7 +271,7 @@ class JourneyServiceTest {
             InOrder inOrder = inOrder(journeyMemberRepository, postRepository);
             inOrder.verify(journeyMemberRepository).existsActiveHost(journeyId, hostUserId);
             inOrder.verify(postRepository).getActiveByIdWithLockOrThrow(post.getId());
-            inOrder.verify(journeyMemberRepository).findActiveMemberForUpdate(journeyId, memberUserId);
+            inOrder.verify(journeyMemberRepository).findActiveMemberWithLock(journeyId, memberUserId);
         }
 
         @Test
@@ -286,7 +286,7 @@ class JourneyServiceTest {
             assertThatThrownBy(() -> journeyService.removeMember(journeyId, requesterUserId, memberUserId))
                     .isInstanceOf(JourneyAccessDeniedException.class);
 
-            verify(journeyMemberRepository, never()).findActiveMemberForUpdate(journeyId, memberUserId);
+            verify(journeyMemberRepository, never()).findActiveMemberWithLock(journeyId, memberUserId);
         }
 
         @Test
@@ -301,7 +301,7 @@ class JourneyServiceTest {
             when(journeyMemberRepository.existsActiveHost(journeyId, hostUserId)).thenReturn(true);
             when(journeyRepository.getByIdWithPostOrThrow(journeyId)).thenReturn(journey);
             when(postRepository.getActiveByIdWithLockOrThrow(post.getId())).thenReturn(post);
-            when(journeyMemberRepository.findActiveMemberForUpdate(journeyId, hostUserId))
+            when(journeyMemberRepository.findActiveMemberWithLock(journeyId, hostUserId))
                     .thenReturn(Optional.of(hostMember));
 
             assertThatThrownBy(() -> journeyService.removeMember(journeyId, hostUserId, hostUserId))

--- a/src/test/java/com/dduru/gildongmu/journey/service/JourneyServiceTest.java
+++ b/src/test/java/com/dduru/gildongmu/journey/service/JourneyServiceTest.java
@@ -35,6 +35,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -44,6 +45,7 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -246,9 +248,10 @@ class JourneyServiceTest {
             ChatRoomMember chatRoomMember = ChatRoomMember.create(room, memberUser, ChatMemberRole.GUEST);
 
             when(journeyMemberRepository.existsActiveHost(journeyId, hostUserId)).thenReturn(true);
+            when(journeyRepository.getByIdWithPostOrThrow(journeyId)).thenReturn(journey);
+            when(postRepository.getActiveByIdWithLockOrThrow(post.getId())).thenReturn(post);
             when(journeyMemberRepository.findActiveMemberForUpdate(journeyId, memberUserId))
                     .thenReturn(Optional.of(member));
-            when(postRepository.getActiveByIdWithLockOrThrow(post.getId())).thenReturn(post);
             when(participationRepository.findByPostIdAndUserIdAndStatus(post.getId(), memberUserId, ParticipationStatus.APPROVED))
                     .thenReturn(Optional.of(participation));
             when(chatRoomRepository.findByJourneyIdAndRoomType(journeyId, ChatRoomType.GROUP))
@@ -264,6 +267,11 @@ class JourneyServiceTest {
             assertThat(post.getRecruitCount()).isEqualTo(1);
             verify(chatRoomMemberRepository).delete(chatRoomMember);
             verify(chatMessageSendService).publishUserKicked(room, memberUserId, hostUserId);
+
+            InOrder inOrder = inOrder(journeyMemberRepository, postRepository);
+            inOrder.verify(journeyMemberRepository).existsActiveHost(journeyId, hostUserId);
+            inOrder.verify(postRepository).getActiveByIdWithLockOrThrow(post.getId());
+            inOrder.verify(journeyMemberRepository).findActiveMemberForUpdate(journeyId, memberUserId);
         }
 
         @Test
@@ -287,9 +295,12 @@ class JourneyServiceTest {
             Long journeyId = 1L;
             Long hostUserId = 10L;
             Journey journey = createJourney(journeyId, hostUserId);
+            Post post = journey.getPost();
             JourneyMember hostMember = JourneyMember.createHost(journey, journey.getPost().getUser());
 
             when(journeyMemberRepository.existsActiveHost(journeyId, hostUserId)).thenReturn(true);
+            when(journeyRepository.getByIdWithPostOrThrow(journeyId)).thenReturn(journey);
+            when(postRepository.getActiveByIdWithLockOrThrow(post.getId())).thenReturn(post);
             when(journeyMemberRepository.findActiveMemberForUpdate(journeyId, hostUserId))
                     .thenReturn(Optional.of(hostMember));
 

--- a/src/test/java/com/dduru/gildongmu/journey/service/JourneyServiceTest.java
+++ b/src/test/java/com/dduru/gildongmu/journey/service/JourneyServiceTest.java
@@ -248,7 +248,7 @@ class JourneyServiceTest {
             ChatRoomMember chatRoomMember = ChatRoomMember.create(room, memberUser, ChatMemberRole.GUEST);
 
             when(journeyMemberRepository.existsActiveHost(journeyId, hostUserId)).thenReturn(true);
-            when(journeyRepository.getByIdWithPostOrThrow(journeyId)).thenReturn(journey);
+            when(journeyRepository.getPostIdByIdOrThrow(journeyId)).thenReturn(post.getId());
             when(postRepository.getActiveByIdWithLockOrThrow(post.getId())).thenReturn(post);
             when(journeyMemberRepository.findActiveMemberWithLock(journeyId, memberUserId))
                     .thenReturn(Optional.of(member));
@@ -299,7 +299,7 @@ class JourneyServiceTest {
             JourneyMember hostMember = JourneyMember.createHost(journey, journey.getPost().getUser());
 
             when(journeyMemberRepository.existsActiveHost(journeyId, hostUserId)).thenReturn(true);
-            when(journeyRepository.getByIdWithPostOrThrow(journeyId)).thenReturn(journey);
+            when(journeyRepository.getPostIdByIdOrThrow(journeyId)).thenReturn(post.getId());
             when(postRepository.getActiveByIdWithLockOrThrow(post.getId())).thenReturn(post);
             when(journeyMemberRepository.findActiveMemberWithLock(journeyId, hostUserId))
                     .thenReturn(Optional.of(hostMember));

--- a/src/test/java/com/dduru/gildongmu/journey/service/JourneyServiceTest.java
+++ b/src/test/java/com/dduru/gildongmu/journey/service/JourneyServiceTest.java
@@ -1,5 +1,12 @@
 package com.dduru.gildongmu.journey.service;
 
+import com.dduru.gildongmu.chat.domain.ChatRoom;
+import com.dduru.gildongmu.chat.domain.ChatRoomMember;
+import com.dduru.gildongmu.chat.domain.enums.ChatMemberRole;
+import com.dduru.gildongmu.chat.domain.enums.ChatRoomType;
+import com.dduru.gildongmu.chat.repository.ChatRoomMemberRepository;
+import com.dduru.gildongmu.chat.repository.ChatRoomRepository;
+import com.dduru.gildongmu.chat.service.ChatMessageSendService;
 import com.dduru.gildongmu.common.config.S3Properties;
 import com.dduru.gildongmu.common.exception.BusinessException;
 import com.dduru.gildongmu.common.exception.ErrorCode;
@@ -12,9 +19,14 @@ import com.dduru.gildongmu.journey.dto.request.JourneyUpdateRequest;
 import com.dduru.gildongmu.journey.dto.response.JourneyUpdateResponse;
 import com.dduru.gildongmu.journey.exception.InvalidJourneyBasicInfoException;
 import com.dduru.gildongmu.journey.exception.JourneyAccessDeniedException;
+import com.dduru.gildongmu.journey.repository.JourneyMemberRepository;
 import com.dduru.gildongmu.journey.repository.JourneyRepository;
+import com.dduru.gildongmu.participation.domain.Participation;
+import com.dduru.gildongmu.participation.domain.enums.ParticipationStatus;
+import com.dduru.gildongmu.participation.repository.ParticipationRepository;
 import com.dduru.gildongmu.post.domain.Post;
 import com.dduru.gildongmu.post.domain.enums.CompanionType;
+import com.dduru.gildongmu.post.repository.PostRepository;
 import com.dduru.gildongmu.profile.domain.enums.Gender;
 import com.dduru.gildongmu.user.domain.User;
 import com.dduru.gildongmu.user.domain.enums.OauthType;
@@ -32,6 +44,8 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -41,6 +55,18 @@ class JourneyServiceTest {
 
     @Mock
     private JourneyRepository journeyRepository;
+    @Mock
+    private JourneyMemberRepository journeyMemberRepository;
+    @Mock
+    private ChatRoomRepository chatRoomRepository;
+    @Mock
+    private ChatRoomMemberRepository chatRoomMemberRepository;
+    @Mock
+    private ParticipationRepository participationRepository;
+    @Mock
+    private PostRepository postRepository;
+    @Mock
+    private ChatMessageSendService chatMessageSendService;
 
     private JourneyService journeyService;
 
@@ -49,7 +75,16 @@ class JourneyServiceTest {
         S3Properties s3Properties = new S3Properties();
         s3Properties.setBucket("dummy-bucket");
         s3Properties.setRegion("ap-northeast-2");
-        journeyService = new JourneyService(journeyRepository, new S3ImageUrlValidator(s3Properties));
+        journeyService = new JourneyService(
+                journeyRepository,
+                journeyMemberRepository,
+                chatRoomRepository,
+                chatRoomMemberRepository,
+                participationRepository,
+                postRepository,
+                chatMessageSendService,
+                new S3ImageUrlValidator(s3Properties)
+        );
     }
 
     @Nested
@@ -190,6 +225,81 @@ class JourneyServiceTest {
         }
     }
 
+    @Nested
+    @DisplayName("나의 여정 멤버 관리")
+    class ManageMembers {
+
+        @Test
+        @DisplayName("호스트는 active 멤버를 내보내고 그룹 채팅방에서도 제거할 수 있다")
+        void hostCanRemoveActiveMemberAndSyncGroupChat() {
+            Long journeyId = 1L;
+            Long hostUserId = 10L;
+            Long memberUserId = 20L;
+            Long roomId = 55L;
+            Journey journey = createJourney(journeyId, hostUserId);
+            Post post = journey.getPost();
+            User memberUser = createUser(memberUserId, "member");
+            JourneyMember member = JourneyMember.createMember(journey, memberUser);
+            Participation participation = Participation.createParticipation(post, memberUser, "같이 가고 싶어요.");
+            post.approveParticipation(participation);
+            ChatRoom room = createGroupChatRoom(roomId, journey);
+            ChatRoomMember chatRoomMember = ChatRoomMember.create(room, memberUser, ChatMemberRole.GUEST);
+
+            when(journeyMemberRepository.existsActiveHost(journeyId, hostUserId)).thenReturn(true);
+            when(journeyMemberRepository.findActiveMemberForUpdate(journeyId, memberUserId))
+                    .thenReturn(Optional.of(member));
+            when(postRepository.getActiveByIdWithLockOrThrow(post.getId())).thenReturn(post);
+            when(participationRepository.findByPostIdAndUserIdAndStatus(post.getId(), memberUserId, ParticipationStatus.APPROVED))
+                    .thenReturn(Optional.of(participation));
+            when(chatRoomRepository.findByJourneyIdAndRoomType(journeyId, ChatRoomType.GROUP))
+                    .thenReturn(Optional.of(room));
+            when(chatRoomMemberRepository.findByRoomIdAndUserId(roomId, memberUserId))
+                    .thenReturn(Optional.of(chatRoomMember));
+
+            journeyService.removeMember(journeyId, hostUserId, memberUserId);
+
+            assertThat(member.getStatus()).isEqualTo(JourneyMemberStatus.REMOVED);
+            assertThat(member.getRemovedAt()).isNotNull();
+            assertThat(participation.getStatus()).isEqualTo(ParticipationStatus.APPROVED);
+            assertThat(post.getRecruitCount()).isEqualTo(1);
+            verify(chatRoomMemberRepository).delete(chatRoomMember);
+            verify(chatMessageSendService).publishUserKicked(room, memberUserId, hostUserId);
+        }
+
+        @Test
+        @DisplayName("active host가 아니면 멤버를 내보낼 수 없다")
+        void nonHostCannotRemoveMember() {
+            Long journeyId = 1L;
+            Long requesterUserId = 30L;
+            Long memberUserId = 20L;
+
+            when(journeyMemberRepository.existsActiveHost(journeyId, requesterUserId)).thenReturn(false);
+
+            assertThatThrownBy(() -> journeyService.removeMember(journeyId, requesterUserId, memberUserId))
+                    .isInstanceOf(JourneyAccessDeniedException.class);
+
+            verify(journeyMemberRepository, never()).findActiveMemberForUpdate(journeyId, memberUserId);
+        }
+
+        @Test
+        @DisplayName("호스트 멤버는 내보낼 수 없다")
+        void cannotRemoveHostMember() {
+            Long journeyId = 1L;
+            Long hostUserId = 10L;
+            Journey journey = createJourney(journeyId, hostUserId);
+            JourneyMember hostMember = JourneyMember.createHost(journey, journey.getPost().getUser());
+
+            when(journeyMemberRepository.existsActiveHost(journeyId, hostUserId)).thenReturn(true);
+            when(journeyMemberRepository.findActiveMemberForUpdate(journeyId, hostUserId))
+                    .thenReturn(Optional.of(hostMember));
+
+            assertThatThrownBy(() -> journeyService.removeMember(journeyId, hostUserId, hostUserId))
+                    .isInstanceOf(JourneyAccessDeniedException.class);
+
+            verify(chatRoomRepository, never()).findByJourneyIdAndRoomType(journeyId, ChatRoomType.GROUP);
+        }
+    }
+
     private Journey createJourney(Long journeyId, Long ownerId) {
         Post post = createPost(100L, ownerId, "제주도 2박 3일 여행", "제주");
         Journey journey = Journey.create(post);
@@ -224,6 +334,12 @@ class JourneyServiceTest {
         );
         ReflectionTestUtils.setField(post, "id", postId);
         return post;
+    }
+
+    private ChatRoom createGroupChatRoom(Long roomId, Journey journey) {
+        ChatRoom room = ChatRoom.createGroupChat(journey);
+        ReflectionTestUtils.setField(room, "id", roomId);
+        return room;
     }
 
     private User createUser(Long userId, String name) {

--- a/src/test/java/com/dduru/gildongmu/participation/service/ParticipationApplicantServiceTest.java
+++ b/src/test/java/com/dduru/gildongmu/participation/service/ParticipationApplicantServiceTest.java
@@ -1,0 +1,109 @@
+package com.dduru.gildongmu.participation.service;
+
+import com.dduru.gildongmu.chat.repository.ChatRoomRepository;
+import com.dduru.gildongmu.journey.domain.enums.JourneyMemberStatus;
+import com.dduru.gildongmu.journey.repository.JourneyMemberRepository;
+import com.dduru.gildongmu.participation.domain.Participation;
+import com.dduru.gildongmu.participation.repository.ParticipationRepository;
+import com.dduru.gildongmu.post.domain.Post;
+import com.dduru.gildongmu.post.dto.response.MyParticipationStatus;
+import com.dduru.gildongmu.post.repository.PostRepository;
+import com.dduru.gildongmu.profile.utils.ProfileImageResolver;
+import com.dduru.gildongmu.user.domain.User;
+import com.dduru.gildongmu.user.domain.enums.OauthType;
+import com.dduru.gildongmu.user.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ParticipationApplicantService 테스트")
+class ParticipationApplicantServiceTest {
+
+    @Mock
+    private ParticipationRepository participationRepository;
+    @Mock
+    private PostRepository postRepository;
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private ChatRoomRepository chatRoomRepository;
+    @Mock
+    private ProfileImageResolver profileImageResolver;
+    @Mock
+    private JourneyMemberRepository journeyMemberRepository;
+
+    @InjectMocks
+    private ParticipationApplicantService participationApplicantService;
+
+    @Nested
+    @DisplayName("내 참여 상태 조회")
+    class GetMyParticipationStatus {
+
+        @Test
+        @DisplayName("승인 이력이 있어도 여정 멤버가 REMOVED이면 REMOVED_BY_HOST를 반환한다")
+        void approvedParticipationWithRemovedJourneyMemberReturnsRemovedByHost() {
+            Long postId = 1L;
+            Long userId = 20L;
+            Participation participation = createApprovedParticipation(postId, userId);
+
+            when(participationRepository.findByPostIdAndUserId(postId, userId))
+                    .thenReturn(Optional.of(participation));
+            when(journeyMemberRepository.findStatusByJourneyPostIdAndUserId(postId, userId))
+                    .thenReturn(Optional.of(JourneyMemberStatus.REMOVED));
+
+            MyParticipationStatus status = participationApplicantService.getMyParticipationStatus(postId, userId, false);
+
+            assertThat(status).isEqualTo(MyParticipationStatus.REMOVED_BY_HOST);
+        }
+    }
+
+    private Participation createApprovedParticipation(Long postId, Long userId) {
+        User author = createUser(10L, "author");
+        User participant = createUser(userId, "participant");
+        Post post = Post.createPost(
+                author,
+                null,
+                "참여 상태 테스트 게시글",
+                "참여 상태 테스트 본문은 충분히 긴 내용입니다.",
+                LocalDate.now().plusDays(1),
+                LocalDate.now().plusDays(2),
+                3,
+                LocalDate.now().plusDays(1),
+                null,
+                true,
+                null,
+                null,
+                null,
+                "[]",
+                null
+        );
+        ReflectionTestUtils.setField(post, "id", postId);
+
+        Participation participation = Participation.createParticipation(post, participant, "hello");
+        participation.approve();
+        return participation;
+    }
+
+    private User createUser(Long userId, String name) {
+        User user = User.builder()
+                .email(name + "@example.com")
+                .name(name)
+                .oauthId("oauth-" + userId)
+                .oauthType(OauthType.KAKAO)
+                .build();
+        ReflectionTestUtils.setField(user, "id", userId);
+        return user;
+    }
+}

--- a/src/test/java/com/dduru/gildongmu/participation/service/ParticipationApplicantServiceTest.java
+++ b/src/test/java/com/dduru/gildongmu/participation/service/ParticipationApplicantServiceTest.java
@@ -1,9 +1,14 @@
 package com.dduru.gildongmu.participation.service;
 
+import com.dduru.gildongmu.chat.domain.enums.ChatRoomType;
+import com.dduru.gildongmu.chat.dto.query.ChatRoomIdByPostIdQueryResult;
 import com.dduru.gildongmu.chat.repository.ChatRoomRepository;
 import com.dduru.gildongmu.journey.domain.enums.JourneyMemberStatus;
+import com.dduru.gildongmu.journey.dto.query.JourneyMemberStatusQueryResult;
 import com.dduru.gildongmu.journey.repository.JourneyMemberRepository;
 import com.dduru.gildongmu.participation.domain.Participation;
+import com.dduru.gildongmu.participation.domain.enums.ParticipationStatus;
+import com.dduru.gildongmu.participation.dto.response.MyParticipationResponse;
 import com.dduru.gildongmu.participation.repository.ParticipationRepository;
 import com.dduru.gildongmu.post.domain.Post;
 import com.dduru.gildongmu.post.dto.response.MyParticipationStatus;
@@ -22,9 +27,14 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -46,6 +56,47 @@ class ParticipationApplicantServiceTest {
 
     @InjectMocks
     private ParticipationApplicantService participationApplicantService;
+
+    @Nested
+    @DisplayName("내 신청 목록 조회")
+    class RetrieveMyApplications {
+
+        @Test
+        @DisplayName("승인 신청의 여정 상태와 그룹 채팅방을 한 번에 조회한다")
+        void retrievesApprovedJourneyStatusesAndGroupRoomsInBulk() {
+            Long userId = 20L;
+            Long activePostId = 1L;
+            Long removedPostId = 2L;
+            Long pendingPostId = 3L;
+            Long groupRoomId = 100L;
+            Participation activeParticipation = createParticipation(11L, activePostId, userId, ParticipationStatus.APPROVED);
+            Participation removedParticipation = createParticipation(12L, removedPostId, userId, ParticipationStatus.APPROVED);
+            Participation pendingParticipation = createParticipation(13L, pendingPostId, userId, ParticipationStatus.PENDING);
+
+            when(participationRepository.findMyApplicationsForVisiblePosts(userId))
+                    .thenReturn(List.of(activeParticipation, removedParticipation, pendingParticipation));
+            when(journeyMemberRepository.findStatusesByJourneyPostIdsAndUserId(Set.of(activePostId, removedPostId), userId))
+                    .thenReturn(List.of(
+                            new JourneyMemberStatusQueryResult(activePostId, JourneyMemberStatus.ACTIVE),
+                            new JourneyMemberStatusQueryResult(removedPostId, JourneyMemberStatus.REMOVED)
+                    ));
+            when(chatRoomRepository.findRoomIdsByJourneyPostIdsAndRoomType(Set.of(activePostId), ChatRoomType.GROUP))
+                    .thenReturn(List.of(new ChatRoomIdByPostIdQueryResult(activePostId, groupRoomId)));
+
+            List<MyParticipationResponse> responses = participationApplicantService.retrieveMyApplications(userId);
+
+            assertThat(responses).extracting(MyParticipationResponse::status)
+                    .containsExactly(
+                            MyParticipationStatus.APPROVED,
+                            MyParticipationStatus.REMOVED_BY_HOST,
+                            MyParticipationStatus.PENDING
+                    );
+            assertThat(responses).extracting(MyParticipationResponse::groupRoomId)
+                    .containsExactly(groupRoomId, null, null);
+            verify(journeyMemberRepository).findStatusesByJourneyPostIdsAndUserId(Set.of(activePostId, removedPostId), userId);
+            verify(journeyMemberRepository, never()).findStatusByJourneyPostIdAndUserId(anyLong(), anyLong());
+        }
+    }
 
     @Nested
     @DisplayName("내 참여 상태 조회")
@@ -70,6 +121,10 @@ class ParticipationApplicantServiceTest {
     }
 
     private Participation createApprovedParticipation(Long postId, Long userId) {
+        return createParticipation(null, postId, userId, ParticipationStatus.APPROVED);
+    }
+
+    private Participation createParticipation(Long participationId, Long postId, Long userId, ParticipationStatus status) {
         User author = createUser(10L, "author");
         User participant = createUser(userId, "participant");
         Post post = Post.createPost(
@@ -92,8 +147,19 @@ class ParticipationApplicantServiceTest {
         ReflectionTestUtils.setField(post, "id", postId);
 
         Participation participation = Participation.createParticipation(post, participant, "hello");
-        participation.approve();
+        ReflectionTestUtils.setField(participation, "id", participationId);
+        applyStatus(participation, status);
         return participation;
+    }
+
+    private void applyStatus(Participation participation, ParticipationStatus status) {
+        switch (status) {
+            case PENDING -> {
+            }
+            case CONTACTING -> participation.contact();
+            case APPROVED -> participation.approve();
+            case REJECTED -> participation.reject();
+        }
     }
 
     private User createUser(Long userId, String name) {

--- a/src/test/java/com/dduru/gildongmu/post/domain/PostTest.java
+++ b/src/test/java/com/dduru/gildongmu/post/domain/PostTest.java
@@ -78,6 +78,24 @@ class PostTest {
         }
     }
 
+    @Nested
+    @DisplayName("승인된 참여자 제거")
+    class RemoveApprovedParticipation {
+
+        @Test
+        @DisplayName("APPROVED 참여자를 현재 모집 인원에서 제외하면 모집 인원이 감소한다")
+        void approvedChangesStatusAndRecruitCount() {
+            Post post = createPost();
+            Participation participation = createParticipation(post);
+            post.approveParticipation(participation);
+
+            post.excludeApprovedParticipation(participation);
+
+            assertThat(participation.isApproved()).isTrue();
+            assertThat(post.getRecruitCount()).isEqualTo(1);
+        }
+    }
+
     private Post createPost() {
         User author = User.builder()
                 .email("author@example.com")

--- a/src/test/java/com/dduru/gildongmu/post/domain/PostTest.java
+++ b/src/test/java/com/dduru/gildongmu/post/domain/PostTest.java
@@ -89,7 +89,7 @@ class PostTest {
             Participation participation = createParticipation(post);
             post.approveParticipation(participation);
 
-            post.excludeApprovedParticipation(participation);
+            post.decrementRecruitCountIfApproved(participation);
 
             assertThat(participation.isApproved()).isTrue();
             assertThat(post.getRecruitCount()).isEqualTo(1);


### PR DESCRIPTION
## 🔎 작업 내용
* 나의 여정 멤버 내보내기 API 추가.
* `DELETE /api/v1/journeys/{journeyId}/members/{memberUserId}` 엔드포인트를 구현.
* active host만 멤버를 내보낼 수 있도록 권한 검증을 추가.
* 호스트 본인/호스트 멤버는 내보낼 수 없도록 예외 처리.
* 멤버 내보내기 시 `journey_members.status`를 `REMOVED`로 변경.
* 승인된 `Participation` 이력은 유지하면서 `Post.recruitCount`만 감소.
* 그룹 채팅방 멤버가 존재하면 함께 제거하고 강퇴 시스템 메시지를 발행.
* 내 신청 상태 응답에 `REMOVED_BY_HOST`를 추가해 승인 이력과 현재 멤버십 상태를 분리해서 표현.
* 참여 신청/그룹 채팅/나의 여정 멤버십 정책 문서를 현재 동작 기준으로 정리.
* 관련 서비스/도메인 테스트 코드를 추가.

## ➕ 이슈 링크
* Closed #234 

## 😎 리뷰 요구사항
> 승인 이력은 유지하고 현재 멤버십만 `REMOVED`로 관리하는 방향이 정책적으로 적절한지 봐주시면 좋겠습니다.
> 특히 `Participation = APPROVED`, `JourneyMemberStatus = REMOVED` 조합을 응답에서 `REMOVED_BY_HOST`로 매핑한 부분과
> 멤버 내보내기 시 `recruitCount` 감소 처리 방식이 의도와 맞는지 확인 부탁드립니다.


## 📝 체크리스트
- [x] 브랜치 이름은 `feat/개발내용` 형식으로 작성했는가?
- [x] 커밋 메시지는 `feat(scope): 커밋 내용` 형식으로 작성했는가?
- [x] 작업 전 Issue를 작성했는가?
- [x] `dev` 브랜치로 병합을 요청했는가?
- [x] 불필요한 주석과 공백은 제거했는가?
- [x] 코드 리뷰어의 피드백을 반영했는가?
- [x] 테스트를 진행했는가?
- [x] 테스트 코드를 작성했는가?
