### PR TITLE
feat: 나의 여정 게시판 게시글 CRUD API 구현

### DIFF
--- a/src/main/java/com/dduru/gildongmu/common/exception/ErrorCode.java
+++ b/src/main/java/com/dduru/gildongmu/common/exception/ErrorCode.java
@@ -91,6 +91,11 @@ public enum ErrorCode {
     JOURNEY_EMPTY_PATCH(HttpStatus.BAD_REQUEST, "제목 또는 대표 사진 중 하나는 입력해야 합니다."),
     JOURNEY_INVALID_TITLE_LENGTH(HttpStatus.BAD_REQUEST, "제목은 5자 이상 40자 이하여야 합니다."),
     JOURNEY_INVALID_PHOTO_URL(HttpStatus.BAD_REQUEST, "대표 사진 URL 형식이 올바르지 않습니다."),
+    JOURNEY_POST_NOT_FOUND(HttpStatus.NOT_FOUND, "나의 여정 게시글을 찾을 수 없습니다."),
+    JOURNEY_POST_ACCESS_DENIED(HttpStatus.FORBIDDEN, "해당 게시글에 대한 권한이 없습니다."),
+    JOURNEY_POST_EMPTY_PATCH(HttpStatus.BAD_REQUEST, "수정할 게시글 내용이 없습니다."),
+    JOURNEY_POST_INVALID_TITLE(HttpStatus.BAD_REQUEST, "게시글 제목은 1자 이상 30자 이하여야 합니다."),
+    JOURNEY_POST_INVALID_CONTENT(HttpStatus.BAD_REQUEST, "게시글 내용은 1자 이상 300자 이하여야 합니다."),
 
     // 신고 (REPORT)
     REPORT_NOT_FOUND(HttpStatus.NOT_FOUND, "신고 내역을 찾을 수 없습니다."),

--- a/src/main/java/com/dduru/gildongmu/common/exception/ErrorCode.java
+++ b/src/main/java/com/dduru/gildongmu/common/exception/ErrorCode.java
@@ -88,6 +88,7 @@ public enum ErrorCode {
     // 나의 여정 (JOURNEY)
     JOURNEY_NOT_FOUND(HttpStatus.NOT_FOUND, "나의 여정을 찾을 수 없습니다."),
     JOURNEY_ACCESS_DENIED(HttpStatus.FORBIDDEN, "나의 여정에 접근할 권한이 없습니다."),
+    JOURNEY_HOST_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "나의 여정 호스트 정보를 찾을 수 없습니다."),
     JOURNEY_EMPTY_PATCH(HttpStatus.BAD_REQUEST, "제목 또는 대표 사진 중 하나는 입력해야 합니다."),
     JOURNEY_INVALID_TITLE_LENGTH(HttpStatus.BAD_REQUEST, "제목은 5자 이상 40자 이하여야 합니다."),
     JOURNEY_INVALID_PHOTO_URL(HttpStatus.BAD_REQUEST, "대표 사진 URL 형식이 올바르지 않습니다."),

--- a/src/main/java/com/dduru/gildongmu/common/exception/ErrorCode.java
+++ b/src/main/java/com/dduru/gildongmu/common/exception/ErrorCode.java
@@ -94,7 +94,6 @@ public enum ErrorCode {
     JOURNEY_POST_NOT_FOUND(HttpStatus.NOT_FOUND, "나의 여정 게시글을 찾을 수 없습니다."),
     JOURNEY_POST_ACCESS_DENIED(HttpStatus.FORBIDDEN, "해당 게시글에 대한 권한이 없습니다."),
     JOURNEY_POST_EMPTY_PATCH(HttpStatus.BAD_REQUEST, "수정할 게시글 내용이 없습니다."),
-    JOURNEY_POST_INVALID_TITLE(HttpStatus.BAD_REQUEST, "게시글 제목은 1자 이상 30자 이하여야 합니다."),
     JOURNEY_POST_INVALID_CONTENT(HttpStatus.BAD_REQUEST, "게시글 내용은 1자 이상 300자 이하여야 합니다."),
 
     // 신고 (REPORT)

--- a/src/main/java/com/dduru/gildongmu/journey/controller/JourneyPostApiDocs.java
+++ b/src/main/java/com/dduru/gildongmu/journey/controller/JourneyPostApiDocs.java
@@ -1,0 +1,114 @@
+package com.dduru.gildongmu.journey.controller;
+
+import com.dduru.gildongmu.common.annotation.ApiErrorResponses;
+import com.dduru.gildongmu.common.dto.ApiResult;
+import com.dduru.gildongmu.common.exception.ErrorCode;
+import com.dduru.gildongmu.journey.dto.request.JourneyPostCreateRequest;
+import com.dduru.gildongmu.journey.dto.request.JourneyPostUpdateRequest;
+import com.dduru.gildongmu.journey.dto.response.JourneyPostListResponse;
+import com.dduru.gildongmu.journey.dto.response.JourneyPostResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "Journey Posts", description = "나의 여정 게시판 API")
+@SecurityRequirement(name = "JWT")
+public interface JourneyPostApiDocs {
+
+    @Operation(
+            summary = "나의 여정 게시글 목록 조회",
+            description = "active journey member가 같은 여정의 게시글 목록을 조회합니다."
+    )
+    @ApiResponse(responseCode = "200", description = "조회 성공")
+    @ApiErrorResponses({
+            ErrorCode.UNAUTHORIZED,
+            ErrorCode.JOURNEY_NOT_FOUND,
+            ErrorCode.JOURNEY_ACCESS_DENIED
+    })
+    ResponseEntity<ApiResult<JourneyPostListResponse>> retrievePosts(
+            @Parameter(description = "여정 ID") Long journeyId,
+            @Parameter(hidden = true) Long userId
+    );
+
+    @Operation(
+            summary = "나의 여정 게시글 단건 조회",
+            description = "active journey member가 같은 여정의 게시글을 단건 조회합니다."
+    )
+    @ApiResponse(responseCode = "200", description = "조회 성공")
+    @ApiErrorResponses({
+            ErrorCode.UNAUTHORIZED,
+            ErrorCode.JOURNEY_NOT_FOUND,
+            ErrorCode.JOURNEY_ACCESS_DENIED,
+            ErrorCode.JOURNEY_POST_NOT_FOUND
+    })
+    ResponseEntity<ApiResult<JourneyPostResponse>> retrievePost(
+            @Parameter(description = "여정 ID") Long journeyId,
+            @Parameter(description = "나의 여정 게시글 ID") Long journeyPostId,
+            @Parameter(hidden = true) Long userId
+    );
+
+    @Operation(
+            summary = "나의 여정 게시글 작성",
+            description = "active journey member가 같은 여정의 게시글을 작성합니다."
+    )
+    @ApiResponse(responseCode = "201", description = "작성 성공")
+    @ApiErrorResponses({
+            ErrorCode.UNAUTHORIZED,
+            ErrorCode.INVALID_INPUT_VALUE,
+            ErrorCode.JOURNEY_NOT_FOUND,
+            ErrorCode.JOURNEY_ACCESS_DENIED,
+            ErrorCode.JOURNEY_POST_INVALID_TITLE,
+            ErrorCode.JOURNEY_POST_INVALID_CONTENT,
+            ErrorCode.IMAGE_URL_NOT_ALLOWED
+    })
+    ResponseEntity<ApiResult<JourneyPostResponse>> createPost(
+            @Parameter(description = "여정 ID") Long journeyId,
+            @Parameter(hidden = true) Long userId,
+            JourneyPostCreateRequest request
+    );
+
+    @Operation(
+            summary = "나의 여정 게시글 수정",
+            description = "작성자 본인이 나의 여정 게시글을 수정합니다."
+    )
+    @ApiResponse(responseCode = "200", description = "수정 성공")
+    @ApiErrorResponses({
+            ErrorCode.UNAUTHORIZED,
+            ErrorCode.INVALID_INPUT_VALUE,
+            ErrorCode.JOURNEY_NOT_FOUND,
+            ErrorCode.JOURNEY_ACCESS_DENIED,
+            ErrorCode.JOURNEY_POST_NOT_FOUND,
+            ErrorCode.JOURNEY_POST_ACCESS_DENIED,
+            ErrorCode.JOURNEY_POST_EMPTY_PATCH,
+            ErrorCode.JOURNEY_POST_INVALID_TITLE,
+            ErrorCode.JOURNEY_POST_INVALID_CONTENT,
+            ErrorCode.IMAGE_URL_NOT_ALLOWED
+    })
+    ResponseEntity<ApiResult<JourneyPostResponse>> updatePost(
+            @Parameter(description = "여정 ID") Long journeyId,
+            @Parameter(description = "나의 여정 게시글 ID") Long journeyPostId,
+            @Parameter(hidden = true) Long userId,
+            JourneyPostUpdateRequest request
+    );
+
+    @Operation(
+            summary = "나의 여정 게시글 삭제",
+            description = "작성자 본인이 나의 여정 게시글을 soft delete 처리합니다."
+    )
+    @ApiResponse(responseCode = "204", description = "삭제 성공")
+    @ApiErrorResponses({
+            ErrorCode.UNAUTHORIZED,
+            ErrorCode.JOURNEY_NOT_FOUND,
+            ErrorCode.JOURNEY_ACCESS_DENIED,
+            ErrorCode.JOURNEY_POST_NOT_FOUND,
+            ErrorCode.JOURNEY_POST_ACCESS_DENIED
+    })
+    ResponseEntity<ApiResult<Void>> deletePost(
+            @Parameter(description = "여정 ID") Long journeyId,
+            @Parameter(description = "나의 여정 게시글 ID") Long journeyPostId,
+            @Parameter(hidden = true) Long userId
+    );
+}

--- a/src/main/java/com/dduru/gildongmu/journey/controller/JourneyPostApiDocs.java
+++ b/src/main/java/com/dduru/gildongmu/journey/controller/JourneyPostApiDocs.java
@@ -4,6 +4,7 @@ import com.dduru.gildongmu.common.annotation.ApiErrorResponses;
 import com.dduru.gildongmu.common.dto.ApiResult;
 import com.dduru.gildongmu.common.exception.ErrorCode;
 import com.dduru.gildongmu.journey.dto.request.JourneyPostCreateRequest;
+import com.dduru.gildongmu.journey.dto.request.JourneyPostListRequest;
 import com.dduru.gildongmu.journey.dto.request.JourneyPostUpdateRequest;
 import com.dduru.gildongmu.journey.dto.response.JourneyPostListResponse;
 import com.dduru.gildongmu.journey.dto.response.JourneyPostResponse;
@@ -12,6 +13,8 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.ResponseEntity;
 
 @Tag(name = "Journey Posts", description = "나의 여정 게시판 API")
@@ -20,17 +23,20 @@ public interface JourneyPostApiDocs {
 
     @Operation(
             summary = "나의 여정 게시글 목록 조회",
-            description = "active journey member가 같은 여정의 게시글 목록을 조회합니다."
+            description = "active journey member가 같은 여정의 게시글 목록을 cursor 기반으로 조회합니다."
     )
     @ApiResponse(responseCode = "200", description = "조회 성공")
     @ApiErrorResponses({
             ErrorCode.UNAUTHORIZED,
+            ErrorCode.INVALID_INPUT_VALUE,
             ErrorCode.JOURNEY_NOT_FOUND,
-            ErrorCode.JOURNEY_ACCESS_DENIED
+            ErrorCode.JOURNEY_ACCESS_DENIED,
+            ErrorCode.JOURNEY_POST_NOT_FOUND
     })
     ResponseEntity<ApiResult<JourneyPostListResponse>> retrievePosts(
             @Parameter(description = "여정 ID") Long journeyId,
-            @Parameter(hidden = true) Long userId
+            @Parameter(hidden = true) Long userId,
+            @Valid @ParameterObject JourneyPostListRequest request
     );
 
     @Operation(

--- a/src/main/java/com/dduru/gildongmu/journey/controller/JourneyPostApiDocs.java
+++ b/src/main/java/com/dduru/gildongmu/journey/controller/JourneyPostApiDocs.java
@@ -60,7 +60,6 @@ public interface JourneyPostApiDocs {
             ErrorCode.INVALID_INPUT_VALUE,
             ErrorCode.JOURNEY_NOT_FOUND,
             ErrorCode.JOURNEY_ACCESS_DENIED,
-            ErrorCode.JOURNEY_POST_INVALID_TITLE,
             ErrorCode.JOURNEY_POST_INVALID_CONTENT,
             ErrorCode.IMAGE_URL_NOT_ALLOWED
     })
@@ -83,7 +82,6 @@ public interface JourneyPostApiDocs {
             ErrorCode.JOURNEY_POST_NOT_FOUND,
             ErrorCode.JOURNEY_POST_ACCESS_DENIED,
             ErrorCode.JOURNEY_POST_EMPTY_PATCH,
-            ErrorCode.JOURNEY_POST_INVALID_TITLE,
             ErrorCode.JOURNEY_POST_INVALID_CONTENT,
             ErrorCode.IMAGE_URL_NOT_ALLOWED
     })

--- a/src/main/java/com/dduru/gildongmu/journey/controller/JourneyPostController.java
+++ b/src/main/java/com/dduru/gildongmu/journey/controller/JourneyPostController.java
@@ -14,7 +14,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -34,7 +33,7 @@ public class JourneyPostController implements JourneyPostApiDocs {
     public ResponseEntity<ApiResult<JourneyPostListResponse>> retrievePosts(
             @PathVariable Long journeyId,
             @CurrentUser Long userId,
-            @Valid @ModelAttribute JourneyPostListRequest request
+            @Valid JourneyPostListRequest request
     ) {
         JourneyPostListResponse response = journeyPostService.retrievePosts(journeyId, userId, request);
         return ResponseEntity.ok(ApiResult.ok(response));

--- a/src/main/java/com/dduru/gildongmu/journey/controller/JourneyPostController.java
+++ b/src/main/java/com/dduru/gildongmu/journey/controller/JourneyPostController.java
@@ -1,0 +1,84 @@
+package com.dduru.gildongmu.journey.controller;
+
+import com.dduru.gildongmu.common.annotation.CurrentUser;
+import com.dduru.gildongmu.common.dto.ApiResult;
+import com.dduru.gildongmu.journey.dto.request.JourneyPostCreateRequest;
+import com.dduru.gildongmu.journey.dto.request.JourneyPostUpdateRequest;
+import com.dduru.gildongmu.journey.dto.response.JourneyPostListResponse;
+import com.dduru.gildongmu.journey.dto.response.JourneyPostResponse;
+import com.dduru.gildongmu.journey.service.JourneyPostService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/journeys/{journeyId}/posts")
+public class JourneyPostController implements JourneyPostApiDocs {
+
+    private final JourneyPostService journeyPostService;
+
+    @Override
+    @GetMapping
+    public ResponseEntity<ApiResult<JourneyPostListResponse>> retrievePosts(
+            @PathVariable Long journeyId,
+            @CurrentUser Long userId
+    ) {
+        JourneyPostListResponse response = journeyPostService.retrievePosts(journeyId, userId);
+        return ResponseEntity.ok(ApiResult.ok(response));
+    }
+
+    @Override
+    @GetMapping("/{journeyPostId}")
+    public ResponseEntity<ApiResult<JourneyPostResponse>> retrievePost(
+            @PathVariable Long journeyId,
+            @PathVariable Long journeyPostId,
+            @CurrentUser Long userId
+    ) {
+        JourneyPostResponse response = journeyPostService.retrievePost(journeyId, journeyPostId, userId);
+        return ResponseEntity.ok(ApiResult.ok(response));
+    }
+
+    @Override
+    @PostMapping
+    public ResponseEntity<ApiResult<JourneyPostResponse>> createPost(
+            @PathVariable Long journeyId,
+            @CurrentUser Long userId,
+            @Valid @RequestBody JourneyPostCreateRequest request
+    ) {
+        JourneyPostResponse response = journeyPostService.createPost(journeyId, userId, request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResult.created(response));
+    }
+
+    @Override
+    @PatchMapping("/{journeyPostId}")
+    public ResponseEntity<ApiResult<JourneyPostResponse>> updatePost(
+            @PathVariable Long journeyId,
+            @PathVariable Long journeyPostId,
+            @CurrentUser Long userId,
+            @Valid @RequestBody JourneyPostUpdateRequest request
+    ) {
+        JourneyPostResponse response = journeyPostService.updatePost(journeyId, journeyPostId, userId, request);
+        return ResponseEntity.ok(ApiResult.ok(response));
+    }
+
+    @Override
+    @DeleteMapping("/{journeyPostId}")
+    public ResponseEntity<ApiResult<Void>> deletePost(
+            @PathVariable Long journeyId,
+            @PathVariable Long journeyPostId,
+            @CurrentUser Long userId
+    ) {
+        journeyPostService.deletePost(journeyId, journeyPostId, userId);
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).body(ApiResult.noContent());
+    }
+}

--- a/src/main/java/com/dduru/gildongmu/journey/controller/JourneyPostController.java
+++ b/src/main/java/com/dduru/gildongmu/journey/controller/JourneyPostController.java
@@ -3,6 +3,7 @@ package com.dduru.gildongmu.journey.controller;
 import com.dduru.gildongmu.common.annotation.CurrentUser;
 import com.dduru.gildongmu.common.dto.ApiResult;
 import com.dduru.gildongmu.journey.dto.request.JourneyPostCreateRequest;
+import com.dduru.gildongmu.journey.dto.request.JourneyPostListRequest;
 import com.dduru.gildongmu.journey.dto.request.JourneyPostUpdateRequest;
 import com.dduru.gildongmu.journey.dto.response.JourneyPostListResponse;
 import com.dduru.gildongmu.journey.dto.response.JourneyPostResponse;
@@ -13,6 +14,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -31,9 +33,10 @@ public class JourneyPostController implements JourneyPostApiDocs {
     @GetMapping
     public ResponseEntity<ApiResult<JourneyPostListResponse>> retrievePosts(
             @PathVariable Long journeyId,
-            @CurrentUser Long userId
+            @CurrentUser Long userId,
+            @Valid @ModelAttribute JourneyPostListRequest request
     ) {
-        JourneyPostListResponse response = journeyPostService.retrievePosts(journeyId, userId);
+        JourneyPostListResponse response = journeyPostService.retrievePosts(journeyId, userId, request);
         return ResponseEntity.ok(ApiResult.ok(response));
     }
 

--- a/src/main/java/com/dduru/gildongmu/journey/domain/JourneyPost.java
+++ b/src/main/java/com/dduru/gildongmu/journey/domain/JourneyPost.java
@@ -28,9 +28,6 @@ public class JourneyPost extends BaseTimeEntity {
     @JoinColumn(name = "author_user_id", nullable = false)
     private User author;
 
-    @Column(nullable = false, length = 30)
-    private String title;
-
     @Column(nullable = false, length = 300)
     private String content;
 
@@ -53,13 +50,11 @@ public class JourneyPost extends BaseTimeEntity {
     private JourneyPost(
             Journey journey,
             User author,
-            String title,
             String content,
             String imageUrl
     ) {
         this.journey = journey;
         this.author = author;
-        this.title = title;
         this.content = content;
         this.imageUrl = imageUrl;
         this.isNotice = false;
@@ -69,23 +64,18 @@ public class JourneyPost extends BaseTimeEntity {
     public static JourneyPost create(
             Journey journey,
             User author,
-            String title,
             String content,
             String imageUrl
     ) {
         return JourneyPost.builder()
                 .journey(journey)
                 .author(author)
-                .title(title)
                 .content(content)
                 .imageUrl(imageUrl)
                 .build();
     }
 
-    public void update(String title, String content, boolean applyImageUrlPatch, String imageUrl) {
-        if (title != null) {
-            this.title = title;
-        }
+    public void update(String content, boolean applyImageUrlPatch, String imageUrl) {
         if (content != null) {
             this.content = content;
         }

--- a/src/main/java/com/dduru/gildongmu/journey/domain/JourneyPost.java
+++ b/src/main/java/com/dduru/gildongmu/journey/domain/JourneyPost.java
@@ -1,12 +1,14 @@
 package com.dduru.gildongmu.journey.domain;
 
 import com.dduru.gildongmu.common.entity.BaseTimeEntity;
+import com.dduru.gildongmu.journey.exception.InvalidJourneyPostException;
 import com.dduru.gildongmu.user.domain.User;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.util.StringUtils;
 
 import java.time.LocalDateTime;
 
@@ -15,6 +17,7 @@ import java.time.LocalDateTime;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class JourneyPost extends BaseTimeEntity {
+    private static final int CONTENT_MAX_LENGTH = 300;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -55,7 +58,7 @@ public class JourneyPost extends BaseTimeEntity {
     ) {
         this.journey = journey;
         this.author = author;
-        this.content = content;
+        this.content = validateContent(content);
         this.imageUrl = imageUrl;
         this.isNotice = false;
         this.isDeleted = false;
@@ -77,11 +80,15 @@ public class JourneyPost extends BaseTimeEntity {
 
     public void update(String content, boolean applyImageUrlPatch, String imageUrl) {
         if (content != null) {
-            this.content = content;
+            updateContent(content);
         }
         if (applyImageUrlPatch) {
             this.imageUrl = imageUrl;
         }
+    }
+
+    private void updateContent(String content) {
+        this.content = validateContent(content);
     }
 
     public void delete(Long deletedBy, LocalDateTime deletedAt) {
@@ -92,5 +99,17 @@ public class JourneyPost extends BaseTimeEntity {
 
     public boolean isAuthor(Long userId) {
         return author.getId().equals(userId);
+    }
+
+    private static String validateContent(String content) {
+        if (!StringUtils.hasText(content)) {
+            throw InvalidJourneyPostException.invalidContent();
+        }
+
+        int length = content.codePointCount(0, content.length());
+        if (length > CONTENT_MAX_LENGTH) {
+            throw InvalidJourneyPostException.invalidContent();
+        }
+        return content;
     }
 }

--- a/src/main/java/com/dduru/gildongmu/journey/domain/JourneyPost.java
+++ b/src/main/java/com/dduru/gildongmu/journey/domain/JourneyPost.java
@@ -1,0 +1,106 @@
+package com.dduru.gildongmu.journey.domain;
+
+import com.dduru.gildongmu.common.entity.BaseTimeEntity;
+import com.dduru.gildongmu.user.domain.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "journey_posts")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class JourneyPost extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "journey_id", nullable = false)
+    private Journey journey;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "author_user_id", nullable = false)
+    private User author;
+
+    @Column(nullable = false, length = 30)
+    private String title;
+
+    @Column(nullable = false, length = 300)
+    private String content;
+
+    @Column(name = "image_url", columnDefinition = "TEXT")
+    private String imageUrl;
+
+    @Column(name = "is_notice", nullable = false)
+    private boolean isNotice;
+
+    @Column(name = "is_deleted", nullable = false)
+    private boolean isDeleted;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    @Column(name = "deleted_by")
+    private Long deletedBy;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private JourneyPost(
+            Journey journey,
+            User author,
+            String title,
+            String content,
+            String imageUrl
+    ) {
+        this.journey = journey;
+        this.author = author;
+        this.title = title;
+        this.content = content;
+        this.imageUrl = imageUrl;
+        this.isNotice = false;
+        this.isDeleted = false;
+    }
+
+    public static JourneyPost create(
+            Journey journey,
+            User author,
+            String title,
+            String content,
+            String imageUrl
+    ) {
+        return JourneyPost.builder()
+                .journey(journey)
+                .author(author)
+                .title(title)
+                .content(content)
+                .imageUrl(imageUrl)
+                .build();
+    }
+
+    public void update(String title, String content, boolean applyImageUrlPatch, String imageUrl) {
+        if (title != null) {
+            this.title = title;
+        }
+        if (content != null) {
+            this.content = content;
+        }
+        if (applyImageUrlPatch) {
+            this.imageUrl = imageUrl;
+        }
+    }
+
+    public void delete(Long deletedBy, LocalDateTime deletedAt) {
+        this.isDeleted = true;
+        this.deletedBy = deletedBy;
+        this.deletedAt = deletedAt;
+    }
+
+    public boolean isAuthor(Long userId) {
+        return author.getId().equals(userId);
+    }
+}

--- a/src/main/java/com/dduru/gildongmu/journey/dto/request/JourneyPostCreateRequest.java
+++ b/src/main/java/com/dduru/gildongmu/journey/dto/request/JourneyPostCreateRequest.java
@@ -1,0 +1,17 @@
+package com.dduru.gildongmu.journey.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record JourneyPostCreateRequest(
+        @NotBlank
+        @Size(max = 30)
+        String title,
+
+        @NotBlank
+        @Size(max = 300)
+        String content,
+
+        String imageUrl
+) {
+}

--- a/src/main/java/com/dduru/gildongmu/journey/dto/request/JourneyPostCreateRequest.java
+++ b/src/main/java/com/dduru/gildongmu/journey/dto/request/JourneyPostCreateRequest.java
@@ -5,10 +5,6 @@ import jakarta.validation.constraints.Size;
 
 public record JourneyPostCreateRequest(
         @NotBlank
-        @Size(max = 30)
-        String title,
-
-        @NotBlank
         @Size(max = 300)
         String content,
 

--- a/src/main/java/com/dduru/gildongmu/journey/dto/request/JourneyPostListRequest.java
+++ b/src/main/java/com/dduru/gildongmu/journey/dto/request/JourneyPostListRequest.java
@@ -1,0 +1,20 @@
+package com.dduru.gildongmu.journey.dto.request;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Positive;
+
+public record JourneyPostListRequest(
+        @Positive(message = "cursor는 1 이상이어야 합니다.")
+        Long cursor,
+
+        @Min(value = 1, message = "size는 1 이상 50 이하로 입력해야 합니다.")
+        @Max(value = 50, message = "size는 1 이상 50 이하로 입력해야 합니다.")
+        Integer size
+) {
+    public static final int DEFAULT_SIZE = 20;
+
+    public int sizeOrDefault() {
+        return size == null ? DEFAULT_SIZE : size;
+    }
+}

--- a/src/main/java/com/dduru/gildongmu/journey/dto/request/JourneyPostUpdateRequest.java
+++ b/src/main/java/com/dduru/gildongmu/journey/dto/request/JourneyPostUpdateRequest.java
@@ -1,0 +1,14 @@
+package com.dduru.gildongmu.journey.dto.request;
+
+import jakarta.validation.constraints.Size;
+
+public record JourneyPostUpdateRequest(
+        @Size(max = 30)
+        String title,
+
+        @Size(max = 300)
+        String content,
+
+        String imageUrl
+) {
+}

--- a/src/main/java/com/dduru/gildongmu/journey/dto/request/JourneyPostUpdateRequest.java
+++ b/src/main/java/com/dduru/gildongmu/journey/dto/request/JourneyPostUpdateRequest.java
@@ -3,9 +3,6 @@ package com.dduru.gildongmu.journey.dto.request;
 import jakarta.validation.constraints.Size;
 
 public record JourneyPostUpdateRequest(
-        @Size(max = 30)
-        String title,
-
         @Size(max = 300)
         String content,
 

--- a/src/main/java/com/dduru/gildongmu/journey/dto/response/JourneyPostListResponse.java
+++ b/src/main/java/com/dduru/gildongmu/journey/dto/response/JourneyPostListResponse.java
@@ -7,11 +7,15 @@ import java.util.List;
 
 public record JourneyPostListResponse(
         Long journeyId,
-        List<JourneyPostResponse> posts
+        List<JourneyPostResponse> posts,
+        Long nextCursor,
+        boolean hasNext,
+        int size
 ) {
     public static JourneyPostListResponse of(
             Long journeyId,
             List<JourneyPost> journeyPosts,
+            boolean hasNext,
             Long currentUserId,
             Long hostUserId,
             ProfileImageResolver profileImageResolver
@@ -19,7 +23,16 @@ public record JourneyPostListResponse(
         List<JourneyPostResponse> posts = journeyPosts.stream()
                 .map(post -> JourneyPostResponse.from(post, currentUserId, hostUserId, profileImageResolver))
                 .toList();
+        Long nextCursor = hasNext && !journeyPosts.isEmpty()
+                ? journeyPosts.get(journeyPosts.size() - 1).getId()
+                : null;
 
-        return new JourneyPostListResponse(journeyId, posts);
+        return new JourneyPostListResponse(
+                journeyId,
+                posts,
+                nextCursor,
+                hasNext,
+                posts.size()
+        );
     }
 }

--- a/src/main/java/com/dduru/gildongmu/journey/dto/response/JourneyPostListResponse.java
+++ b/src/main/java/com/dduru/gildongmu/journey/dto/response/JourneyPostListResponse.java
@@ -1,0 +1,25 @@
+package com.dduru.gildongmu.journey.dto.response;
+
+import com.dduru.gildongmu.journey.domain.JourneyPost;
+import com.dduru.gildongmu.profile.utils.ProfileImageResolver;
+
+import java.util.List;
+
+public record JourneyPostListResponse(
+        Long journeyId,
+        List<JourneyPostResponse> posts
+) {
+    public static JourneyPostListResponse of(
+            Long journeyId,
+            List<JourneyPost> journeyPosts,
+            Long currentUserId,
+            Long hostUserId,
+            ProfileImageResolver profileImageResolver
+    ) {
+        List<JourneyPostResponse> posts = journeyPosts.stream()
+                .map(post -> JourneyPostResponse.from(post, currentUserId, hostUserId, profileImageResolver))
+                .toList();
+
+        return new JourneyPostListResponse(journeyId, posts);
+    }
+}

--- a/src/main/java/com/dduru/gildongmu/journey/dto/response/JourneyPostResponse.java
+++ b/src/main/java/com/dduru/gildongmu/journey/dto/response/JourneyPostResponse.java
@@ -9,7 +9,6 @@ import java.time.LocalDateTime;
 public record JourneyPostResponse(
         Long journeyPostId,
         ParticipantInfo author,
-        String title,
         String content,
         String imageUrl,
         boolean isNotice,
@@ -30,7 +29,6 @@ public record JourneyPostResponse(
                         hostUserId != null && hostUserId.equals(journeyPost.getAuthor().getId()),
                         profileImageResolver
                 ),
-                journeyPost.getTitle(),
                 journeyPost.getContent(),
                 journeyPost.getImageUrl(),
                 journeyPost.isNotice(),

--- a/src/main/java/com/dduru/gildongmu/journey/dto/response/JourneyPostResponse.java
+++ b/src/main/java/com/dduru/gildongmu/journey/dto/response/JourneyPostResponse.java
@@ -1,0 +1,42 @@
+package com.dduru.gildongmu.journey.dto.response;
+
+import com.dduru.gildongmu.journey.domain.JourneyPost;
+import com.dduru.gildongmu.post.dto.response.ParticipantInfo;
+import com.dduru.gildongmu.profile.utils.ProfileImageResolver;
+
+import java.time.LocalDateTime;
+
+public record JourneyPostResponse(
+        Long journeyPostId,
+        ParticipantInfo author,
+        String title,
+        String content,
+        String imageUrl,
+        boolean isNotice,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt,
+        boolean isAuthor
+) {
+    public static JourneyPostResponse from(
+            JourneyPost journeyPost,
+            Long currentUserId,
+            Long hostUserId,
+            ProfileImageResolver profileImageResolver
+    ) {
+        return new JourneyPostResponse(
+                journeyPost.getId(),
+                ParticipantInfo.from(
+                        journeyPost.getAuthor(),
+                        hostUserId != null && hostUserId.equals(journeyPost.getAuthor().getId()),
+                        profileImageResolver
+                ),
+                journeyPost.getTitle(),
+                journeyPost.getContent(),
+                journeyPost.getImageUrl(),
+                journeyPost.isNotice(),
+                journeyPost.getCreatedAt(),
+                journeyPost.getModifiedAt(),
+                journeyPost.isAuthor(currentUserId)
+        );
+    }
+}

--- a/src/main/java/com/dduru/gildongmu/journey/dto/response/JourneyPostResponse.java
+++ b/src/main/java/com/dduru/gildongmu/journey/dto/response/JourneyPostResponse.java
@@ -14,7 +14,8 @@ public record JourneyPostResponse(
         boolean isNotice,
         LocalDateTime createdAt,
         LocalDateTime updatedAt,
-        boolean isAuthor
+        boolean isAuthor,
+        long commentCount
 ) {
     public static JourneyPostResponse from(
             JourneyPost journeyPost,
@@ -34,7 +35,8 @@ public record JourneyPostResponse(
                 journeyPost.isNotice(),
                 journeyPost.getCreatedAt(),
                 journeyPost.getModifiedAt(),
-                journeyPost.isAuthor(currentUserId)
+                journeyPost.isAuthor(currentUserId),
+                0L
         );
     }
 }

--- a/src/main/java/com/dduru/gildongmu/journey/exception/InvalidJourneyPostException.java
+++ b/src/main/java/com/dduru/gildongmu/journey/exception/InvalidJourneyPostException.java
@@ -1,0 +1,23 @@
+package com.dduru.gildongmu.journey.exception;
+
+import com.dduru.gildongmu.common.exception.BusinessException;
+import com.dduru.gildongmu.common.exception.ErrorCode;
+
+public class InvalidJourneyPostException extends BusinessException {
+
+    private InvalidJourneyPostException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public static InvalidJourneyPostException emptyPatch() {
+        return new InvalidJourneyPostException(ErrorCode.JOURNEY_POST_EMPTY_PATCH);
+    }
+
+    public static InvalidJourneyPostException invalidTitle() {
+        return new InvalidJourneyPostException(ErrorCode.JOURNEY_POST_INVALID_TITLE);
+    }
+
+    public static InvalidJourneyPostException invalidContent() {
+        return new InvalidJourneyPostException(ErrorCode.JOURNEY_POST_INVALID_CONTENT);
+    }
+}

--- a/src/main/java/com/dduru/gildongmu/journey/exception/InvalidJourneyPostException.java
+++ b/src/main/java/com/dduru/gildongmu/journey/exception/InvalidJourneyPostException.java
@@ -13,10 +13,6 @@ public class InvalidJourneyPostException extends BusinessException {
         return new InvalidJourneyPostException(ErrorCode.JOURNEY_POST_EMPTY_PATCH);
     }
 
-    public static InvalidJourneyPostException invalidTitle() {
-        return new InvalidJourneyPostException(ErrorCode.JOURNEY_POST_INVALID_TITLE);
-    }
-
     public static InvalidJourneyPostException invalidContent() {
         return new InvalidJourneyPostException(ErrorCode.JOURNEY_POST_INVALID_CONTENT);
     }

--- a/src/main/java/com/dduru/gildongmu/journey/exception/JourneyHostNotFoundException.java
+++ b/src/main/java/com/dduru/gildongmu/journey/exception/JourneyHostNotFoundException.java
@@ -1,0 +1,11 @@
+package com.dduru.gildongmu.journey.exception;
+
+import com.dduru.gildongmu.common.exception.BusinessException;
+import com.dduru.gildongmu.common.exception.ErrorCode;
+
+public class JourneyHostNotFoundException extends BusinessException {
+
+    public JourneyHostNotFoundException() {
+        super(ErrorCode.JOURNEY_HOST_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/dduru/gildongmu/journey/exception/JourneyPostAccessDeniedException.java
+++ b/src/main/java/com/dduru/gildongmu/journey/exception/JourneyPostAccessDeniedException.java
@@ -1,0 +1,11 @@
+package com.dduru.gildongmu.journey.exception;
+
+import com.dduru.gildongmu.common.exception.BusinessException;
+import com.dduru.gildongmu.common.exception.ErrorCode;
+
+public class JourneyPostAccessDeniedException extends BusinessException {
+
+    public JourneyPostAccessDeniedException() {
+        super(ErrorCode.JOURNEY_POST_ACCESS_DENIED);
+    }
+}

--- a/src/main/java/com/dduru/gildongmu/journey/exception/JourneyPostNotFoundException.java
+++ b/src/main/java/com/dduru/gildongmu/journey/exception/JourneyPostNotFoundException.java
@@ -1,0 +1,11 @@
+package com.dduru.gildongmu.journey.exception;
+
+import com.dduru.gildongmu.common.exception.BusinessException;
+import com.dduru.gildongmu.common.exception.ErrorCode;
+
+public class JourneyPostNotFoundException extends BusinessException {
+
+    public JourneyPostNotFoundException() {
+        super(ErrorCode.JOURNEY_POST_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/dduru/gildongmu/journey/repository/JourneyMemberRepository.java
+++ b/src/main/java/com/dduru/gildongmu/journey/repository/JourneyMemberRepository.java
@@ -23,6 +23,15 @@ public interface JourneyMemberRepository extends JpaRepository<JourneyMember, Lo
     int countByJourneyIdAndStatus(Long journeyId, JourneyMemberStatus status);
 
     @Query("""
+            SELECT jm.user.id
+            FROM JourneyMember jm
+            WHERE jm.journey.id = :journeyId
+              AND jm.role = 'HOST'
+              AND jm.status = 'ACTIVE'
+            """)
+    Optional<Long> findActiveHostUserIdByJourneyId(@Param("journeyId") Long journeyId);
+
+    @Query("""
             SELECT COUNT(jm) > 0
             FROM JourneyMember jm
             WHERE jm.journey.id = :journeyId

--- a/src/main/java/com/dduru/gildongmu/journey/repository/JourneyPostRepository.java
+++ b/src/main/java/com/dduru/gildongmu/journey/repository/JourneyPostRepository.java
@@ -2,10 +2,12 @@ package com.dduru.gildongmu.journey.repository;
 
 import com.dduru.gildongmu.journey.domain.JourneyPost;
 import com.dduru.gildongmu.journey.exception.JourneyPostNotFoundException;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -20,12 +22,39 @@ public interface JourneyPostRepository extends JpaRepository<JourneyPost, Long> 
             LEFT JOIN FETCH profile.bgColor
             WHERE jp.journey.id = :journeyId
               AND jp.isDeleted = false
+              AND (
+                    :cursorId IS NULL
+                    OR (
+                        :cursorNotice = true
+                        AND jp.isNotice = true
+                        AND (
+                            jp.createdAt < :cursorCreatedAt
+                            OR (jp.createdAt = :cursorCreatedAt AND jp.id < :cursorId)
+                        )
+                    )
+                    OR (
+                        :cursorNotice = true
+                        AND jp.isNotice = false
+                    )
+                    OR (
+                        :cursorNotice = false
+                        AND jp.isNotice = false
+                        AND (
+                            jp.createdAt < :cursorCreatedAt
+                            OR (jp.createdAt = :cursorCreatedAt AND jp.id < :cursorId)
+                        )
+                    )
+              )
             ORDER BY jp.isNotice DESC,
                      jp.createdAt DESC,
                      jp.id DESC
             """)
     List<JourneyPost> findActivePostsByJourneyIdWithAuthorProfile(
-            @Param("journeyId") Long journeyId
+            @Param("journeyId") Long journeyId,
+            @Param("cursorNotice") Boolean cursorNotice,
+            @Param("cursorCreatedAt") LocalDateTime cursorCreatedAt,
+            @Param("cursorId") Long cursorId,
+            Pageable pageable
     );
 
     @Query("""

--- a/src/main/java/com/dduru/gildongmu/journey/repository/JourneyPostRepository.java
+++ b/src/main/java/com/dduru/gildongmu/journey/repository/JourneyPostRepository.java
@@ -1,0 +1,52 @@
+package com.dduru.gildongmu.journey.repository;
+
+import com.dduru.gildongmu.journey.domain.JourneyPost;
+import com.dduru.gildongmu.journey.exception.JourneyPostNotFoundException;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface JourneyPostRepository extends JpaRepository<JourneyPost, Long> {
+
+    @Query("""
+            SELECT jp
+            FROM JourneyPost jp
+            JOIN FETCH jp.author author
+            LEFT JOIN FETCH author.profile profile
+            LEFT JOIN FETCH profile.avatar
+            LEFT JOIN FETCH profile.bgColor
+            WHERE jp.journey.id = :journeyId
+              AND jp.isDeleted = false
+            ORDER BY jp.isNotice DESC,
+                     jp.createdAt DESC,
+                     jp.id DESC
+            """)
+    List<JourneyPost> findActivePostsByJourneyIdWithAuthorProfile(
+            @Param("journeyId") Long journeyId
+    );
+
+    @Query("""
+            SELECT jp
+            FROM JourneyPost jp
+            JOIN FETCH jp.journey
+            JOIN FETCH jp.author author
+            LEFT JOIN FETCH author.profile profile
+            LEFT JOIN FETCH profile.avatar
+            LEFT JOIN FETCH profile.bgColor
+            WHERE jp.id = :journeyPostId
+              AND jp.journey.id = :journeyId
+              AND jp.isDeleted = false
+            """)
+    Optional<JourneyPost> findActivePostByIdAndJourneyIdWithAuthorProfile(
+            @Param("journeyPostId") Long journeyPostId,
+            @Param("journeyId") Long journeyId
+    );
+
+    default JourneyPost getActivePostByIdAndJourneyIdOrThrow(Long journeyPostId, Long journeyId) {
+        return findActivePostByIdAndJourneyIdWithAuthorProfile(journeyPostId, journeyId)
+                .orElseThrow(JourneyPostNotFoundException::new);
+    }
+}

--- a/src/main/java/com/dduru/gildongmu/journey/service/JourneyPostService.java
+++ b/src/main/java/com/dduru/gildongmu/journey/service/JourneyPostService.java
@@ -36,8 +36,6 @@ import java.util.List;
 @RequiredArgsConstructor
 @Transactional
 public class JourneyPostService {
-    private static final int CONTENT_MAX_LENGTH = 300;
-
     private final JourneyRepository journeyRepository;
     private final JourneyMemberRepository journeyMemberRepository;
     private final JourneyPostRepository journeyPostRepository;
@@ -200,16 +198,7 @@ public class JourneyPostService {
     }
 
     private String normalizeContent(String content) {
-        if (!StringUtils.hasText(content)) {
-            throw InvalidJourneyPostException.invalidContent();
-        }
-
-        String normalizedContent = content.trim();
-        int length = normalizedContent.codePointCount(0, normalizedContent.length());
-        if (length > CONTENT_MAX_LENGTH) {
-            throw InvalidJourneyPostException.invalidContent();
-        }
-        return normalizedContent;
+        return content == null ? null : content.trim();
     }
 
     private String normalizeContentPatch(String content) {

--- a/src/main/java/com/dduru/gildongmu/journey/service/JourneyPostService.java
+++ b/src/main/java/com/dduru/gildongmu/journey/service/JourneyPostService.java
@@ -103,7 +103,7 @@ public class JourneyPostService {
         JourneyPost journeyPost = getOwnedJourneyPost(journeyId, journeyPostId, userId);
         Long hostUserId = findActiveHostUserId(journeyId);
 
-        String content = normalizeContentPatch(request.content());
+        String content = normalizeContent(request.content());
         boolean applyImageUrlPatch = request.imageUrl() != null;
         String imageUrl = applyImageUrlPatch ? normalizeImageUrl(request.imageUrl()) : null;
         validateHasAnyPatch(content, applyImageUrlPatch);
@@ -199,13 +199,6 @@ public class JourneyPostService {
 
     private String normalizeContent(String content) {
         return content == null ? null : content.trim();
-    }
-
-    private String normalizeContentPatch(String content) {
-        if (content == null) {
-            return null;
-        }
-        return normalizeContent(content);
     }
 
     private String normalizeImageUrl(String imageUrl) {

--- a/src/main/java/com/dduru/gildongmu/journey/service/JourneyPostService.java
+++ b/src/main/java/com/dduru/gildongmu/journey/service/JourneyPostService.java
@@ -1,0 +1,208 @@
+package com.dduru.gildongmu.journey.service;
+
+import com.dduru.gildongmu.common.time.TimeProvider;
+import com.dduru.gildongmu.common.validation.S3ImageUrlValidator;
+import com.dduru.gildongmu.journey.domain.Journey;
+import com.dduru.gildongmu.journey.domain.JourneyPost;
+import com.dduru.gildongmu.journey.domain.enums.JourneyMemberStatus;
+import com.dduru.gildongmu.journey.dto.request.JourneyPostCreateRequest;
+import com.dduru.gildongmu.journey.dto.request.JourneyPostUpdateRequest;
+import com.dduru.gildongmu.journey.dto.response.JourneyPostListResponse;
+import com.dduru.gildongmu.journey.dto.response.JourneyPostResponse;
+import com.dduru.gildongmu.journey.exception.InvalidJourneyPostException;
+import com.dduru.gildongmu.journey.exception.JourneyAccessDeniedException;
+import com.dduru.gildongmu.journey.exception.JourneyPostAccessDeniedException;
+import com.dduru.gildongmu.journey.repository.JourneyMemberRepository;
+import com.dduru.gildongmu.journey.repository.JourneyPostRepository;
+import com.dduru.gildongmu.journey.repository.JourneyRepository;
+import com.dduru.gildongmu.profile.utils.ProfileImageResolver;
+import com.dduru.gildongmu.s3.enums.S3ImageDirectory;
+import com.dduru.gildongmu.user.domain.User;
+import com.dduru.gildongmu.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class JourneyPostService {
+    private static final int TITLE_MAX_LENGTH = 30;
+    private static final int CONTENT_MAX_LENGTH = 300;
+
+    private final JourneyRepository journeyRepository;
+    private final JourneyMemberRepository journeyMemberRepository;
+    private final JourneyPostRepository journeyPostRepository;
+    private final UserRepository userRepository;
+    private final S3ImageUrlValidator s3ImageUrlValidator;
+    private final ProfileImageResolver profileImageResolver;
+    private final TimeProvider timeProvider;
+
+    @Transactional(readOnly = true)
+    public JourneyPostListResponse retrievePosts(Long journeyId, Long userId) {
+        Journey journey = getAccessibleJourney(journeyId, userId);
+        Long hostUserId = findActiveHostUserId(journeyId);
+
+        List<JourneyPost> journeyPosts = journeyPostRepository.findActivePostsByJourneyIdWithAuthorProfile(journeyId);
+        return JourneyPostListResponse.of(journey.getId(), journeyPosts, userId, hostUserId, profileImageResolver);
+    }
+
+    @Transactional(readOnly = true)
+    public JourneyPostResponse retrievePost(Long journeyId, Long journeyPostId, Long userId) {
+        getAccessibleJourney(journeyId, userId);
+        Long hostUserId = findActiveHostUserId(journeyId);
+
+        JourneyPost journeyPost = journeyPostRepository.getActivePostByIdAndJourneyIdOrThrow(journeyPostId, journeyId);
+        return JourneyPostResponse.from(journeyPost, userId, hostUserId, profileImageResolver);
+    }
+
+    public JourneyPostResponse createPost(Long journeyId, Long userId, JourneyPostCreateRequest request) {
+        Journey journey = getAccessibleJourney(journeyId, userId);
+        Long hostUserId = findActiveHostUserId(journeyId);
+        User author = userRepository.getByIdOrThrow(userId);
+
+        JourneyPost journeyPost = createJourneyPost(journey, author, request);
+        JourneyPost savedPost = journeyPostRepository.saveAndFlush(journeyPost);
+
+        log.info("나의 여정 게시글 생성됨 - journeyId={}, journeyPostId={}, userId={}",
+                journeyId, savedPost.getId(), userId);
+        return JourneyPostResponse.from(savedPost, userId, hostUserId, profileImageResolver);
+    }
+
+    public JourneyPostResponse updatePost(
+            Long journeyId,
+            Long journeyPostId,
+            Long userId,
+            JourneyPostUpdateRequest request
+    ) {
+        JourneyPost journeyPost = getOwnedJourneyPost(journeyId, journeyPostId, userId);
+        Long hostUserId = findActiveHostUserId(journeyId);
+
+        String title = normalizeTitlePatch(request.title());
+        String content = normalizeContentPatch(request.content());
+        boolean applyImageUrlPatch = request.imageUrl() != null;
+        String imageUrl = applyImageUrlPatch ? normalizeImageUrl(request.imageUrl()) : null;
+        validateHasAnyPatch(title, content, applyImageUrlPatch);
+
+        updateJourneyPost(journeyPost, title, content, applyImageUrlPatch, imageUrl);
+        journeyPostRepository.flush();
+
+        log.info("나의 여정 게시글 수정됨 - journeyId={}, journeyPostId={}, userId={}",
+                journeyId, journeyPostId, userId);
+        return JourneyPostResponse.from(journeyPost, userId, hostUserId, profileImageResolver);
+    }
+
+    public void deletePost(Long journeyId, Long journeyPostId, Long userId) {
+        JourneyPost journeyPost = getOwnedJourneyPost(journeyId, journeyPostId, userId);
+
+        journeyPost.delete(userId, timeProvider.now());
+        log.info("나의 여정 게시글 삭제됨 - journeyId={}, journeyPostId={}, userId={}",
+                journeyId, journeyPostId, userId);
+    }
+
+    private JourneyPost createJourneyPost(Journey journey, User author, JourneyPostCreateRequest request) {
+        return JourneyPost.create(
+                journey,
+                author,
+                normalizeTitle(request.title()),
+                normalizeContent(request.content()),
+                normalizeImageUrl(request.imageUrl())
+        );
+    }
+
+    private void updateJourneyPost(
+            JourneyPost journeyPost,
+            String title,
+            String content,
+            boolean applyImageUrlPatch,
+            String imageUrl
+    ) {
+        journeyPost.update(title, content, applyImageUrlPatch, imageUrl);
+    }
+
+    private Journey getAccessibleJourney(Long journeyId, Long userId) {
+        Journey journey = journeyRepository.getByIdOrThrow(journeyId);
+        boolean isActiveMember = journeyMemberRepository.existsByJourneyIdAndUserIdAndStatus(
+                journeyId,
+                userId,
+                JourneyMemberStatus.ACTIVE
+        );
+        if (!isActiveMember) {
+            throw new JourneyAccessDeniedException();
+        }
+        return journey;
+    }
+
+    private JourneyPost getOwnedJourneyPost(Long journeyId, Long journeyPostId, Long userId) {
+        getAccessibleJourney(journeyId, userId);
+
+        JourneyPost journeyPost = journeyPostRepository.getActivePostByIdAndJourneyIdOrThrow(journeyPostId, journeyId);
+        if (!journeyPost.isAuthor(userId)) {
+            throw new JourneyPostAccessDeniedException();
+        }
+        return journeyPost;
+    }
+
+    private Long findActiveHostUserId(Long journeyId) {
+        return journeyMemberRepository.findActiveHostUserIdByJourneyId(journeyId)
+                .orElse(null);
+    }
+
+    private void validateHasAnyPatch(String title, String content, boolean applyImageUrlPatch) {
+        if (title == null && content == null && !applyImageUrlPatch) {
+            throw InvalidJourneyPostException.emptyPatch();
+        }
+    }
+
+    private String normalizeTitle(String title) {
+        if (!StringUtils.hasText(title)) {
+            throw InvalidJourneyPostException.invalidTitle();
+        }
+
+        String normalizedTitle = title.trim();
+        int length = normalizedTitle.codePointCount(0, normalizedTitle.length());
+        if (length > TITLE_MAX_LENGTH) {
+            throw InvalidJourneyPostException.invalidTitle();
+        }
+        return normalizedTitle;
+    }
+
+    private String normalizeTitlePatch(String title) {
+        if (title == null) {
+            return null;
+        }
+        return normalizeTitle(title);
+    }
+
+    private String normalizeContent(String content) {
+        if (!StringUtils.hasText(content)) {
+            throw InvalidJourneyPostException.invalidContent();
+        }
+
+        String normalizedContent = content.trim();
+        int length = normalizedContent.codePointCount(0, normalizedContent.length());
+        if (length > CONTENT_MAX_LENGTH) {
+            throw InvalidJourneyPostException.invalidContent();
+        }
+        return normalizedContent;
+    }
+
+    private String normalizeContentPatch(String content) {
+        if (content == null) {
+            return null;
+        }
+        return normalizeContent(content);
+    }
+
+    private String normalizeImageUrl(String imageUrl) {
+        if (!StringUtils.hasText(imageUrl)) {
+            return null;
+        }
+        return s3ImageUrlValidator.validateAndNormalize(imageUrl, S3ImageDirectory.JOURNEY_POSTS);
+    }
+}

--- a/src/main/java/com/dduru/gildongmu/journey/service/JourneyPostService.java
+++ b/src/main/java/com/dduru/gildongmu/journey/service/JourneyPostService.java
@@ -32,7 +32,6 @@ import java.util.List;
 @RequiredArgsConstructor
 @Transactional
 public class JourneyPostService {
-    private static final int TITLE_MAX_LENGTH = 30;
     private static final int CONTENT_MAX_LENGTH = 300;
 
     private final JourneyRepository journeyRepository;
@@ -83,13 +82,12 @@ public class JourneyPostService {
         JourneyPost journeyPost = getOwnedJourneyPost(journeyId, journeyPostId, userId);
         Long hostUserId = findActiveHostUserId(journeyId);
 
-        String title = normalizeTitlePatch(request.title());
         String content = normalizeContentPatch(request.content());
         boolean applyImageUrlPatch = request.imageUrl() != null;
         String imageUrl = applyImageUrlPatch ? normalizeImageUrl(request.imageUrl()) : null;
-        validateHasAnyPatch(title, content, applyImageUrlPatch);
+        validateHasAnyPatch(content, applyImageUrlPatch);
 
-        updateJourneyPost(journeyPost, title, content, applyImageUrlPatch, imageUrl);
+        updateJourneyPost(journeyPost, content, applyImageUrlPatch, imageUrl);
         journeyPostRepository.flush();
 
         log.info("나의 여정 게시글 수정됨 - journeyId={}, journeyPostId={}, userId={}",
@@ -109,7 +107,6 @@ public class JourneyPostService {
         return JourneyPost.create(
                 journey,
                 author,
-                normalizeTitle(request.title()),
                 normalizeContent(request.content()),
                 normalizeImageUrl(request.imageUrl())
         );
@@ -117,12 +114,11 @@ public class JourneyPostService {
 
     private void updateJourneyPost(
             JourneyPost journeyPost,
-            String title,
             String content,
             boolean applyImageUrlPatch,
             String imageUrl
     ) {
-        journeyPost.update(title, content, applyImageUrlPatch, imageUrl);
+        journeyPost.update(content, applyImageUrlPatch, imageUrl);
     }
 
     private Journey getAccessibleJourney(Long journeyId, Long userId) {
@@ -153,30 +149,10 @@ public class JourneyPostService {
                 .orElse(null);
     }
 
-    private void validateHasAnyPatch(String title, String content, boolean applyImageUrlPatch) {
-        if (title == null && content == null && !applyImageUrlPatch) {
+    private void validateHasAnyPatch(String content, boolean applyImageUrlPatch) {
+        if (content == null && !applyImageUrlPatch) {
             throw InvalidJourneyPostException.emptyPatch();
         }
-    }
-
-    private String normalizeTitle(String title) {
-        if (!StringUtils.hasText(title)) {
-            throw InvalidJourneyPostException.invalidTitle();
-        }
-
-        String normalizedTitle = title.trim();
-        int length = normalizedTitle.codePointCount(0, normalizedTitle.length());
-        if (length > TITLE_MAX_LENGTH) {
-            throw InvalidJourneyPostException.invalidTitle();
-        }
-        return normalizedTitle;
-    }
-
-    private String normalizeTitlePatch(String title) {
-        if (title == null) {
-            return null;
-        }
-        return normalizeTitle(title);
     }
 
     private String normalizeContent(String content) {

--- a/src/main/java/com/dduru/gildongmu/journey/service/JourneyPostService.java
+++ b/src/main/java/com/dduru/gildongmu/journey/service/JourneyPostService.java
@@ -6,6 +6,7 @@ import com.dduru.gildongmu.journey.domain.Journey;
 import com.dduru.gildongmu.journey.domain.JourneyPost;
 import com.dduru.gildongmu.journey.domain.enums.JourneyMemberStatus;
 import com.dduru.gildongmu.journey.dto.request.JourneyPostCreateRequest;
+import com.dduru.gildongmu.journey.dto.request.JourneyPostListRequest;
 import com.dduru.gildongmu.journey.dto.request.JourneyPostUpdateRequest;
 import com.dduru.gildongmu.journey.dto.response.JourneyPostListResponse;
 import com.dduru.gildongmu.journey.dto.response.JourneyPostResponse;
@@ -22,10 +23,12 @@ import com.dduru.gildongmu.user.domain.User;
 import com.dduru.gildongmu.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Slf4j
@@ -44,12 +47,31 @@ public class JourneyPostService {
     private final TimeProvider timeProvider;
 
     @Transactional(readOnly = true)
-    public JourneyPostListResponse retrievePosts(Long journeyId, Long userId) {
+    public JourneyPostListResponse retrievePosts(Long journeyId, Long userId, JourneyPostListRequest request) {
+        JourneyPostListRequest normalizedRequest = normalizeRequest(request);
         Journey journey = getAccessibleJourney(journeyId, userId);
         Long hostUserId = findActiveHostUserId(journeyId);
+        JourneyPost cursorPost = findCursorPost(journeyId, normalizedRequest.cursor());
+        int size = normalizedRequest.sizeOrDefault();
 
-        List<JourneyPost> journeyPosts = journeyPostRepository.findActivePostsByJourneyIdWithAuthorProfile(journeyId);
-        return JourneyPostListResponse.of(journey.getId(), journeyPosts, userId, hostUserId, profileImageResolver);
+        List<JourneyPost> fetchedPosts = journeyPostRepository.findActivePostsByJourneyIdWithAuthorProfile(
+                journeyId,
+                cursorPost == null ? null : cursorPost.isNotice(),
+                cursorPost == null ? null : cursorPost.getCreatedAt(),
+                cursorPost == null ? null : cursorPost.getId(),
+                PageRequest.of(0, size + 1)
+        );
+        boolean hasNext = fetchedPosts.size() > size;
+        List<JourneyPost> journeyPosts = trimLookAheadPosts(fetchedPosts, size);
+
+        return JourneyPostListResponse.of(
+                journey.getId(),
+                journeyPosts,
+                hasNext,
+                userId,
+                hostUserId,
+                profileImageResolver
+        );
     }
 
     @Transactional(readOnly = true)
@@ -120,6 +142,27 @@ public class JourneyPostService {
             String imageUrl
     ) {
         journeyPost.update(content, applyImageUrlPatch, imageUrl);
+    }
+
+    private static JourneyPostListRequest normalizeRequest(JourneyPostListRequest request) {
+        if (request == null) {
+            return new JourneyPostListRequest(null, null);
+        }
+        return request;
+    }
+
+    private JourneyPost findCursorPost(Long journeyId, Long cursor) {
+        if (cursor == null) {
+            return null;
+        }
+        return journeyPostRepository.getActivePostByIdAndJourneyIdOrThrow(cursor, journeyId);
+    }
+
+    private static List<JourneyPost> trimLookAheadPosts(List<JourneyPost> posts, int size) {
+        if (posts.size() <= size) {
+            return posts;
+        }
+        return new ArrayList<>(posts.subList(0, size));
     }
 
     private Journey getAccessibleJourney(Long journeyId, Long userId) {

--- a/src/main/java/com/dduru/gildongmu/journey/service/JourneyPostService.java
+++ b/src/main/java/com/dduru/gildongmu/journey/service/JourneyPostService.java
@@ -11,6 +11,7 @@ import com.dduru.gildongmu.journey.dto.response.JourneyPostListResponse;
 import com.dduru.gildongmu.journey.dto.response.JourneyPostResponse;
 import com.dduru.gildongmu.journey.exception.InvalidJourneyPostException;
 import com.dduru.gildongmu.journey.exception.JourneyAccessDeniedException;
+import com.dduru.gildongmu.journey.exception.JourneyHostNotFoundException;
 import com.dduru.gildongmu.journey.exception.JourneyPostAccessDeniedException;
 import com.dduru.gildongmu.journey.repository.JourneyMemberRepository;
 import com.dduru.gildongmu.journey.repository.JourneyPostRepository;
@@ -146,7 +147,7 @@ public class JourneyPostService {
 
     private Long findActiveHostUserId(Long journeyId) {
         return journeyMemberRepository.findActiveHostUserIdByJourneyId(journeyId)
-                .orElse(null);
+                .orElseThrow(JourneyHostNotFoundException::new);
     }
 
     private void validateHasAnyPatch(String content, boolean applyImageUrlPatch) {

--- a/src/main/java/com/dduru/gildongmu/s3/enums/S3ImageDirectory.java
+++ b/src/main/java/com/dduru/gildongmu/s3/enums/S3ImageDirectory.java
@@ -4,6 +4,7 @@ public enum S3ImageDirectory {
     POSTS("posts"),
     PROFILES("profiles"),
     JOURNEYS("journeys"),
+    JOURNEY_POSTS("journeys/posts"),
     CHATS("chats");
 
     private final String directory;

--- a/src/main/resources/db/migration/V18__journey_posts.sql
+++ b/src/main/resources/db/migration/V18__journey_posts.sql
@@ -1,0 +1,23 @@
+CREATE TABLE journey_posts
+(
+    id             BIGINT AUTO_INCREMENT PRIMARY KEY,
+    journey_id     BIGINT       NOT NULL,
+    author_user_id BIGINT       NOT NULL,
+    title          VARCHAR(30)  NOT NULL,
+    content        VARCHAR(300) NOT NULL,
+    image_url      TEXT         NULL,
+    is_notice      BOOLEAN      NOT NULL DEFAULT FALSE,
+    is_deleted     BOOLEAN      NOT NULL DEFAULT FALSE,
+    deleted_at     DATETIME(6)  NULL,
+    deleted_by     BIGINT       NULL,
+    created_at     DATETIME(6)  NULL,
+    modified_at    DATETIME(6)  NULL,
+    CONSTRAINT fk_journey_posts_journey FOREIGN KEY (journey_id) REFERENCES journeys (id) ON DELETE CASCADE,
+    CONSTRAINT fk_journey_posts_author FOREIGN KEY (author_user_id) REFERENCES users (id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_journey_posts_journey_deleted_notice_created
+    ON journey_posts (journey_id, is_deleted, is_notice, created_at, id);
+
+CREATE INDEX idx_journey_posts_author
+    ON journey_posts (author_user_id);

--- a/src/main/resources/db/migration/V18__journey_posts.sql
+++ b/src/main/resources/db/migration/V18__journey_posts.sql
@@ -17,6 +17,3 @@ CREATE TABLE journey_posts
 
 CREATE INDEX idx_journey_posts_journey_deleted_notice_created
     ON journey_posts (journey_id, is_deleted, is_notice, created_at, id);
-
-CREATE INDEX idx_journey_posts_author
-    ON journey_posts (author_user_id);

--- a/src/main/resources/db/migration/V18__journey_posts.sql
+++ b/src/main/resources/db/migration/V18__journey_posts.sql
@@ -3,7 +3,6 @@ CREATE TABLE journey_posts
     id             BIGINT AUTO_INCREMENT PRIMARY KEY,
     journey_id     BIGINT       NOT NULL,
     author_user_id BIGINT       NOT NULL,
-    title          VARCHAR(30)  NOT NULL,
     content        VARCHAR(300) NOT NULL,
     image_url      TEXT         NULL,
     is_notice      BOOLEAN      NOT NULL DEFAULT FALSE,

--- a/src/test/java/com/dduru/gildongmu/journey/service/JourneyPostServiceTest.java
+++ b/src/test/java/com/dduru/gildongmu/journey/service/JourneyPostServiceTest.java
@@ -1,0 +1,396 @@
+package com.dduru.gildongmu.journey.service;
+
+import com.dduru.gildongmu.common.config.S3Properties;
+import com.dduru.gildongmu.common.exception.BusinessException;
+import com.dduru.gildongmu.common.exception.ErrorCode;
+import com.dduru.gildongmu.common.time.TimeProvider;
+import com.dduru.gildongmu.common.validation.InvalidImageUrlException;
+import com.dduru.gildongmu.common.validation.S3ImageUrlValidator;
+import com.dduru.gildongmu.destination.domain.Destination;
+import com.dduru.gildongmu.journey.domain.Journey;
+import com.dduru.gildongmu.journey.domain.JourneyPost;
+import com.dduru.gildongmu.journey.domain.enums.JourneyMemberStatus;
+import com.dduru.gildongmu.journey.dto.request.JourneyPostCreateRequest;
+import com.dduru.gildongmu.journey.dto.request.JourneyPostUpdateRequest;
+import com.dduru.gildongmu.journey.dto.response.JourneyPostListResponse;
+import com.dduru.gildongmu.journey.dto.response.JourneyPostResponse;
+import com.dduru.gildongmu.journey.exception.InvalidJourneyPostException;
+import com.dduru.gildongmu.journey.exception.JourneyAccessDeniedException;
+import com.dduru.gildongmu.journey.exception.JourneyPostAccessDeniedException;
+import com.dduru.gildongmu.journey.repository.JourneyMemberRepository;
+import com.dduru.gildongmu.journey.repository.JourneyPostRepository;
+import com.dduru.gildongmu.journey.repository.JourneyRepository;
+import com.dduru.gildongmu.post.domain.Post;
+import com.dduru.gildongmu.post.domain.enums.CompanionType;
+import com.dduru.gildongmu.profile.domain.Profile;
+import com.dduru.gildongmu.profile.domain.enums.Gender;
+import com.dduru.gildongmu.profile.utils.ProfileImageResolver;
+import com.dduru.gildongmu.user.domain.User;
+import com.dduru.gildongmu.user.domain.enums.OauthType;
+import com.dduru.gildongmu.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("JourneyPostService 테스트")
+class JourneyPostServiceTest {
+    private static final String S3_HOST = "https://dummy-bucket.s3.ap-northeast-2.amazonaws.com";
+    private static final LocalDateTime NOW = LocalDateTime.of(2026, 5, 12, 18, 45);
+
+    @Mock
+    private JourneyRepository journeyRepository;
+    @Mock
+    private JourneyMemberRepository journeyMemberRepository;
+    @Mock
+    private JourneyPostRepository journeyPostRepository;
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private ProfileImageResolver profileImageResolver;
+    @Mock
+    private TimeProvider timeProvider;
+
+    private JourneyPostService journeyPostService;
+
+    @BeforeEach
+    void setUp() {
+        S3Properties s3Properties = new S3Properties();
+        s3Properties.setBucket("dummy-bucket");
+        s3Properties.setRegion("ap-northeast-2");
+
+        journeyPostService = new JourneyPostService(
+                journeyRepository,
+                journeyMemberRepository,
+                journeyPostRepository,
+                userRepository,
+                new S3ImageUrlValidator(s3Properties),
+                profileImageResolver,
+                timeProvider
+        );
+    }
+
+    @Nested
+    @DisplayName("게시글 작성")
+    class Create {
+
+        @Test
+        @DisplayName("active member는 게시글을 작성할 수 있다")
+        void activeMemberCanCreatePost() {
+            Long journeyId = 1L;
+            Long userId = 10L;
+            Journey journey = createJourney(journeyId, userId);
+            User author = createUser(userId, "author");
+            JourneyPostCreateRequest request = new JourneyPostCreateRequest(
+                    "  제주공항 집합  ",
+                    "  출발 30분 전에 만나요.  ",
+                    S3_HOST + "/journeys/posts/notice.png"
+            );
+
+            givenActiveMember(journeyId, userId, journey);
+            givenActiveHost(journeyId, userId);
+            when(userRepository.getByIdOrThrow(userId)).thenReturn(author);
+            when(journeyPostRepository.saveAndFlush(any(JourneyPost.class))).thenAnswer(invocation -> {
+                JourneyPost journeyPost = invocation.getArgument(0);
+                ReflectionTestUtils.setField(journeyPost, "id", 101L);
+                return journeyPost;
+            });
+
+            JourneyPostResponse response = journeyPostService.createPost(journeyId, userId, request);
+
+            assertThat(response.journeyPostId()).isEqualTo(101L);
+            assertThat(response.title()).isEqualTo("제주공항 집합");
+            assertThat(response.content()).isEqualTo("출발 30분 전에 만나요.");
+            assertThat(response.imageUrl()).isEqualTo(S3_HOST + "/journeys/posts/notice.png");
+            assertThat(response.isAuthor()).isTrue();
+            assertThat(response.author().isHost()).isTrue();
+
+            ArgumentCaptor<JourneyPost> postCaptor = ArgumentCaptor.forClass(JourneyPost.class);
+            verify(journeyPostRepository).saveAndFlush(postCaptor.capture());
+            assertThat(postCaptor.getValue().getJourney()).isEqualTo(journey);
+            assertThat(postCaptor.getValue().getAuthor()).isEqualTo(author);
+            assertThat(postCaptor.getValue().isNotice()).isFalse();
+        }
+
+        @Test
+        @DisplayName("공백 제목이면 예외가 발생한다")
+        void blankTitleThrowsException() {
+            Long journeyId = 1L;
+            Long userId = 10L;
+            Journey journey = createJourney(journeyId, userId);
+            JourneyPostCreateRequest request = new JourneyPostCreateRequest(
+                    "   ",
+                    "내용입니다.",
+                    null
+            );
+
+            givenActiveMember(journeyId, userId, journey);
+            givenActiveHost(journeyId, userId);
+            when(userRepository.getByIdOrThrow(userId)).thenReturn(createUser(userId, "author"));
+
+            assertThatThrownBy(() -> journeyPostService.createPost(journeyId, userId, request))
+                    .isInstanceOf(InvalidJourneyPostException.class)
+                    .extracting(e -> ((BusinessException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.JOURNEY_POST_INVALID_TITLE);
+
+            verify(journeyPostRepository, never()).saveAndFlush(any());
+        }
+
+        @Test
+        @DisplayName("허용되지 않는 이미지 URL이면 예외가 발생한다")
+        void invalidImageUrlThrowsException() {
+            Long journeyId = 1L;
+            Long userId = 10L;
+            Journey journey = createJourney(journeyId, userId);
+            JourneyPostCreateRequest request = new JourneyPostCreateRequest(
+                    "제주공항 집합",
+                    "출발 30분 전에 만나요.",
+                    "https://example.com/image.png"
+            );
+
+            givenActiveMember(journeyId, userId, journey);
+            givenActiveHost(journeyId, userId);
+            when(userRepository.getByIdOrThrow(userId)).thenReturn(createUser(userId, "author"));
+
+            assertThatThrownBy(() -> journeyPostService.createPost(journeyId, userId, request))
+                    .isInstanceOf(InvalidImageUrlException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("게시글 조회")
+    class Retrieve {
+
+        @Test
+        @DisplayName("active member는 게시글 목록을 조회할 수 있다")
+        void activeMemberCanRetrievePosts() {
+            Long journeyId = 1L;
+            Long userId = 10L;
+            Journey journey = createJourney(journeyId, userId);
+            JourneyPost journeyPost = createJourneyPost(101L, journey, createUser(20L, "author"));
+
+            givenActiveMember(journeyId, userId, journey);
+            givenActiveHost(journeyId, userId);
+            when(journeyPostRepository.findActivePostsByJourneyIdWithAuthorProfile(journeyId))
+                    .thenReturn(List.of(journeyPost));
+
+            JourneyPostListResponse response = journeyPostService.retrievePosts(journeyId, userId);
+
+            assertThat(response.journeyId()).isEqualTo(journeyId);
+            assertThat(response.posts()).hasSize(1);
+            assertThat(response.posts().get(0).journeyPostId()).isEqualTo(101L);
+            assertThat(response.posts().get(0).isAuthor()).isFalse();
+            assertThat(response.posts().get(0).author().isHost()).isFalse();
+        }
+
+        @Test
+        @DisplayName("active member가 아니면 게시글을 조회할 수 없다")
+        void inactiveMemberCannotRetrievePosts() {
+            Long journeyId = 1L;
+            Long userId = 10L;
+            Journey journey = createJourney(journeyId, 20L);
+
+            when(journeyRepository.getByIdOrThrow(journeyId)).thenReturn(journey);
+            when(journeyMemberRepository.existsByJourneyIdAndUserIdAndStatus(journeyId, userId, JourneyMemberStatus.ACTIVE))
+                    .thenReturn(false);
+
+            assertThatThrownBy(() -> journeyPostService.retrievePosts(journeyId, userId))
+                    .isInstanceOf(JourneyAccessDeniedException.class);
+
+            verify(journeyPostRepository, never()).findActivePostsByJourneyIdWithAuthorProfile(journeyId);
+        }
+    }
+
+    @Nested
+    @DisplayName("게시글 수정/삭제")
+    class UpdateAndDelete {
+
+        @Test
+        @DisplayName("작성자는 게시글을 수정할 수 있다")
+        void authorCanUpdatePost() {
+            Long journeyId = 1L;
+            Long userId = 10L;
+            Long journeyPostId = 101L;
+            Journey journey = createJourney(journeyId, userId);
+            JourneyPost journeyPost = createJourneyPost(journeyPostId, journey, createUser(userId, "author"));
+            JourneyPostUpdateRequest request = new JourneyPostUpdateRequest(
+                    "수정된 제목",
+                    "수정된 내용입니다.",
+                    null
+            );
+
+            givenActiveMember(journeyId, userId, journey);
+            givenActiveHost(journeyId, userId);
+            when(journeyPostRepository.getActivePostByIdAndJourneyIdOrThrow(journeyPostId, journeyId))
+                    .thenReturn(journeyPost);
+
+            JourneyPostResponse response = journeyPostService.updatePost(journeyId, journeyPostId, userId, request);
+
+            assertThat(response.title()).isEqualTo("수정된 제목");
+            assertThat(response.content()).isEqualTo("수정된 내용입니다.");
+            assertThat(response.imageUrl()).isEqualTo(S3_HOST + "/journeys/posts/old.png");
+            assertThat(journeyPost.getTitle()).isEqualTo("수정된 제목");
+            assertThat(journeyPost.getContent()).isEqualTo("수정된 내용입니다.");
+            verify(journeyPostRepository).flush();
+        }
+
+        @Test
+        @DisplayName("수정 값이 모두 없으면 예외가 발생한다")
+        void emptyPatchThrowsException() {
+            Long journeyId = 1L;
+            Long userId = 10L;
+            Long journeyPostId = 101L;
+            Journey journey = createJourney(journeyId, userId);
+            JourneyPost journeyPost = createJourneyPost(journeyPostId, journey, createUser(userId, "author"));
+            JourneyPostUpdateRequest request = new JourneyPostUpdateRequest(null, null, null);
+
+            givenActiveMember(journeyId, userId, journey);
+            givenActiveHost(journeyId, userId);
+            when(journeyPostRepository.getActivePostByIdAndJourneyIdOrThrow(journeyPostId, journeyId))
+                    .thenReturn(journeyPost);
+
+            assertThatThrownBy(() -> journeyPostService.updatePost(journeyId, journeyPostId, userId, request))
+                    .isInstanceOf(InvalidJourneyPostException.class)
+                    .extracting(e -> ((BusinessException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.JOURNEY_POST_EMPTY_PATCH);
+
+            verify(journeyPostRepository, never()).flush();
+        }
+
+        @Test
+        @DisplayName("작성자가 아니면 게시글을 수정할 수 없다")
+        void nonAuthorCannotUpdatePost() {
+            Long journeyId = 1L;
+            Long userId = 10L;
+            Long journeyPostId = 101L;
+            Journey journey = createJourney(journeyId, userId);
+            JourneyPost journeyPost = createJourneyPost(journeyPostId, journey, createUser(20L, "author"));
+            JourneyPostUpdateRequest request = new JourneyPostUpdateRequest(
+                    "수정된 제목",
+                    "수정된 내용입니다.",
+                    null
+            );
+
+            givenActiveMember(journeyId, userId, journey);
+            when(journeyPostRepository.getActivePostByIdAndJourneyIdOrThrow(journeyPostId, journeyId))
+                    .thenReturn(journeyPost);
+
+            assertThatThrownBy(() -> journeyPostService.updatePost(journeyId, journeyPostId, userId, request))
+                    .isInstanceOf(JourneyPostAccessDeniedException.class);
+
+            verify(journeyPostRepository, never()).flush();
+        }
+
+        @Test
+        @DisplayName("작성자는 게시글을 soft delete 처리할 수 있다")
+        void authorCanDeletePost() {
+            Long journeyId = 1L;
+            Long userId = 10L;
+            Long journeyPostId = 101L;
+            Journey journey = createJourney(journeyId, userId);
+            JourneyPost journeyPost = createJourneyPost(journeyPostId, journey, createUser(userId, "author"));
+
+            givenActiveMember(journeyId, userId, journey);
+            when(journeyPostRepository.getActivePostByIdAndJourneyIdOrThrow(journeyPostId, journeyId))
+                    .thenReturn(journeyPost);
+            when(timeProvider.now()).thenReturn(NOW);
+
+            journeyPostService.deletePost(journeyId, journeyPostId, userId);
+
+            assertThat(journeyPost.isDeleted()).isTrue();
+            assertThat(journeyPost.getDeletedBy()).isEqualTo(userId);
+            assertThat(journeyPost.getDeletedAt()).isEqualTo(NOW);
+        }
+    }
+
+    private void givenActiveMember(Long journeyId, Long userId, Journey journey) {
+        when(journeyRepository.getByIdOrThrow(journeyId)).thenReturn(journey);
+        when(journeyMemberRepository.existsByJourneyIdAndUserIdAndStatus(journeyId, userId, JourneyMemberStatus.ACTIVE))
+                .thenReturn(true);
+    }
+
+    private void givenActiveHost(Long journeyId, Long hostUserId) {
+        when(journeyMemberRepository.findActiveHostUserIdByJourneyId(journeyId))
+                .thenReturn(Optional.of(hostUserId));
+    }
+
+    private Journey createJourney(Long journeyId, Long ownerId) {
+        Post post = createPost(100L, ownerId);
+        Journey journey = Journey.create(post);
+        ReflectionTestUtils.setField(journey, "id", journeyId);
+        return journey;
+    }
+
+    private JourneyPost createJourneyPost(Long journeyPostId, Journey journey, User author) {
+        JourneyPost journeyPost = JourneyPost.create(
+                journey,
+                author,
+                "기존 제목",
+                "기존 내용입니다.",
+                S3_HOST + "/journeys/posts/old.png"
+        );
+        ReflectionTestUtils.setField(journeyPost, "id", journeyPostId);
+        return journeyPost;
+    }
+
+    private Post createPost(Long postId, Long ownerId) {
+        User owner = createUser(ownerId, "owner-" + ownerId);
+        Destination destination = Destination.builder()
+                .countryCode("KR")
+                .countryName("대한민국")
+                .city("제주")
+                .build();
+
+        Post post = Post.createPost(
+                owner,
+                destination,
+                "제주도 2박 3일 여행",
+                "나의 여정 게시판 테스트용 본문입니다.",
+                LocalDate.now().plusDays(5),
+                LocalDate.now().plusDays(7),
+                4,
+                LocalDate.now().plusDays(6),
+                Gender.U,
+                true,
+                null,
+                null,
+                S3_HOST + "/posts/photo.png",
+                "[]",
+                CompanionType.FULL
+        );
+        ReflectionTestUtils.setField(post, "id", postId);
+        return post;
+    }
+
+    private User createUser(Long userId, String name) {
+        User user = User.builder()
+                .email(name + "@example.com")
+                .name(name)
+                .oauthId("oauth-" + userId)
+                .oauthType(OauthType.KAKAO)
+                .build();
+        ReflectionTestUtils.setField(user, "id", userId);
+        Profile profile = new Profile(user);
+        ReflectionTestUtils.setField(profile, "nickname", name);
+        ReflectionTestUtils.setField(user, "profile", profile);
+        return user;
+    }
+}

--- a/src/test/java/com/dduru/gildongmu/journey/service/JourneyPostServiceTest.java
+++ b/src/test/java/com/dduru/gildongmu/journey/service/JourneyPostServiceTest.java
@@ -100,7 +100,6 @@ class JourneyPostServiceTest {
             Journey journey = createJourney(journeyId, userId);
             User author = createUser(userId, "author");
             JourneyPostCreateRequest request = new JourneyPostCreateRequest(
-                    "  제주공항 집합  ",
                     "  출발 30분 전에 만나요.  ",
                     S3_HOST + "/journeys/posts/notice.png"
             );
@@ -117,7 +116,6 @@ class JourneyPostServiceTest {
             JourneyPostResponse response = journeyPostService.createPost(journeyId, userId, request);
 
             assertThat(response.journeyPostId()).isEqualTo(101L);
-            assertThat(response.title()).isEqualTo("제주공항 집합");
             assertThat(response.content()).isEqualTo("출발 30분 전에 만나요.");
             assertThat(response.imageUrl()).isEqualTo(S3_HOST + "/journeys/posts/notice.png");
             assertThat(response.isAuthor()).isTrue();
@@ -131,14 +129,13 @@ class JourneyPostServiceTest {
         }
 
         @Test
-        @DisplayName("공백 제목이면 예외가 발생한다")
-        void blankTitleThrowsException() {
+        @DisplayName("공백 내용이면 예외가 발생한다")
+        void blankContentThrowsException() {
             Long journeyId = 1L;
             Long userId = 10L;
             Journey journey = createJourney(journeyId, userId);
             JourneyPostCreateRequest request = new JourneyPostCreateRequest(
                     "   ",
-                    "내용입니다.",
                     null
             );
 
@@ -149,7 +146,7 @@ class JourneyPostServiceTest {
             assertThatThrownBy(() -> journeyPostService.createPost(journeyId, userId, request))
                     .isInstanceOf(InvalidJourneyPostException.class)
                     .extracting(e -> ((BusinessException) e).getErrorCode())
-                    .isEqualTo(ErrorCode.JOURNEY_POST_INVALID_TITLE);
+                    .isEqualTo(ErrorCode.JOURNEY_POST_INVALID_CONTENT);
 
             verify(journeyPostRepository, never()).saveAndFlush(any());
         }
@@ -161,7 +158,6 @@ class JourneyPostServiceTest {
             Long userId = 10L;
             Journey journey = createJourney(journeyId, userId);
             JourneyPostCreateRequest request = new JourneyPostCreateRequest(
-                    "제주공항 집합",
                     "출발 30분 전에 만나요.",
                     "https://example.com/image.png"
             );
@@ -232,7 +228,6 @@ class JourneyPostServiceTest {
             Journey journey = createJourney(journeyId, userId);
             JourneyPost journeyPost = createJourneyPost(journeyPostId, journey, createUser(userId, "author"));
             JourneyPostUpdateRequest request = new JourneyPostUpdateRequest(
-                    "수정된 제목",
                     "수정된 내용입니다.",
                     null
             );
@@ -244,10 +239,8 @@ class JourneyPostServiceTest {
 
             JourneyPostResponse response = journeyPostService.updatePost(journeyId, journeyPostId, userId, request);
 
-            assertThat(response.title()).isEqualTo("수정된 제목");
             assertThat(response.content()).isEqualTo("수정된 내용입니다.");
             assertThat(response.imageUrl()).isEqualTo(S3_HOST + "/journeys/posts/old.png");
-            assertThat(journeyPost.getTitle()).isEqualTo("수정된 제목");
             assertThat(journeyPost.getContent()).isEqualTo("수정된 내용입니다.");
             verify(journeyPostRepository).flush();
         }
@@ -260,7 +253,7 @@ class JourneyPostServiceTest {
             Long journeyPostId = 101L;
             Journey journey = createJourney(journeyId, userId);
             JourneyPost journeyPost = createJourneyPost(journeyPostId, journey, createUser(userId, "author"));
-            JourneyPostUpdateRequest request = new JourneyPostUpdateRequest(null, null, null);
+            JourneyPostUpdateRequest request = new JourneyPostUpdateRequest(null, null);
 
             givenActiveMember(journeyId, userId, journey);
             givenActiveHost(journeyId, userId);
@@ -284,7 +277,6 @@ class JourneyPostServiceTest {
             Journey journey = createJourney(journeyId, userId);
             JourneyPost journeyPost = createJourneyPost(journeyPostId, journey, createUser(20L, "author"));
             JourneyPostUpdateRequest request = new JourneyPostUpdateRequest(
-                    "수정된 제목",
                     "수정된 내용입니다.",
                     null
             );
@@ -343,7 +335,6 @@ class JourneyPostServiceTest {
         JourneyPost journeyPost = JourneyPost.create(
                 journey,
                 author,
-                "기존 제목",
                 "기존 내용입니다.",
                 S3_HOST + "/journeys/posts/old.png"
         );

--- a/src/test/java/com/dduru/gildongmu/journey/service/JourneyPostServiceTest.java
+++ b/src/test/java/com/dduru/gildongmu/journey/service/JourneyPostServiceTest.java
@@ -209,6 +209,7 @@ class JourneyPostServiceTest {
             assertThat(response.posts().get(0).journeyPostId()).isEqualTo(101L);
             assertThat(response.posts().get(0).isAuthor()).isFalse();
             assertThat(response.posts().get(0).author().isHost()).isFalse();
+            assertThat(response.posts().get(0).commentCount()).isZero();
             assertThat(response.nextCursor()).isEqualTo(101L);
             assertThat(response.hasNext()).isTrue();
             assertThat(response.size()).isEqualTo(1);

--- a/src/test/java/com/dduru/gildongmu/journey/service/JourneyPostServiceTest.java
+++ b/src/test/java/com/dduru/gildongmu/journey/service/JourneyPostServiceTest.java
@@ -11,6 +11,7 @@ import com.dduru.gildongmu.journey.domain.Journey;
 import com.dduru.gildongmu.journey.domain.JourneyPost;
 import com.dduru.gildongmu.journey.domain.enums.JourneyMemberStatus;
 import com.dduru.gildongmu.journey.dto.request.JourneyPostCreateRequest;
+import com.dduru.gildongmu.journey.dto.request.JourneyPostListRequest;
 import com.dduru.gildongmu.journey.dto.request.JourneyPostUpdateRequest;
 import com.dduru.gildongmu.journey.dto.response.JourneyPostListResponse;
 import com.dduru.gildongmu.journey.dto.response.JourneyPostResponse;
@@ -37,6 +38,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Pageable;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDate;
@@ -47,6 +49,7 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -183,19 +186,68 @@ class JourneyPostServiceTest {
             Long userId = 10L;
             Journey journey = createJourney(journeyId, userId);
             JourneyPost journeyPost = createJourneyPost(101L, journey, createUser(20L, "author"));
+            JourneyPost lookAheadPost = createJourneyPost(100L, journey, createUser(30L, "next"));
 
             givenActiveMember(journeyId, userId, journey);
             givenActiveHost(journeyId, userId);
-            when(journeyPostRepository.findActivePostsByJourneyIdWithAuthorProfile(journeyId))
-                    .thenReturn(List.of(journeyPost));
+            when(journeyPostRepository.findActivePostsByJourneyIdWithAuthorProfile(
+                    eq(journeyId),
+                    eq(null),
+                    eq(null),
+                    eq(null),
+                    any(Pageable.class)
+            )).thenReturn(List.of(journeyPost, lookAheadPost));
 
-            JourneyPostListResponse response = journeyPostService.retrievePosts(journeyId, userId);
+            JourneyPostListResponse response = journeyPostService.retrievePosts(
+                    journeyId,
+                    userId,
+                    new JourneyPostListRequest(null, 1)
+            );
 
             assertThat(response.journeyId()).isEqualTo(journeyId);
             assertThat(response.posts()).hasSize(1);
             assertThat(response.posts().get(0).journeyPostId()).isEqualTo(101L);
             assertThat(response.posts().get(0).isAuthor()).isFalse();
             assertThat(response.posts().get(0).author().isHost()).isFalse();
+            assertThat(response.nextCursor()).isEqualTo(101L);
+            assertThat(response.hasNext()).isTrue();
+            assertThat(response.size()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("cursor가 있으면 cursor 이후 게시글을 조회한다")
+        void retrievePostsWithCursor() {
+            Long journeyId = 1L;
+            Long userId = 10L;
+            Long cursor = 102L;
+            LocalDateTime cursorCreatedAt = LocalDateTime.of(2026, 5, 13, 14, 0);
+            Journey journey = createJourney(journeyId, userId);
+            JourneyPost cursorPost = createJourneyPost(cursor, journey, createUser(20L, "cursor"));
+            JourneyPost olderPost = createJourneyPost(101L, journey, createUser(30L, "older"));
+            setCreatedAt(cursorPost, cursorCreatedAt);
+
+            givenActiveMember(journeyId, userId, journey);
+            givenActiveHost(journeyId, userId);
+            when(journeyPostRepository.getActivePostByIdAndJourneyIdOrThrow(cursor, journeyId))
+                    .thenReturn(cursorPost);
+            when(journeyPostRepository.findActivePostsByJourneyIdWithAuthorProfile(
+                    eq(journeyId),
+                    eq(false),
+                    eq(cursorCreatedAt),
+                    eq(cursor),
+                    any(Pageable.class)
+            )).thenReturn(List.of(olderPost));
+
+            JourneyPostListResponse response = journeyPostService.retrievePosts(
+                    journeyId,
+                    userId,
+                    new JourneyPostListRequest(cursor, 20)
+            );
+
+            assertThat(response.posts()).hasSize(1);
+            assertThat(response.posts().get(0).journeyPostId()).isEqualTo(101L);
+            assertThat(response.nextCursor()).isNull();
+            assertThat(response.hasNext()).isFalse();
         }
 
         @Test
@@ -209,10 +261,16 @@ class JourneyPostServiceTest {
             when(journeyMemberRepository.existsByJourneyIdAndUserIdAndStatus(journeyId, userId, JourneyMemberStatus.ACTIVE))
                     .thenReturn(false);
 
-            assertThatThrownBy(() -> journeyPostService.retrievePosts(journeyId, userId))
+            assertThatThrownBy(() -> journeyPostService.retrievePosts(journeyId, userId, new JourneyPostListRequest(null, null)))
                     .isInstanceOf(JourneyAccessDeniedException.class);
 
-            verify(journeyPostRepository, never()).findActivePostsByJourneyIdWithAuthorProfile(journeyId);
+            verify(journeyPostRepository, never()).findActivePostsByJourneyIdWithAuthorProfile(
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any()
+            );
         }
 
         @Test
@@ -226,12 +284,18 @@ class JourneyPostServiceTest {
             when(journeyMemberRepository.findActiveHostUserIdByJourneyId(journeyId))
                     .thenReturn(Optional.empty());
 
-            assertThatThrownBy(() -> journeyPostService.retrievePosts(journeyId, userId))
+            assertThatThrownBy(() -> journeyPostService.retrievePosts(journeyId, userId, new JourneyPostListRequest(null, null)))
                     .isInstanceOf(JourneyHostNotFoundException.class)
                     .extracting(e -> ((BusinessException) e).getErrorCode())
                     .isEqualTo(ErrorCode.JOURNEY_HOST_NOT_FOUND);
 
-            verify(journeyPostRepository, never()).findActivePostsByJourneyIdWithAuthorProfile(journeyId);
+            verify(journeyPostRepository, never()).findActivePostsByJourneyIdWithAuthorProfile(
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any()
+            );
         }
     }
 
@@ -360,6 +424,10 @@ class JourneyPostServiceTest {
         );
         ReflectionTestUtils.setField(journeyPost, "id", journeyPostId);
         return journeyPost;
+    }
+
+    private void setCreatedAt(JourneyPost journeyPost, LocalDateTime createdAt) {
+        ReflectionTestUtils.setField(journeyPost, "createdAt", createdAt);
     }
 
     private Post createPost(Long postId, Long ownerId) {

--- a/src/test/java/com/dduru/gildongmu/journey/service/JourneyPostServiceTest.java
+++ b/src/test/java/com/dduru/gildongmu/journey/service/JourneyPostServiceTest.java
@@ -16,6 +16,7 @@ import com.dduru.gildongmu.journey.dto.response.JourneyPostListResponse;
 import com.dduru.gildongmu.journey.dto.response.JourneyPostResponse;
 import com.dduru.gildongmu.journey.exception.InvalidJourneyPostException;
 import com.dduru.gildongmu.journey.exception.JourneyAccessDeniedException;
+import com.dduru.gildongmu.journey.exception.JourneyHostNotFoundException;
 import com.dduru.gildongmu.journey.exception.JourneyPostAccessDeniedException;
 import com.dduru.gildongmu.journey.repository.JourneyMemberRepository;
 import com.dduru.gildongmu.journey.repository.JourneyPostRepository;
@@ -210,6 +211,25 @@ class JourneyPostServiceTest {
 
             assertThatThrownBy(() -> journeyPostService.retrievePosts(journeyId, userId))
                     .isInstanceOf(JourneyAccessDeniedException.class);
+
+            verify(journeyPostRepository, never()).findActivePostsByJourneyIdWithAuthorProfile(journeyId);
+        }
+
+        @Test
+        @DisplayName("active host가 없으면 예외가 발생한다")
+        void missingActiveHostThrowsException() {
+            Long journeyId = 1L;
+            Long userId = 10L;
+            Journey journey = createJourney(journeyId, userId);
+
+            givenActiveMember(journeyId, userId, journey);
+            when(journeyMemberRepository.findActiveHostUserIdByJourneyId(journeyId))
+                    .thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> journeyPostService.retrievePosts(journeyId, userId))
+                    .isInstanceOf(JourneyHostNotFoundException.class)
+                    .extracting(e -> ((BusinessException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.JOURNEY_HOST_NOT_FOUND);
 
             verify(journeyPostRepository, never()).findActivePostsByJourneyIdWithAuthorProfile(journeyId);
         }


### PR DESCRIPTION
## 🔎 작업 내용
* `journey_posts` 테이블 마이그레이션(`V18__journey_posts.sql`)을 추가.
* 공개 모집글과 분리된 `JourneyPost` 도메인을 추가.
* 나의 여정 게시글 목록 조회 / 단건 조회 / 작성 / 수정 / 삭제 API를 구현.
* active member만 게시글을 조회/작성할 수 있도록 권한 검증을 추가.
* 게시글 수정/삭제는 작성자 본인만 가능하도록 검증을 추가.
* 게시글 삭제는 soft delete 방식으로 처리하고, 삭제된 게시글은 조회에서 제외하도록 반영.
* 내용 길이 검증, empty patch 검증, 이미지 URL 검증을 추가.
* 추후 공지 기능 확장을 위해 `isNotice` 필드를 포함한 구조로 설계.
* `JourneyPostServiceTest`를 추가해 생성/조회/수정/삭제 및 예외 케이스를 검증.

## ➕ 이슈 링크
* CLOSED #249 


## 😎 리뷰 요구사항
> `JourneyPost`를 별도 도메인으로 분리한 방향이 적절한지 봐주시면 좋겠습니다.
> 특히 active member 접근 권한, 작성자 수정/삭제 권한, soft delete 처리 방식이 의도한 정책과 맞는지 확인 부탁드립니다.
> 또한 현재 목록 정렬이 `isNotice DESC, createdAt DESC, id DESC` 기준인데, 추후 공지 기능 확장 관점에서 무리가 없는지도 같이 봐주시면 좋겠습니다.

## 🧑‍💻 예정 작업
- #236 

## 📝 체크리스트
- [x] 브랜치 이름은 `feat/개발내용` 형식으로 작성했는가?
- [x] 커밋 메시지는 `feat(scope): 커밋 내용` 형식으로 작성했는가?
- [x] 작업 전 Issue를 작성했는가?
- [x] `dev` 브랜치로 병합을 요청했는가?
- [x] 불필요한 주석과 공백은 제거했는가?
- [x] 코드 리뷰어의 피드백을 반영했는가?
- [x] 테스트를 진행했는가?
- [x] 테스트 코드를 작성했는가?
