### PR TITLE
[#260] fix(swagger): Swagger 문서 정리

### DIFF
--- a/docs/005-conventions/003-faq.md
+++ b/docs/005-conventions/003-faq.md
@@ -25,6 +25,8 @@ chat/dto/ws
 public class PostController implements PostApiDocs
 ```
 
+자세한 작성 기준은 [Swagger API 명세 작성 가이드](./004-swagger-api-docs.md)를 확인합니다.
+
 ---
 
 ## 성공 응답은 어떤 포맷을 쓰나요?

--- a/docs/005-conventions/004-swagger-api-docs.md
+++ b/docs/005-conventions/004-swagger-api-docs.md
@@ -1,0 +1,150 @@
+# 004. Swagger API 명세 작성 가이드
+
+> 이 문서를 보면 Swagger UI에 노출되는 API 명세를 어떤 형식으로 작성해야 하는지 파악할 수 있습니다.
+
+---
+
+## 한 줄 요약
+
+Swagger 명세는 Controller가 아니라 `*ApiDocs` 인터페이스에 작성하고, 성공 응답과 실제 발생 가능한 `ErrorCode`를 빠짐없이 문서화합니다.
+
+---
+
+## 1. 기본 위치
+
+Controller는 구현만 담당하고 Swagger 어노테이션은 같은 패키지의 `{Domain}ApiDocs` 인터페이스에 둡니다.
+
+```java
+@RestController
+public class PostController implements PostApiDocs {
+}
+```
+
+```java
+@Tag(name = "Posts", description = "여행 게시글 API")
+public interface PostApiDocs {
+}
+```
+
+작성 기준:
+
+| 항목 | 규칙 |
+|---|---|
+| `@Tag` | 도메인 API 단위로 인터페이스에 작성 |
+| `@Operation` | 모든 API 메서드에 `summary`, `description` 작성 |
+| `@ApiResponse` | 성공 응답을 모든 API 메서드에 명시 |
+| `@ApiErrorResponses` | 실패 응답이 있는 API 메서드에 실제 `ErrorCode` 작성 |
+| `@Parameter` | path variable, 숨겨야 하는 인증 사용자 ID 등에 작성 |
+| `@ParameterObject` | query parameter DTO에 사용 |
+| DTO `@Schema` | 필드 의미, 예시, 허용 값이 코드만으로 명확하지 않을 때 작성 |
+
+---
+
+## 2. 성공 응답
+
+성공 응답은 실제 Controller가 반환하는 `ApiResult<T>`와 HTTP status에 맞춰 문서화합니다.
+
+| 상황 | 응답 문서 |
+|---|---|
+| 조회/일반 성공 | `@ApiResponse(responseCode = "200", description = "조회 성공")` |
+| 생성 성공 | `@ApiResponse(responseCode = "201", description = "생성 성공")` |
+| 본문 없는 성공 | `@ApiResponse(responseCode = "204", description = "삭제 성공", content = @Content())` |
+
+204 응답은 본문이 없으므로 반드시 `content = @Content()`를 지정합니다. 지정하지 않으면 Swagger UI가 응답 본문이 있는 것처럼 보일 수 있습니다.
+
+```java
+@Operation(summary = "게시글 삭제", description = "게시글을 삭제합니다.")
+@ApiResponse(responseCode = "204", description = "삭제 성공", content = @Content())
+@ApiErrorResponses({
+        ErrorCode.POST_NOT_FOUND,
+        ErrorCode.POST_ACCESS_DENIED,
+        ErrorCode.UNAUTHORIZED
+})
+ResponseEntity<ApiResult<Void>> deletePost(
+        @Parameter(description = "게시글 ID") Long postId,
+        @Parameter(hidden = true) Long userId
+);
+```
+
+---
+
+## 3. 실패 응답
+
+비즈니스 실패 응답은 `@ApiErrorResponses`에 `ErrorCode`를 나열합니다. `ApiErrorResponseDocsCustomizer`가 HTTP status별 응답과 예시를 Swagger UI에 자동 추가합니다.
+
+```java
+@ApiErrorResponses({
+        ErrorCode.INVALID_INPUT_VALUE,
+        ErrorCode.POST_NOT_FOUND,
+        ErrorCode.POST_ACCESS_DENIED
+})
+```
+
+작성 기준:
+
+| 상황 | 규칙 |
+|---|---|
+| request DTO에 validation이 있다 | `INVALID_INPUT_VALUE`를 포함 |
+| 인증 필수 API다 | 인증 실패 응답이 필요한 경우 `UNAUTHORIZED`를 포함 |
+| 권한 검증이 있다 | 도메인별 access denied `ErrorCode`를 포함 |
+| 조회 대상이 없을 수 있다 | 도메인별 not found `ErrorCode`를 포함 |
+| 같은 HTTP status의 에러가 여러 개다 | 모두 나열하면 examples로 묶여 표시됨 |
+| 현재 코드에서 발생하지 않는다 | 문서화하지 않음 |
+
+`@ApiErrorResponses`는 "클라이언트가 이 API에서 받을 수 있는 에러"만 적습니다. 다른 API에서 쓰는 공통 `ErrorCode`이거나 과거 구현에서만 발생하던 에러는 제외합니다.
+
+---
+
+## 4. 파라미터와 인증 사용자
+
+API 경로에 드러나는 값은 `@Parameter(description = "...")`로 설명합니다.
+
+```java
+ResponseEntity<ApiResult<PostDetailResponse>> retrievePostDetail(
+        @Parameter(description = "게시글 ID") Long postId,
+        @Parameter(hidden = true) Long userId
+);
+```
+
+Controller에서 `@CurrentUser`, `@OptionalCurrentUser`로 주입받는 사용자 ID는 클라이언트가 보내는 값이 아니므로 `@Parameter(hidden = true)`를 사용합니다.
+
+Query parameter가 DTO로 묶여 있으면 `@ParameterObject`를 사용합니다.
+
+```java
+ResponseEntity<ApiResult<PostListResponse>> retrievePosts(
+        @ParameterObject PostListRequest request
+);
+```
+
+---
+
+## 5. 보안과 그룹
+
+Swagger UI는 `/swagger-ui.html`에서 확인합니다. 문서 그룹은 `public`, `admin`으로 나뉩니다.
+
+| 그룹 | 기준 |
+|---|---|
+| `public` | 일반 사용자 API |
+| `admin` | 관리자 API |
+
+보안 표시 방식은 `SwaggerConfig`의 전역 OpenAPI 설정과 개별 `@SecurityRequirement`에 영향을 받습니다. 인증 필요 여부를 바꿀 때는 개별 `ApiDocs`만 보지 말고 `SwaggerConfig`와 실제 Spring Security 설정을 함께 확인합니다.
+
+---
+
+## 6. 체크리스트
+
+- [ ] Controller가 `*ApiDocs` 인터페이스를 구현하는가?
+- [ ] 모든 API 메서드에 `@Operation`이 있는가?
+- [ ] 모든 API 메서드에 성공 `@ApiResponse`가 있는가?
+- [ ] 204 응답에 `content = @Content()`가 있는가?
+- [ ] request validation이 있으면 `INVALID_INPUT_VALUE`가 문서화되어 있는가?
+- [ ] 실제 서비스/도메인에서 발생하는 비즈니스 `ErrorCode`가 모두 문서화되어 있는가?
+- [ ] 현재 코드에서 발생하지 않는 `ErrorCode`를 문서화하지 않았는가?
+- [ ] 인증 사용자 ID는 `@Parameter(hidden = true)`로 숨겼는가?
+- [ ] Swagger UI에서 `public`/`admin` 그룹과 응답 예시를 확인했는가?
+
+## 관련 문서
+
+- [패키지 구조 가이드](../002-architecture/001-package-structure.md)
+- [공통 기반 사용 가이드](../002-architecture/003-common-foundation.md)
+- [예외 처리 전략](./002-exception.md)

--- a/docs/005-conventions/README.md
+++ b/docs/005-conventions/README.md
@@ -8,6 +8,7 @@
 | [팀 협업 컨벤션](./001-team.md) | Issue, branch, commit, PR 규칙 |
 | [예외 처리 전략](./002-exception.md) | 중앙 `ErrorCode` + 개별 예외 클래스 사용 기준 |
 | [팀 FAQ](./003-faq.md) | DTO, ApiDocs, Service, Repository 등 자주 묻는 질문 |
+| [Swagger API 명세 작성 가이드](./004-swagger-api-docs.md) | Swagger UI에 노출되는 API 명세 작성 기준 |
 
 ## 파일명 / 제목 규칙
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,7 @@
 | 로컬 실행/Docker | [Docker 운영 가이드](./004-operations/003-docker.md) |
 | 배포/Blue-Green | [배포 파이프라인](./004-operations/002-deployment.md) |
 | PR/커밋/브랜치 | [팀 협업 컨벤션](./005-conventions/001-team.md) |
+| Swagger API 명세 작성 | [Swagger API 명세 작성 가이드](./005-conventions/004-swagger-api-docs.md) |
 | 채팅 API 설계 | [API 설계 문서](./003-api/) |
 | 의사결정 기록 | [ADR](./006-adr/) |
 | 새 문서 작성 | [공통 문서 템플릿](./000-template.md) |
@@ -54,7 +55,8 @@ docs/
 │   ├── 000-template.md
 │   ├── 001-team.md
 │   ├── 002-exception.md
-│   └── 003-faq.md
+│   ├── 003-faq.md
+│   └── 004-swagger-api-docs.md
 ├── 006-adr/
 │   ├── 000-template.md
 │   ├── 001-package-by-feature-controller-service-repository.md
@@ -105,6 +107,7 @@ Swagger보다 상세한 API별 처리 흐름, 예외, 테스트 케이스를 정
 - [팀 협업 컨벤션](./005-conventions/001-team.md)
 - [예외 처리 전략](./005-conventions/002-exception.md)
 - [팀 FAQ](./005-conventions/003-faq.md)
+- [Swagger API 명세 작성 가이드](./005-conventions/004-swagger-api-docs.md)
 
 ### 006-adr - 의사결정 기록
 

--- a/src/main/java/com/dduru/gildongmu/admin/report/controller/AdminReportApiDocs.java
+++ b/src/main/java/com/dduru/gildongmu/admin/report/controller/AdminReportApiDocs.java
@@ -9,6 +9,7 @@ import com.dduru.gildongmu.common.dto.ApiResult;
 import com.dduru.gildongmu.common.exception.ErrorCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springdoc.core.annotations.ParameterObject;
@@ -22,6 +23,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 public interface AdminReportApiDocs {
 
     @Operation(summary = "신고 목록 조회", description = "신고 내역을 상태·페이지로 조회합니다. 상태를 생략하면 전체입니다.")
+    @ApiResponse(responseCode = "200", description = "신고 목록 조회 성공")
     @ApiErrorResponses({
             ErrorCode.UNAUTHORIZED,
             ErrorCode.ACCESS_DENIED
@@ -32,6 +34,7 @@ public interface AdminReportApiDocs {
     );
 
     @Operation(summary = "신고 처리", description = "신고 상태·처리 메모를 갱신하고 처리자를 기록합니다.")
+    @ApiResponse(responseCode = "200", description = "신고 처리 성공")
     @ApiErrorResponses({
             ErrorCode.INVALID_INPUT_VALUE,
             ErrorCode.REPORT_NOT_FOUND,

--- a/src/main/java/com/dduru/gildongmu/admin/user/controller/AdminUserApiDocs.java
+++ b/src/main/java/com/dduru/gildongmu/admin/user/controller/AdminUserApiDocs.java
@@ -7,6 +7,7 @@ import com.dduru.gildongmu.common.dto.ApiResult;
 import com.dduru.gildongmu.common.exception.ErrorCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Pageable;
@@ -18,6 +19,7 @@ import org.springframework.http.ResponseEntity;
 public interface AdminUserApiDocs {
 
     @Operation(summary = "사용자 목록 조회", description = "전체 사용자를 페이지 단위로 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "사용자 목록 조회 성공")
     @ApiErrorResponses({
             ErrorCode.UNAUTHORIZED,
             ErrorCode.ACCESS_DENIED
@@ -27,6 +29,7 @@ public interface AdminUserApiDocs {
     );
 
     @Operation(summary = "사용자 상세 조회", description = "사용자 기본 정보와 프로필 요약을 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "사용자 상세 조회 성공")
     @ApiErrorResponses({
             ErrorCode.USER_NOT_FOUND,
             ErrorCode.UNAUTHORIZED,

--- a/src/main/java/com/dduru/gildongmu/common/exception/ApiErrorResponseDocsCustomizer.java
+++ b/src/main/java/com/dduru/gildongmu/common/exception/ApiErrorResponseDocsCustomizer.java
@@ -145,7 +145,6 @@ public class ApiErrorResponseDocsCustomizer {
                 
                 Map<String, Object> dataMap = new LinkedHashMap<>();
                 dataMap.put("errorCode", errorCode.name());
-                dataMap.put("field", null);
                 dataMap.put("message", errorCode.getMessage());
                 errorResponseMap.put("data", dataMap);
                 

--- a/src/main/java/com/dduru/gildongmu/journey/controller/JourneyApiDocs.java
+++ b/src/main/java/com/dduru/gildongmu/journey/controller/JourneyApiDocs.java
@@ -9,6 +9,7 @@ import com.dduru.gildongmu.journey.dto.response.JourneyMainListResponse;
 import com.dduru.gildongmu.journey.dto.response.JourneyUpdateResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -67,7 +68,7 @@ public interface JourneyApiDocs {
             summary = "나의 여정 멤버 내보내기",
             description = "active host가 특정 나의 여정 멤버를 내보냅니다. 멤버십을 REMOVED로 변경하고 그룹 채팅방 멤버십도 함께 제거합니다."
     )
-    @ApiResponse(responseCode = "204", description = "내보내기 성공")
+    @ApiResponse(responseCode = "204", description = "내보내기 성공", content = @Content())
     @ApiErrorResponses({
             ErrorCode.UNAUTHORIZED,
             ErrorCode.JOURNEY_ACCESS_DENIED

--- a/src/main/java/com/dduru/gildongmu/journey/controller/JourneyPostApiDocs.java
+++ b/src/main/java/com/dduru/gildongmu/journey/controller/JourneyPostApiDocs.java
@@ -70,6 +70,9 @@ public interface JourneyPostApiDocs {
             ErrorCode.JOURNEY_NOT_FOUND,
             ErrorCode.JOURNEY_ACCESS_DENIED,
             ErrorCode.JOURNEY_POST_INVALID_CONTENT,
+            ErrorCode.IMAGE_URL_INVALID_FORMAT,
+            ErrorCode.IMAGE_URL_NOT_ABSOLUTE,
+            ErrorCode.IMAGE_URL_INVALID_SCHEME,
             ErrorCode.IMAGE_URL_NOT_ALLOWED
     })
     ResponseEntity<ApiResult<JourneyPostResponse>> createPost(
@@ -92,6 +95,9 @@ public interface JourneyPostApiDocs {
             ErrorCode.JOURNEY_POST_ACCESS_DENIED,
             ErrorCode.JOURNEY_POST_EMPTY_PATCH,
             ErrorCode.JOURNEY_POST_INVALID_CONTENT,
+            ErrorCode.IMAGE_URL_INVALID_FORMAT,
+            ErrorCode.IMAGE_URL_NOT_ABSOLUTE,
+            ErrorCode.IMAGE_URL_INVALID_SCHEME,
             ErrorCode.IMAGE_URL_NOT_ALLOWED
     })
     ResponseEntity<ApiResult<JourneyPostResponse>> updatePost(

--- a/src/main/java/com/dduru/gildongmu/journey/controller/JourneyPostApiDocs.java
+++ b/src/main/java/com/dduru/gildongmu/journey/controller/JourneyPostApiDocs.java
@@ -12,6 +12,7 @@ import com.dduru.gildongmu.journey.dto.response.JourneyPostNoticeUpdateResponse;
 import com.dduru.gildongmu.journey.dto.response.JourneyPostResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -124,7 +125,7 @@ public interface JourneyPostApiDocs {
             summary = "나의 여정 게시글 삭제",
             description = "작성자 본인이 나의 여정 게시글을 soft delete 처리합니다."
     )
-    @ApiResponse(responseCode = "204", description = "삭제 성공")
+    @ApiResponse(responseCode = "204", description = "삭제 성공", content = @Content())
     @ApiErrorResponses({
             ErrorCode.UNAUTHORIZED,
             ErrorCode.JOURNEY_NOT_FOUND,

--- a/src/main/java/com/dduru/gildongmu/participation/controller/ParticipationApiDocs.java
+++ b/src/main/java/com/dduru/gildongmu/participation/controller/ParticipationApiDocs.java
@@ -97,7 +97,6 @@ public interface ParticipationApiDocs {
             ErrorCode.POST_NOT_FOUND,
             ErrorCode.PARTICIPATION_NOT_FOUND,
             ErrorCode.POST_ACCESS_DENIED,
-            ErrorCode.PARTICIPATION_POST_MISMATCH,
             ErrorCode.RECRUITMENT_CLOSED,
             ErrorCode.RECRUITMENT_FULL,
             ErrorCode.PARTICIPATION_REJECTION_NOT_ALLOWED,

--- a/src/main/java/com/dduru/gildongmu/profile/controller/ProfileApiDocs.java
+++ b/src/main/java/com/dduru/gildongmu/profile/controller/ProfileApiDocs.java
@@ -65,7 +65,8 @@ public interface ProfileApiDocs {
             ErrorCode.UNAUTHORIZED,
             ErrorCode.INVALID_TOKEN,
             ErrorCode.PROFILE_NOT_FOUND,
-            ErrorCode.DUPLICATE_PHONE_NUMBER
+            ErrorCode.DUPLICATE_PHONE_NUMBER,
+            ErrorCode.USER_ONBOARDING_NOT_FOUND
     })
     ResponseEntity<ApiResult<Void>> setupInitialProfile(
             @Parameter(hidden = true) Long userId,
@@ -88,7 +89,9 @@ public interface ProfileApiDocs {
             ErrorCode.NICKNAME_CONTAINS_BAD_WORD,
             ErrorCode.NICKNAME_ALREADY_TAKEN,
             ErrorCode.UNAUTHORIZED,
-            ErrorCode.PROFILE_NOT_FOUND
+            ErrorCode.PROFILE_NOT_FOUND,
+            ErrorCode.BG_COLOR_NOT_FOUND,
+            ErrorCode.USER_ONBOARDING_NOT_FOUND
     })
     ResponseEntity<ApiResult<Void>> updateProfile(
             @Parameter(hidden = true) Long userId,

--- a/src/main/java/com/dduru/gildongmu/survey/controller/SurveyApiDocs.java
+++ b/src/main/java/com/dduru/gildongmu/survey/controller/SurveyApiDocs.java
@@ -24,7 +24,10 @@ public interface SurveyApiDocs {
     @ApiErrorResponses({
             ErrorCode.INVALID_INPUT_VALUE,
             ErrorCode.UNAUTHORIZED,
-            ErrorCode.USER_NOT_FOUND
+            ErrorCode.USER_NOT_FOUND,
+            ErrorCode.PROFILE_NOT_FOUND,
+            ErrorCode.USER_ONBOARDING_NOT_FOUND,
+            ErrorCode.AVATAR_PROFILE_NOT_FOUND
     })
     ResponseEntity<ApiResult<SurveyResponse>> submitSurvey(@Parameter(hidden = true) Long userId, @Valid SurveyRequest request);
 
@@ -47,7 +50,8 @@ public interface SurveyApiDocs {
     @ApiResponse(responseCode = "204", description = "스킵 성공", content = @Content())
     @ApiErrorResponses({
             ErrorCode.UNAUTHORIZED,
-            ErrorCode.USER_ONBOARDING_NOT_FOUND
+            ErrorCode.USER_ONBOARDING_NOT_FOUND,
+            ErrorCode.SURVEY_ALREADY_COMPLETED
     })
     ResponseEntity<ApiResult<Void>> skipSurvey(@Parameter(hidden = true) Long userId);
 }

--- a/src/main/java/com/dduru/gildongmu/survey/controller/SurveyApiDocs.java
+++ b/src/main/java/com/dduru/gildongmu/survey/controller/SurveyApiDocs.java
@@ -8,6 +8,7 @@ import com.dduru.gildongmu.survey.dto.response.SurveyQuestionListResponse;
 import com.dduru.gildongmu.survey.dto.response.SurveyResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -43,7 +44,7 @@ public interface SurveyApiDocs {
     ResponseEntity<ApiResult<SurveyQuestionListResponse>> getSurveyQuestions();
 
     @Operation(summary = "설문조사 스킵", description = "설문조사를 건너뛰고 온보딩 상태를 SKIPPED로 업데이트합니다.")
-    @ApiResponse(responseCode = "204", description = "스킵 성공")
+    @ApiResponse(responseCode = "204", description = "스킵 성공", content = @Content())
     @ApiErrorResponses({
             ErrorCode.UNAUTHORIZED,
             ErrorCode.USER_ONBOARDING_NOT_FOUND


### PR DESCRIPTION
## 🔎 작업 내용
* 관리자 API Swagger 문서에 누락된 200 성공 응답 추가
* 204 응답 문서에 `content = @Content()`를 추가해 no-content 응답 표기 정리
* 공통 에러 응답 예시에서 실제 직렬화와 다르게 `field: null`이 표시되던 부분을 제거
* 설문/프로필/Journey 게시글 API에 실제 발생 가능한 ErrorCode 보강
* 현재 참여신청 거절 흐름에서 발생하지 않는 `PARTICIPATION_POST_MISMATCH` 문서 예시 제거

## ➕ 이슈 링크
* Closed #260

## 📝 체크리스트
- [x] 브랜치 이름은 `feat/개발내용` 형식으로 작성했는가?
- [x] 커밋 메시지는 `feat(scope): 커밋 내용` 형식으로 작성했는가?
- [x] 작업 전 Issue를 작성했는가?
- [x] `dev` 브랜치로 병합을 요청했는가?
- [x] 불필요한 주석과 공백은 제거했는가?
- [ ] 코드 리뷰어의 피드백을 반영했는가?
- [x] 테스트를 진행했는가?
- [ ] 테스트 코드를 작성했는가?

## ✅ 검증
* `./gradlew clean test`