### PR TITLE
feat: 나의 여정 게시글 공지 지정/해제 API 구현 

### DIFF
--- a/src/main/java/com/dduru/gildongmu/common/exception/ErrorCode.java
+++ b/src/main/java/com/dduru/gildongmu/common/exception/ErrorCode.java
@@ -96,6 +96,7 @@ public enum ErrorCode {
     JOURNEY_POST_EMPTY_PATCH(HttpStatus.BAD_REQUEST, "수정할 게시글 내용이 없습니다."),
     JOURNEY_POST_INVALID_TITLE(HttpStatus.BAD_REQUEST, "게시글 제목은 1자 이상 30자 이하여야 합니다."),
     JOURNEY_POST_INVALID_CONTENT(HttpStatus.BAD_REQUEST, "게시글 내용은 1자 이상 300자 이하여야 합니다."),
+    JOURNEY_POST_NOTICE_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "공지 게시글은 최대 3개까지 설정할 수 있습니다."),
 
     // 신고 (REPORT)
     REPORT_NOT_FOUND(HttpStatus.NOT_FOUND, "신고 내역을 찾을 수 없습니다."),

--- a/src/main/java/com/dduru/gildongmu/journey/controller/JourneyPostApiDocs.java
+++ b/src/main/java/com/dduru/gildongmu/journey/controller/JourneyPostApiDocs.java
@@ -8,6 +8,7 @@ import com.dduru.gildongmu.journey.dto.request.JourneyPostListRequest;
 import com.dduru.gildongmu.journey.dto.request.JourneyPostNoticeUpdateRequest;
 import com.dduru.gildongmu.journey.dto.request.JourneyPostUpdateRequest;
 import com.dduru.gildongmu.journey.dto.response.JourneyPostListResponse;
+import com.dduru.gildongmu.journey.dto.response.JourneyPostNoticeUpdateResponse;
 import com.dduru.gildongmu.journey.dto.response.JourneyPostResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -103,7 +104,7 @@ public interface JourneyPostApiDocs {
             summary = "나의 여정 게시글 공지 지정/해제",
             description = "active host가 특정 게시글의 공지 여부를 변경합니다. 공지는 여정당 최대 3개까지 설정할 수 있습니다."
     )
-    @ApiResponse(responseCode = "204", description = "공지 상태 변경 성공")
+    @ApiResponse(responseCode = "200", description = "공지 상태 변경 성공")
     @ApiErrorResponses({
             ErrorCode.UNAUTHORIZED,
             ErrorCode.INVALID_INPUT_VALUE,
@@ -112,7 +113,7 @@ public interface JourneyPostApiDocs {
             ErrorCode.JOURNEY_POST_NOT_FOUND,
             ErrorCode.JOURNEY_POST_NOTICE_LIMIT_EXCEEDED
     })
-    ResponseEntity<ApiResult<Void>> updatePostNotice(
+    ResponseEntity<ApiResult<JourneyPostNoticeUpdateResponse>> updatePostNotice(
             @Parameter(description = "여정 ID") Long journeyId,
             @Parameter(description = "나의 여정 게시글 ID") Long journeyPostId,
             @Parameter(hidden = true) Long userId,

--- a/src/main/java/com/dduru/gildongmu/journey/controller/JourneyPostApiDocs.java
+++ b/src/main/java/com/dduru/gildongmu/journey/controller/JourneyPostApiDocs.java
@@ -4,6 +4,7 @@ import com.dduru.gildongmu.common.annotation.ApiErrorResponses;
 import com.dduru.gildongmu.common.dto.ApiResult;
 import com.dduru.gildongmu.common.exception.ErrorCode;
 import com.dduru.gildongmu.journey.dto.request.JourneyPostCreateRequest;
+import com.dduru.gildongmu.journey.dto.request.JourneyPostNoticeUpdateRequest;
 import com.dduru.gildongmu.journey.dto.request.JourneyPostUpdateRequest;
 import com.dduru.gildongmu.journey.dto.response.JourneyPostListResponse;
 import com.dduru.gildongmu.journey.dto.response.JourneyPostResponse;
@@ -92,6 +93,26 @@ public interface JourneyPostApiDocs {
             @Parameter(description = "나의 여정 게시글 ID") Long journeyPostId,
             @Parameter(hidden = true) Long userId,
             JourneyPostUpdateRequest request
+    );
+
+    @Operation(
+            summary = "나의 여정 게시글 공지 지정/해제",
+            description = "active host가 특정 게시글의 공지 여부를 변경합니다. 공지는 여정당 최대 3개까지 설정할 수 있습니다."
+    )
+    @ApiResponse(responseCode = "204", description = "공지 상태 변경 성공")
+    @ApiErrorResponses({
+            ErrorCode.UNAUTHORIZED,
+            ErrorCode.INVALID_INPUT_VALUE,
+            ErrorCode.JOURNEY_NOT_FOUND,
+            ErrorCode.JOURNEY_ACCESS_DENIED,
+            ErrorCode.JOURNEY_POST_NOT_FOUND,
+            ErrorCode.JOURNEY_POST_NOTICE_LIMIT_EXCEEDED
+    })
+    ResponseEntity<ApiResult<Void>> updatePostNotice(
+            @Parameter(description = "여정 ID") Long journeyId,
+            @Parameter(description = "나의 여정 게시글 ID") Long journeyPostId,
+            @Parameter(hidden = true) Long userId,
+            JourneyPostNoticeUpdateRequest request
     );
 
     @Operation(

--- a/src/main/java/com/dduru/gildongmu/journey/controller/JourneyPostController.java
+++ b/src/main/java/com/dduru/gildongmu/journey/controller/JourneyPostController.java
@@ -7,6 +7,7 @@ import com.dduru.gildongmu.journey.dto.request.JourneyPostListRequest;
 import com.dduru.gildongmu.journey.dto.request.JourneyPostNoticeUpdateRequest;
 import com.dduru.gildongmu.journey.dto.request.JourneyPostUpdateRequest;
 import com.dduru.gildongmu.journey.dto.response.JourneyPostListResponse;
+import com.dduru.gildongmu.journey.dto.response.JourneyPostNoticeUpdateResponse;
 import com.dduru.gildongmu.journey.dto.response.JourneyPostResponse;
 import com.dduru.gildongmu.journey.service.JourneyPostService;
 import jakarta.validation.Valid;
@@ -76,14 +77,19 @@ public class JourneyPostController implements JourneyPostApiDocs {
 
     @Override
     @PatchMapping("/{journeyPostId}/notice")
-    public ResponseEntity<ApiResult<Void>> updatePostNotice(
+    public ResponseEntity<ApiResult<JourneyPostNoticeUpdateResponse>> updatePostNotice(
             @PathVariable Long journeyId,
             @PathVariable Long journeyPostId,
             @CurrentUser Long userId,
             @Valid @RequestBody JourneyPostNoticeUpdateRequest request
     ) {
-        journeyPostService.updatePostNotice(journeyId, journeyPostId, userId, request);
-        return ResponseEntity.status(HttpStatus.NO_CONTENT).body(ApiResult.noContent());
+        JourneyPostNoticeUpdateResponse response = journeyPostService.updatePostNotice(
+                journeyId,
+                journeyPostId,
+                userId,
+                request
+        );
+        return ResponseEntity.ok(ApiResult.ok(response));
     }
 
     @Override

--- a/src/main/java/com/dduru/gildongmu/journey/controller/JourneyPostController.java
+++ b/src/main/java/com/dduru/gildongmu/journey/controller/JourneyPostController.java
@@ -3,6 +3,7 @@ package com.dduru.gildongmu.journey.controller;
 import com.dduru.gildongmu.common.annotation.CurrentUser;
 import com.dduru.gildongmu.common.dto.ApiResult;
 import com.dduru.gildongmu.journey.dto.request.JourneyPostCreateRequest;
+import com.dduru.gildongmu.journey.dto.request.JourneyPostNoticeUpdateRequest;
 import com.dduru.gildongmu.journey.dto.request.JourneyPostUpdateRequest;
 import com.dduru.gildongmu.journey.dto.response.JourneyPostListResponse;
 import com.dduru.gildongmu.journey.dto.response.JourneyPostResponse;
@@ -69,6 +70,18 @@ public class JourneyPostController implements JourneyPostApiDocs {
     ) {
         JourneyPostResponse response = journeyPostService.updatePost(journeyId, journeyPostId, userId, request);
         return ResponseEntity.ok(ApiResult.ok(response));
+    }
+
+    @Override
+    @PatchMapping("/{journeyPostId}/notice")
+    public ResponseEntity<ApiResult<Void>> updatePostNotice(
+            @PathVariable Long journeyId,
+            @PathVariable Long journeyPostId,
+            @CurrentUser Long userId,
+            @Valid @RequestBody JourneyPostNoticeUpdateRequest request
+    ) {
+        journeyPostService.updatePostNotice(journeyId, journeyPostId, userId, request);
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).body(ApiResult.noContent());
     }
 
     @Override

--- a/src/main/java/com/dduru/gildongmu/journey/domain/JourneyPost.java
+++ b/src/main/java/com/dduru/gildongmu/journey/domain/JourneyPost.java
@@ -94,10 +94,14 @@ public class JourneyPost extends BaseTimeEntity {
         }
     }
 
-    public void delete(Long deletedBy, LocalDateTime deletedAt) {
+    public void softDelete(Long deletedBy, LocalDateTime deletedAt) {
         this.isDeleted = true;
         this.deletedBy = deletedBy;
         this.deletedAt = deletedAt;
+    }
+
+    public void updateNoticeStatus(boolean isNotice) {
+        this.isNotice = isNotice;
     }
 
     public boolean isAuthor(Long userId) {

--- a/src/main/java/com/dduru/gildongmu/journey/dto/request/JourneyPostNoticeUpdateRequest.java
+++ b/src/main/java/com/dduru/gildongmu/journey/dto/request/JourneyPostNoticeUpdateRequest.java
@@ -1,0 +1,9 @@
+package com.dduru.gildongmu.journey.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record JourneyPostNoticeUpdateRequest(
+        @NotNull(message = "공지 여부는 필수입니다.")
+        Boolean isNotice
+) {
+}

--- a/src/main/java/com/dduru/gildongmu/journey/dto/response/JourneyPostNoticeUpdateResponse.java
+++ b/src/main/java/com/dduru/gildongmu/journey/dto/response/JourneyPostNoticeUpdateResponse.java
@@ -1,0 +1,15 @@
+package com.dduru.gildongmu.journey.dto.response;
+
+import com.dduru.gildongmu.journey.domain.JourneyPost;
+
+public record JourneyPostNoticeUpdateResponse(
+        Long journeyPostId,
+        boolean isNotice
+) {
+    public static JourneyPostNoticeUpdateResponse from(JourneyPost journeyPost) {
+        return new JourneyPostNoticeUpdateResponse(
+                journeyPost.getId(),
+                journeyPost.isNotice()
+        );
+    }
+}

--- a/src/main/java/com/dduru/gildongmu/journey/exception/JourneyPostNoticeLimitExceededException.java
+++ b/src/main/java/com/dduru/gildongmu/journey/exception/JourneyPostNoticeLimitExceededException.java
@@ -1,0 +1,11 @@
+package com.dduru.gildongmu.journey.exception;
+
+import com.dduru.gildongmu.common.exception.BusinessException;
+import com.dduru.gildongmu.common.exception.ErrorCode;
+
+public class JourneyPostNoticeLimitExceededException extends BusinessException {
+
+    public JourneyPostNoticeLimitExceededException() {
+        super(ErrorCode.JOURNEY_POST_NOTICE_LIMIT_EXCEEDED);
+    }
+}

--- a/src/main/java/com/dduru/gildongmu/journey/repository/JourneyPostRepository.java
+++ b/src/main/java/com/dduru/gildongmu/journey/repository/JourneyPostRepository.java
@@ -12,6 +12,15 @@ import java.util.Optional;
 public interface JourneyPostRepository extends JpaRepository<JourneyPost, Long> {
 
     @Query("""
+            SELECT COUNT(jp)
+            FROM JourneyPost jp
+            WHERE jp.journey.id = :journeyId
+              AND jp.isNotice = true
+              AND jp.isDeleted = false
+            """)
+    long countActiveNoticesByJourneyId(@Param("journeyId") Long journeyId);
+
+    @Query("""
             SELECT jp
             FROM JourneyPost jp
             JOIN FETCH jp.author author

--- a/src/main/java/com/dduru/gildongmu/journey/repository/JourneyRepository.java
+++ b/src/main/java/com/dduru/gildongmu/journey/repository/JourneyRepository.java
@@ -3,7 +3,9 @@ package com.dduru.gildongmu.journey.repository;
 import com.dduru.gildongmu.journey.domain.Journey;
 import com.dduru.gildongmu.journey.domain.enums.JourneyMemberStatus;
 import com.dduru.gildongmu.journey.exception.JourneyNotFoundException;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -12,6 +14,14 @@ import java.util.Optional;
 public interface JourneyRepository extends JpaRepository<Journey, Long> {
 
     Optional<Journey> findByPostId(Long postId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("""
+            SELECT j
+            FROM Journey j
+            WHERE j.id = :journeyId
+            """)
+    Optional<Journey> findByIdWithLock(@Param("journeyId") Long journeyId);
 
     @Query("""
             SELECT j
@@ -45,6 +55,10 @@ public interface JourneyRepository extends JpaRepository<Journey, Long> {
 
     default Journey getByIdOrThrow(Long journeyId) {
         return findById(journeyId).orElseThrow(JourneyNotFoundException::new);
+    }
+
+    default Journey getByIdWithLockOrThrow(Long journeyId) {
+        return findByIdWithLock(journeyId).orElseThrow(JourneyNotFoundException::new);
     }
 
     default Journey getByPostIdOrThrow(Long postId) {

--- a/src/main/java/com/dduru/gildongmu/journey/service/JourneyPostService.java
+++ b/src/main/java/com/dduru/gildongmu/journey/service/JourneyPostService.java
@@ -10,6 +10,7 @@ import com.dduru.gildongmu.journey.dto.request.JourneyPostListRequest;
 import com.dduru.gildongmu.journey.dto.request.JourneyPostNoticeUpdateRequest;
 import com.dduru.gildongmu.journey.dto.request.JourneyPostUpdateRequest;
 import com.dduru.gildongmu.journey.dto.response.JourneyPostListResponse;
+import com.dduru.gildongmu.journey.dto.response.JourneyPostNoticeUpdateResponse;
 import com.dduru.gildongmu.journey.dto.response.JourneyPostResponse;
 import com.dduru.gildongmu.journey.exception.InvalidJourneyPostException;
 import com.dduru.gildongmu.journey.exception.JourneyAccessDeniedException;
@@ -128,7 +129,7 @@ public class JourneyPostService {
                 journeyId, journeyPostId, userId);
     }
 
-    public void updatePostNotice(
+    public JourneyPostNoticeUpdateResponse updatePostNotice(
             Long journeyId,
             Long journeyPostId,
             Long userId,
@@ -143,6 +144,7 @@ public class JourneyPostService {
         journeyPost.updateNoticeStatus(nextNotice);
         log.info("나의 여정 게시글 공지 상태 변경됨 - journeyId={}, journeyPostId={}, isNotice={}, userId={}",
                 journeyId, journeyPostId, nextNotice, userId);
+        return JourneyPostNoticeUpdateResponse.from(journeyPost);
     }
 
     private JourneyPost createJourneyPost(Journey journey, User author, JourneyPostCreateRequest request) {

--- a/src/main/java/com/dduru/gildongmu/journey/service/JourneyPostService.java
+++ b/src/main/java/com/dduru/gildongmu/journey/service/JourneyPostService.java
@@ -138,7 +138,7 @@ public class JourneyPostService {
 
         JourneyPost journeyPost = journeyPostRepository.getActivePostByIdAndJourneyIdOrThrow(journeyPostId, journeyId);
         boolean nextNotice = Boolean.TRUE.equals(request.isNotice());
-        validateNoticeLimitBeforeMarking(journeyId, journeyPost, nextNotice);
+        validateNoticeLimitBeforeMarking(journeyId, userId, journeyPost, nextNotice);
 
         journeyPost.updateNoticeStatus(nextNotice);
         log.info("나의 여정 게시글 공지 상태 변경됨 - journeyId={}, journeyPostId={}, isNotice={}, userId={}",
@@ -208,18 +208,25 @@ public class JourneyPostService {
     }
 
     private void validateActiveHost(Long journeyId, Long userId) {
-        // 같은 여정의 공지 개수 검사와 상태 변경을 직렬화해 최대 3개 정책을 지킨다.
-        journeyRepository.getByIdWithLockOrThrow(journeyId);
         boolean isActiveHost = journeyMemberRepository.existsActiveHost(journeyId, userId);
         if (!isActiveHost) {
             throw new JourneyAccessDeniedException();
         }
     }
 
-    private void validateNoticeLimitBeforeMarking(Long journeyId, JourneyPost journeyPost, boolean nextNotice) {
+    private void validateNoticeLimitBeforeMarking(
+            Long journeyId,
+            Long userId,
+            JourneyPost journeyPost,
+            boolean nextNotice
+    ) {
         if (!nextNotice || journeyPost.isNotice()) {
             return;
         }
+
+        // 새 공지를 추가하는 경로만 직렬화해 여정당 공지 최대 3개 정책을 보장한다.
+        journeyRepository.getByIdWithLockOrThrow(journeyId);
+        validateActiveHost(journeyId, userId);
 
         long noticeCount = journeyPostRepository.countActiveNoticesByJourneyId(journeyId);
         if (noticeCount >= NOTICE_LIMIT) {

--- a/src/main/java/com/dduru/gildongmu/journey/service/JourneyPostService.java
+++ b/src/main/java/com/dduru/gildongmu/journey/service/JourneyPostService.java
@@ -6,12 +6,14 @@ import com.dduru.gildongmu.journey.domain.Journey;
 import com.dduru.gildongmu.journey.domain.JourneyPost;
 import com.dduru.gildongmu.journey.domain.enums.JourneyMemberStatus;
 import com.dduru.gildongmu.journey.dto.request.JourneyPostCreateRequest;
+import com.dduru.gildongmu.journey.dto.request.JourneyPostNoticeUpdateRequest;
 import com.dduru.gildongmu.journey.dto.request.JourneyPostUpdateRequest;
 import com.dduru.gildongmu.journey.dto.response.JourneyPostListResponse;
 import com.dduru.gildongmu.journey.dto.response.JourneyPostResponse;
 import com.dduru.gildongmu.journey.exception.InvalidJourneyPostException;
 import com.dduru.gildongmu.journey.exception.JourneyAccessDeniedException;
 import com.dduru.gildongmu.journey.exception.JourneyPostAccessDeniedException;
+import com.dduru.gildongmu.journey.exception.JourneyPostNoticeLimitExceededException;
 import com.dduru.gildongmu.journey.repository.JourneyMemberRepository;
 import com.dduru.gildongmu.journey.repository.JourneyPostRepository;
 import com.dduru.gildongmu.journey.repository.JourneyRepository;
@@ -34,6 +36,7 @@ import java.util.List;
 public class JourneyPostService {
     private static final int TITLE_MAX_LENGTH = 30;
     private static final int CONTENT_MAX_LENGTH = 300;
+    private static final int NOTICE_LIMIT = 3;
 
     private final JourneyRepository journeyRepository;
     private final JourneyMemberRepository journeyMemberRepository;
@@ -100,9 +103,26 @@ public class JourneyPostService {
     public void deletePost(Long journeyId, Long journeyPostId, Long userId) {
         JourneyPost journeyPost = getOwnedJourneyPost(journeyId, journeyPostId, userId);
 
-        journeyPost.delete(userId, timeProvider.now());
+        journeyPost.softDelete(userId, timeProvider.now());
         log.info("나의 여정 게시글 삭제됨 - journeyId={}, journeyPostId={}, userId={}",
                 journeyId, journeyPostId, userId);
+    }
+
+    public void updatePostNotice(
+            Long journeyId,
+            Long journeyPostId,
+            Long userId,
+            JourneyPostNoticeUpdateRequest request
+    ) {
+        validateActiveHost(journeyId, userId);
+
+        JourneyPost journeyPost = journeyPostRepository.getActivePostByIdAndJourneyIdOrThrow(journeyPostId, journeyId);
+        boolean nextNotice = Boolean.TRUE.equals(request.isNotice());
+        validateNoticeLimitBeforeMarking(journeyId, journeyPost, nextNotice);
+
+        journeyPost.updateNoticeStatus(nextNotice);
+        log.info("나의 여정 게시글 공지 상태 변경됨 - journeyId={}, journeyPostId={}, isNotice={}, userId={}",
+                journeyId, journeyPostId, nextNotice, userId);
     }
 
     private JourneyPost createJourneyPost(Journey journey, User author, JourneyPostCreateRequest request) {
@@ -146,6 +166,26 @@ public class JourneyPostService {
             throw new JourneyPostAccessDeniedException();
         }
         return journeyPost;
+    }
+
+    private void validateActiveHost(Long journeyId, Long userId) {
+        // 같은 여정의 공지 개수 검사와 상태 변경을 직렬화해 최대 3개 정책을 지킨다.
+        journeyRepository.getByIdWithLockOrThrow(journeyId);
+        boolean isActiveHost = journeyMemberRepository.existsActiveHost(journeyId, userId);
+        if (!isActiveHost) {
+            throw new JourneyAccessDeniedException();
+        }
+    }
+
+    private void validateNoticeLimitBeforeMarking(Long journeyId, JourneyPost journeyPost, boolean nextNotice) {
+        if (!nextNotice || journeyPost.isNotice()) {
+            return;
+        }
+
+        long noticeCount = journeyPostRepository.countActiveNoticesByJourneyId(journeyId);
+        if (noticeCount >= NOTICE_LIMIT) {
+            throw new JourneyPostNoticeLimitExceededException();
+        }
     }
 
     private Long findActiveHostUserId(Long journeyId) {

--- a/src/main/java/com/dduru/gildongmu/journey/service/JourneyService.java
+++ b/src/main/java/com/dduru/gildongmu/journey/service/JourneyService.java
@@ -57,7 +57,7 @@ public class JourneyService {
     }
 
     public void removeMember(Long journeyId, Long hostUserId, Long memberUserId) {
-        validateHostAuthority(journeyId, hostUserId);
+        validateActiveHost(journeyId, hostUserId);
 
         Post post = getPostForMemberRemoval(journeyId);
         JourneyMember member = getActiveMemberForUpdate(journeyId, memberUserId);
@@ -79,7 +79,7 @@ public class JourneyService {
                 .orElseThrow(JourneyAccessDeniedException::new);
     }
 
-    private void validateHostAuthority(Long journeyId, Long hostUserId) {
+    private void validateActiveHost(Long journeyId, Long hostUserId) {
         boolean isActiveHost = journeyMemberRepository.existsActiveHost(journeyId, hostUserId);
         if (!isActiveHost) {
             throw new JourneyAccessDeniedException();

--- a/src/test/java/com/dduru/gildongmu/journey/service/JourneyPostServiceTest.java
+++ b/src/test/java/com/dduru/gildongmu/journey/service/JourneyPostServiceTest.java
@@ -316,7 +316,8 @@ class JourneyPostServiceTest {
             JourneyPost journeyPost = createJourneyPost(journeyPostId, journey, createUser(20L, "author"));
             JourneyPostNoticeUpdateRequest request = new JourneyPostNoticeUpdateRequest(true);
 
-            givenActiveHost(journeyId, hostUserId, journey);
+            givenActiveHostPermission(journeyId, hostUserId);
+            givenLockedJourney(journeyId, journey);
             when(journeyPostRepository.getActivePostByIdAndJourneyIdOrThrow(journeyPostId, journeyId))
                     .thenReturn(journeyPost);
             when(journeyPostRepository.countActiveNoticesByJourneyId(journeyId)).thenReturn(2L);
@@ -336,7 +337,8 @@ class JourneyPostServiceTest {
             JourneyPost journeyPost = createJourneyPost(journeyPostId, journey, createUser(20L, "author"));
             JourneyPostNoticeUpdateRequest request = new JourneyPostNoticeUpdateRequest(true);
 
-            givenActiveHost(journeyId, hostUserId, journey);
+            givenActiveHostPermission(journeyId, hostUserId);
+            givenLockedJourney(journeyId, journey);
             when(journeyPostRepository.getActivePostByIdAndJourneyIdOrThrow(journeyPostId, journeyId))
                     .thenReturn(journeyPost);
             when(journeyPostRepository.countActiveNoticesByJourneyId(journeyId)).thenReturn(3L);
@@ -360,13 +362,14 @@ class JourneyPostServiceTest {
             journeyPost.updateNoticeStatus(true);
             JourneyPostNoticeUpdateRequest request = new JourneyPostNoticeUpdateRequest(false);
 
-            givenActiveHost(journeyId, hostUserId, journey);
+            givenActiveHostPermission(journeyId, hostUserId);
             when(journeyPostRepository.getActivePostByIdAndJourneyIdOrThrow(journeyPostId, journeyId))
                     .thenReturn(journeyPost);
 
             journeyPostService.updatePostNotice(journeyId, journeyPostId, hostUserId, request);
 
             assertThat(journeyPost.isNotice()).isFalse();
+            verify(journeyRepository, never()).getByIdWithLockOrThrow(journeyId);
             verify(journeyPostRepository, never()).countActiveNoticesByJourneyId(journeyId);
         }
 
@@ -381,13 +384,14 @@ class JourneyPostServiceTest {
             journeyPost.updateNoticeStatus(true);
             JourneyPostNoticeUpdateRequest request = new JourneyPostNoticeUpdateRequest(true);
 
-            givenActiveHost(journeyId, hostUserId, journey);
+            givenActiveHostPermission(journeyId, hostUserId);
             when(journeyPostRepository.getActivePostByIdAndJourneyIdOrThrow(journeyPostId, journeyId))
                     .thenReturn(journeyPost);
 
             journeyPostService.updatePostNotice(journeyId, journeyPostId, hostUserId, request);
 
             assertThat(journeyPost.isNotice()).isTrue();
+            verify(journeyRepository, never()).getByIdWithLockOrThrow(journeyId);
             verify(journeyPostRepository, never()).countActiveNoticesByJourneyId(journeyId);
         }
 
@@ -397,15 +401,14 @@ class JourneyPostServiceTest {
             Long journeyId = 1L;
             Long userId = 20L;
             Long journeyPostId = 101L;
-            Journey journey = createJourney(journeyId, 10L);
             JourneyPostNoticeUpdateRequest request = new JourneyPostNoticeUpdateRequest(true);
 
-            when(journeyRepository.getByIdWithLockOrThrow(journeyId)).thenReturn(journey);
             when(journeyMemberRepository.existsActiveHost(journeyId, userId)).thenReturn(false);
 
             assertThatThrownBy(() -> journeyPostService.updatePostNotice(journeyId, journeyPostId, userId, request))
                     .isInstanceOf(JourneyAccessDeniedException.class);
 
+            verify(journeyRepository, never()).getByIdWithLockOrThrow(journeyId);
             verify(journeyPostRepository, never()).getActivePostByIdAndJourneyIdOrThrow(journeyPostId, journeyId);
         }
     }
@@ -519,8 +522,11 @@ class JourneyPostServiceTest {
                 .thenReturn(Optional.of(hostUserId));
     }
 
-    private void givenActiveHost(Long journeyId, Long hostUserId, Journey journey) {
+    private void givenLockedJourney(Long journeyId, Journey journey) {
         when(journeyRepository.getByIdWithLockOrThrow(journeyId)).thenReturn(journey);
+    }
+
+    private void givenActiveHostPermission(Long journeyId, Long hostUserId) {
         when(journeyMemberRepository.existsActiveHost(journeyId, hostUserId)).thenReturn(true);
     }
 

--- a/src/test/java/com/dduru/gildongmu/journey/service/JourneyPostServiceTest.java
+++ b/src/test/java/com/dduru/gildongmu/journey/service/JourneyPostServiceTest.java
@@ -11,12 +11,14 @@ import com.dduru.gildongmu.journey.domain.Journey;
 import com.dduru.gildongmu.journey.domain.JourneyPost;
 import com.dduru.gildongmu.journey.domain.enums.JourneyMemberStatus;
 import com.dduru.gildongmu.journey.dto.request.JourneyPostCreateRequest;
+import com.dduru.gildongmu.journey.dto.request.JourneyPostNoticeUpdateRequest;
 import com.dduru.gildongmu.journey.dto.request.JourneyPostUpdateRequest;
 import com.dduru.gildongmu.journey.dto.response.JourneyPostListResponse;
 import com.dduru.gildongmu.journey.dto.response.JourneyPostResponse;
 import com.dduru.gildongmu.journey.exception.InvalidJourneyPostException;
 import com.dduru.gildongmu.journey.exception.JourneyAccessDeniedException;
 import com.dduru.gildongmu.journey.exception.JourneyPostAccessDeniedException;
+import com.dduru.gildongmu.journey.exception.JourneyPostNoticeLimitExceededException;
 import com.dduru.gildongmu.journey.repository.JourneyMemberRepository;
 import com.dduru.gildongmu.journey.repository.JourneyPostRepository;
 import com.dduru.gildongmu.journey.repository.JourneyRepository;
@@ -220,6 +222,114 @@ class JourneyPostServiceTest {
     }
 
     @Nested
+    @DisplayName("게시글 공지 지정/해제")
+    class UpdateNotice {
+
+        @Test
+        @DisplayName("active host는 게시글을 공지로 지정할 수 있다")
+        void activeHostCanMarkNotice() {
+            Long journeyId = 1L;
+            Long hostUserId = 10L;
+            Long journeyPostId = 101L;
+            Journey journey = createJourney(journeyId, hostUserId);
+            JourneyPost journeyPost = createJourneyPost(journeyPostId, journey, createUser(20L, "author"));
+            JourneyPostNoticeUpdateRequest request = new JourneyPostNoticeUpdateRequest(true);
+
+            givenActiveHost(journeyId, hostUserId, journey);
+            when(journeyPostRepository.getActivePostByIdAndJourneyIdOrThrow(journeyPostId, journeyId))
+                    .thenReturn(journeyPost);
+            when(journeyPostRepository.countActiveNoticesByJourneyId(journeyId)).thenReturn(2L);
+
+            journeyPostService.updatePostNotice(journeyId, journeyPostId, hostUserId, request);
+
+            assertThat(journeyPost.isNotice()).isTrue();
+        }
+
+        @Test
+        @DisplayName("공지 게시글이 이미 3개이면 추가 지정할 수 없다")
+        void cannotMarkNoticeWhenLimitExceeded() {
+            Long journeyId = 1L;
+            Long hostUserId = 10L;
+            Long journeyPostId = 101L;
+            Journey journey = createJourney(journeyId, hostUserId);
+            JourneyPost journeyPost = createJourneyPost(journeyPostId, journey, createUser(20L, "author"));
+            JourneyPostNoticeUpdateRequest request = new JourneyPostNoticeUpdateRequest(true);
+
+            givenActiveHost(journeyId, hostUserId, journey);
+            when(journeyPostRepository.getActivePostByIdAndJourneyIdOrThrow(journeyPostId, journeyId))
+                    .thenReturn(journeyPost);
+            when(journeyPostRepository.countActiveNoticesByJourneyId(journeyId)).thenReturn(3L);
+
+            assertThatThrownBy(() -> journeyPostService.updatePostNotice(journeyId, journeyPostId, hostUserId, request))
+                    .isInstanceOf(JourneyPostNoticeLimitExceededException.class)
+                    .extracting(e -> ((BusinessException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.JOURNEY_POST_NOTICE_LIMIT_EXCEEDED);
+
+            assertThat(journeyPost.isNotice()).isFalse();
+        }
+
+        @Test
+        @DisplayName("공지 해제는 개수 제한을 검사하지 않는다")
+        void unmarkNoticeDoesNotCheckLimit() {
+            Long journeyId = 1L;
+            Long hostUserId = 10L;
+            Long journeyPostId = 101L;
+            Journey journey = createJourney(journeyId, hostUserId);
+            JourneyPost journeyPost = createJourneyPost(journeyPostId, journey, createUser(20L, "author"));
+            journeyPost.updateNoticeStatus(true);
+            JourneyPostNoticeUpdateRequest request = new JourneyPostNoticeUpdateRequest(false);
+
+            givenActiveHost(journeyId, hostUserId, journey);
+            when(journeyPostRepository.getActivePostByIdAndJourneyIdOrThrow(journeyPostId, journeyId))
+                    .thenReturn(journeyPost);
+
+            journeyPostService.updatePostNotice(journeyId, journeyPostId, hostUserId, request);
+
+            assertThat(journeyPost.isNotice()).isFalse();
+            verify(journeyPostRepository, never()).countActiveNoticesByJourneyId(journeyId);
+        }
+
+        @Test
+        @DisplayName("이미 공지인 게시글을 다시 공지로 지정하면 개수 제한을 검사하지 않는다")
+        void alreadyNoticeDoesNotCheckLimit() {
+            Long journeyId = 1L;
+            Long hostUserId = 10L;
+            Long journeyPostId = 101L;
+            Journey journey = createJourney(journeyId, hostUserId);
+            JourneyPost journeyPost = createJourneyPost(journeyPostId, journey, createUser(20L, "author"));
+            journeyPost.updateNoticeStatus(true);
+            JourneyPostNoticeUpdateRequest request = new JourneyPostNoticeUpdateRequest(true);
+
+            givenActiveHost(journeyId, hostUserId, journey);
+            when(journeyPostRepository.getActivePostByIdAndJourneyIdOrThrow(journeyPostId, journeyId))
+                    .thenReturn(journeyPost);
+
+            journeyPostService.updatePostNotice(journeyId, journeyPostId, hostUserId, request);
+
+            assertThat(journeyPost.isNotice()).isTrue();
+            verify(journeyPostRepository, never()).countActiveNoticesByJourneyId(journeyId);
+        }
+
+        @Test
+        @DisplayName("active host가 아니면 공지 상태를 변경할 수 없다")
+        void nonHostCannotUpdateNotice() {
+            Long journeyId = 1L;
+            Long userId = 20L;
+            Long journeyPostId = 101L;
+            Journey journey = createJourney(journeyId, 10L);
+            JourneyPostNoticeUpdateRequest request = new JourneyPostNoticeUpdateRequest(true);
+
+            when(journeyRepository.getByIdWithLockOrThrow(journeyId)).thenReturn(journey);
+            when(journeyMemberRepository.existsActiveHost(journeyId, userId)).thenReturn(false);
+
+            assertThatThrownBy(() -> journeyPostService.updatePostNotice(journeyId, journeyPostId, userId, request))
+                    .isInstanceOf(JourneyAccessDeniedException.class);
+
+            verify(journeyPostRepository, never()).getActivePostByIdAndJourneyIdOrThrow(journeyPostId, journeyId);
+        }
+    }
+
+    @Nested
     @DisplayName("게시글 수정/삭제")
     class UpdateAndDelete {
 
@@ -330,6 +440,11 @@ class JourneyPostServiceTest {
     private void givenActiveHost(Long journeyId, Long hostUserId) {
         when(journeyMemberRepository.findActiveHostUserIdByJourneyId(journeyId))
                 .thenReturn(Optional.of(hostUserId));
+    }
+
+    private void givenActiveHost(Long journeyId, Long hostUserId, Journey journey) {
+        when(journeyRepository.getByIdWithLockOrThrow(journeyId)).thenReturn(journey);
+        when(journeyMemberRepository.existsActiveHost(journeyId, hostUserId)).thenReturn(true);
     }
 
     private Journey createJourney(Long journeyId, Long ownerId) {

--- a/src/test/java/com/dduru/gildongmu/journey/service/JourneyPostServiceTest.java
+++ b/src/test/java/com/dduru/gildongmu/journey/service/JourneyPostServiceTest.java
@@ -15,6 +15,7 @@ import com.dduru.gildongmu.journey.dto.request.JourneyPostListRequest;
 import com.dduru.gildongmu.journey.dto.request.JourneyPostNoticeUpdateRequest;
 import com.dduru.gildongmu.journey.dto.request.JourneyPostUpdateRequest;
 import com.dduru.gildongmu.journey.dto.response.JourneyPostListResponse;
+import com.dduru.gildongmu.journey.dto.response.JourneyPostNoticeUpdateResponse;
 import com.dduru.gildongmu.journey.dto.response.JourneyPostResponse;
 import com.dduru.gildongmu.journey.exception.InvalidJourneyPostException;
 import com.dduru.gildongmu.journey.exception.JourneyAccessDeniedException;
@@ -322,9 +323,16 @@ class JourneyPostServiceTest {
                     .thenReturn(journeyPost);
             when(journeyPostRepository.countActiveNoticesByJourneyId(journeyId)).thenReturn(2L);
 
-            journeyPostService.updatePostNotice(journeyId, journeyPostId, hostUserId, request);
+            JourneyPostNoticeUpdateResponse response = journeyPostService.updatePostNotice(
+                    journeyId,
+                    journeyPostId,
+                    hostUserId,
+                    request
+            );
 
             assertThat(journeyPost.isNotice()).isTrue();
+            assertThat(response.journeyPostId()).isEqualTo(journeyPostId);
+            assertThat(response.isNotice()).isTrue();
         }
 
         @Test
@@ -366,9 +374,16 @@ class JourneyPostServiceTest {
             when(journeyPostRepository.getActivePostByIdAndJourneyIdOrThrow(journeyPostId, journeyId))
                     .thenReturn(journeyPost);
 
-            journeyPostService.updatePostNotice(journeyId, journeyPostId, hostUserId, request);
+            JourneyPostNoticeUpdateResponse response = journeyPostService.updatePostNotice(
+                    journeyId,
+                    journeyPostId,
+                    hostUserId,
+                    request
+            );
 
             assertThat(journeyPost.isNotice()).isFalse();
+            assertThat(response.journeyPostId()).isEqualTo(journeyPostId);
+            assertThat(response.isNotice()).isFalse();
             verify(journeyRepository, never()).getByIdWithLockOrThrow(journeyId);
             verify(journeyPostRepository, never()).countActiveNoticesByJourneyId(journeyId);
         }
@@ -388,9 +403,16 @@ class JourneyPostServiceTest {
             when(journeyPostRepository.getActivePostByIdAndJourneyIdOrThrow(journeyPostId, journeyId))
                     .thenReturn(journeyPost);
 
-            journeyPostService.updatePostNotice(journeyId, journeyPostId, hostUserId, request);
+            JourneyPostNoticeUpdateResponse response = journeyPostService.updatePostNotice(
+                    journeyId,
+                    journeyPostId,
+                    hostUserId,
+                    request
+            );
 
             assertThat(journeyPost.isNotice()).isTrue();
+            assertThat(response.journeyPostId()).isEqualTo(journeyPostId);
+            assertThat(response.isNotice()).isTrue();
             verify(journeyRepository, never()).getByIdWithLockOrThrow(journeyId);
             verify(journeyPostRepository, never()).countActiveNoticesByJourneyId(journeyId);
         }


### PR DESCRIPTION
## 🔎 작업 내용
* 나의 여정 게시글 공지 지정/해제 요청 DTO(`JourneyPostNoticeUpdateRequest`)를 추가.
* `PATCH /api/v1/journeys/{journeyId}/posts/{journeyPostId}/notice` API를 구현.
* active host만 공지 상태를 변경할 수 있도록 권한 검증을 추가.
* 공지 지정 시 여정당 공지 게시글이 최대 3개까지만 유지되도록 제한 로직을 추가.
* 공지 해제 또는 이미 공지인 게시글에 대한 재요청은 공지 개수 검사를 생략하도록 처리.
* 공지 개수 검증과 상태 변경이 안전하게 동작하도록 journey 단위 비관적 락(`getByIdWithLockOrThrow`)을 적용.
* `JourneyPost` 도메인에 공지 상태 변경 메서드(`updateNoticeStatus`)를 추가.
* 공지 개수 조회용 repository 메서드(`countActiveNoticesByJourneyId`)를 추가.
* 신규 예외 `JourneyPostNoticeLimitExceededException` 및 에러코드 `JOURNEY_POST_NOTICE_LIMIT_EXCEEDED`를 추가.
* Swagger 문서와 서비스 테스트를 보강했습니다.

## ➕ 이슈 링크
* CLOSED #236 


## 😎 리뷰 요구사항
> 공지 최대 3개 제한을 journey 락 + count 조회로 처리한 방향이 적절한지 중점적으로 봐주시면 좋겠습니다.
> 특히 공지 해제나 이미 공지인 게시글 재설정 요청에서 개수 검사를 생략한 분기와,
> active host 권한 검증 범위가 의도한 정책과 맞는지 확인 부탁드립니다.


## 📝 체크리스트
- [x] 브랜치 이름은 `feat/개발내용` 형식으로 작성했는가?
- [x] 커밋 메시지는 `feat(scope): 커밋 내용` 형식으로 작성했는가?
- [x] 작업 전 Issue를 작성했는가?
- [x] `dev` 브랜치로 병합을 요청했는가?
- [x] 불필요한 주석과 공백은 제거했는가?
- [x] 코드 리뷰어의 피드백을 반영했는가?
- [x] 테스트를 진행했는가?
- [x] 테스트 코드를 작성했는가?
