### PR TITLE
task: 채팅 API Swagger 문서 보강

### DIFF
--- a/docs/001-design/flows/005-chat-api-response-guide.md
+++ b/docs/001-design/flows/005-chat-api-response-guide.md
@@ -107,6 +107,19 @@
 - 메시지 생성 이후 입장한 멤버는 과거 메시지의 `unreadCount` 계산 대상이 아니다.
 - `SYSTEM` 메시지는 `unreadCount=null`이다.
 
+### 3.5 이전 메시지와 실시간 메시지 누적
+
+채팅방에 들어가면 REST로 이전 메시지 기록을 먼저 조회하고, 이후 같은 방 topic의 WebSocket 이벤트를 받아 화면에 이어 붙인다.
+
+1. `GET /api/v1/chat-rooms/{chatRoomId}/messages`로 `roomInfo`, `messages`, `page.nextCursor`를 가져온다.
+2. 응답의 `messages`는 오래된 순서로 화면에 렌더링한다.
+3. `/topic/chat/rooms/{roomId}`를 구독한다.
+4. `TEXT`, `IMAGE`, `SYSTEM` 이벤트가 오면 현재 메시지 목록의 마지막에 추가한다.
+5. 위로 스크롤해 과거 메시지가 더 필요하면 `beforeMessageId=page.nextCursor`로 다음 페이지를 조회해 목록 앞쪽에 붙인다.
+6. 화면에 노출된 마지막 메시지까지 확인한 시점에 읽음 처리 API를 호출한다.
+
+즉, 채팅방 진입 시점의 기록은 REST 응답으로 확인하고, 진입 이후 새로 쌓이는 메시지는 WebSocket payload로 바로 확인하는 구조다. WebSocket 연결이 끊겼거나 이벤트 누락이 의심되면 REST 메시지 조회를 다시 호출해 서버 snapshot과 맞춘다.
+
 ## 4. 읽음 처리 기준
 
 ### 4.1 언제 호출할지

--- a/docs/001-design/flows/005-chat-api-response-guide.md
+++ b/docs/001-design/flows/005-chat-api-response-guide.md
@@ -1,237 +1,222 @@
-# 005. Chat API Response Guide
+# 005. Chat API Client Implementation Guide
 
-> Swagger 응답 스키마만으로 판단하기 어려운 채팅 API 응답 데이터의 의미와 프론트엔드 사용 기준을 정리한다.
+> 모바일 클라이언트가 채팅 목록, 채팅 상세, 읽음 처리, 실시간 이벤트를 구현할 때 어떤 API와 필드를 사용해야 하는지 정리한다.
 
 ---
 
 ## 한 줄 요약
 
-채팅 화면은 `roomType`과 `messageType`을 먼저 판단한 뒤, 타입별 표시 필드와 null 규칙에 맞춰 렌더링한다.
+채팅 화면은 REST로 최초 snapshot을 받고, WebSocket 이벤트로 변경분을 반영한다. 렌더링은 `roomType`과 `messageType`을 먼저 보고 분기한다.
 
 ---
 
-## 1. 목적
+## 1. 모바일 화면별 API 요약
 
-채팅 API는 목록, 메시지 조회, 읽음 처리, 실시간 이벤트가 함께 동작한다. Swagger는 필드 타입은 보여주지만 아래 기준은 충분히 드러내기 어렵다.
-
-- `PRIVATE`와 `GROUP` 채팅방에서 같은 필드가 서로 다른 의미를 가지는 경우
-- 메시지 타입별로 사용해야 하는 필드가 달라지는 경우
-- `null`이 정상 상태인지, 데이터 누락인지 구분해야 하는 경우
-- REST 조회 결과와 WebSocket 이벤트를 화면 상태에 적용하는 기준
-
-이 문서는 현재 백엔드 구현을 기준으로 API 소비자가 화면 표시와 상태 갱신에 사용할 수 있는 기준을 제공한다.
-
-## 2. 공통 enum
-
-### 2.1 ChatRoomType
-
-| 값 | 의미 | 주요 사용 화면 |
+| 화면/상황 | 사용할 API 또는 WS | 클라이언트 처리 기준 |
 |---|---|---|
-| `PRIVATE` | 게시글 기준 1:1 채팅방 | 신청자-방장 개별 연락 |
-| `GROUP` | 여정 기준 그룹 채팅방 | 승인 이후 참여자 그룹 대화 |
+| 채팅 탭 최초 진입 | `GET /api/v1/chat-rooms?roomType=ALL` | 전체 채팅방 목록 snapshot을 만든다. |
+| 채팅방 타입 필터 | `GET /api/v1/chat-rooms?roomType=PRIVATE`, `GROUP` | 디자인의 `전체`, `1:1 채팅`, `여행방 채팅` 드롭다운에 사용한다. |
+| 채팅 목록 실시간 갱신 | `SUBSCRIBE /user/queue/chat-room-list` | `UPSERT`는 `chatRoomId` 기준 교체/삽입, `REMOVE`는 제거한다. |
+| 요청함 탭 | `GET /api/v1/participations` | 내가 작성한 게시글에 들어온 신청 목록을 조회한다. |
+| 요청함 상태 필터 | `GET /api/v1/participations?status=PENDING` 등 | 특정 신청 상태만 보고 싶을 때 사용한다. |
+| 신청내역 탭 | `GET /api/v1/users/me/participations` | 내가 보낸 동행 신청 목록을 조회한다. |
+| 1:1 채팅방 열기 | `POST /api/v1/posts/{postId}/chats/private` 또는 `POST /api/v1/participations/{participationId}/contact` | 게시글 상세에서 직접 열거나, 방장이 신청자에게 연락을 시작할 때 사용한다. |
+| 채팅방 진입 | `GET /api/v1/chat-rooms/{chatRoomId}/messages` | 헤더 정보와 첫 메시지 페이지를 함께 만든다. |
+| 과거 메시지 로딩 | `GET /api/v1/chat-rooms/{chatRoomId}/messages?beforeMessageId={nextCursor}` | 위로 스크롤할 때 `page.nextCursor`를 전달한다. |
+| 텍스트 메시지 전송 | `SEND /app/chat/rooms/{roomId}/messages` | `messageType=TEXT`, `content=본문`으로 보낸다. |
+| 이미지 메시지 전송 | `POST /api/v1/images/chats/presigned-url` 후 `SEND /app/chat/rooms/{roomId}/messages` | S3 업로드 후 `fileUrl`을 `IMAGE` 메시지의 `content`로 보낸다. |
+| 메시지/읽음 이벤트 수신 | `SUBSCRIBE /topic/chat/rooms/{roomId}` | 메시지 payload와 `READ` 이벤트가 같은 topic으로 온다. |
+| 읽음 처리 | `PATCH /api/v1/chat-rooms/{chatRoomId}/read` | 화면에 노출된 마지막 메시지 ID를 `lastReadMessageId`로 보낸다. |
+| 방장이 멤버 내보내기 | `DELETE /api/v1/journeys/{journeyId}/members/{memberUserId}` | 여정 멤버십과 그룹 채팅 멤버십이 함께 제거된다. |
 
-### 2.2 ChatRoomStatus
+## 2. 채팅 목록 화면 구현 기준
 
-| 값 | 의미 | 프론트 사용 기준 |
+### 2.1 최초 로딩
+
+1. STOMP 연결을 준비한다.
+2. `GET /api/v1/chat-rooms`로 현재 목록 snapshot을 조회한다.
+3. `/user/queue/chat-room-list`를 구독한다.
+4. 이후 수신하는 목록 이벤트를 `chatRoomId` 기준으로 반영한다.
+5. 앱 foreground 복귀, WebSocket 재연결, 이벤트 누락이 의심될 때는 REST 목록을 다시 조회해 동기화한다.
+
+### 2.2 목록 필터
+
+| UI 필터 | 요청 값 | 의미 |
 |---|---|---|
-| `ACTIVE` | 사용 가능한 채팅방 | 일반 채팅 화면으로 진입 가능 |
-| `CLOSED` | 닫힌 채팅방 | 메시지 입력 비활성화 후보 |
-| `DELETED` | 삭제된 채팅방 | 일반 조회 대상에서 제외되며 조회 시 not found 처리 |
+| 전체 | `roomType=ALL` 또는 생략 | 모든 채팅방 |
+| 1:1 채팅 | `roomType=PRIVATE` | 게시글 기준 1:1 채팅방 |
+| 여행방 채팅 | `roomType=GROUP` | 여정 기준 그룹 채팅방 |
 
-### 2.3 ChatMessageType
+### 2.3 목록 item 표시 필드
 
-| 값 | 의미 | 사용 필드 |
+| UI 요소 | 우선 사용 필드 | 타입별 기준 |
 |---|---|---|
-| `TEXT` | 일반 텍스트 메시지 | `content`, `sender`, `unreadCount` |
-| `IMAGE` | 이미지 메시지 | `images`, `sender`, `unreadCount` |
-| `SYSTEM` | 서버가 생성한 시스템 메시지 | `systemMessage` |
+| 썸네일 | `thumbnailUrl` | `PRIVATE`은 상대 프로필, `GROUP`은 여정 이미지 또는 게시글 이미지 |
+| 제목 | `displayName` | `PRIVATE`은 상대 닉네임, `GROUP`은 여정 제목 |
+| 부제 | `postTitle` 또는 클라이언트 조합 | `PRIVATE`은 게시글 제목, `GROUP`은 여정/인원 정보 표시 가능 |
+| 인원 수 | `participantCount` | 그룹방 목록에서 인원 아이콘 옆에 표시 |
+| 마지막 메시지 | `lastMessage` | 없으면 빈 상태 문구 또는 생략 |
+| 안 읽은 수 | `unreadCount` | 0이면 뱃지를 숨긴다. |
+| 정렬 기준 | `activityAt`, `chatRoomId` | `activityAt DESC`, `chatRoomId DESC` |
 
-클라이언트가 STOMP로 보낼 수 있는 타입은 `TEXT`, `IMAGE`다. `SYSTEM`은 서버에서만 생성한다.
+`displayName`과 `thumbnailUrl`은 서버가 화면 표시용으로 조립한 값이다. 클라이언트는 목록에서 상대 유저나 여정 정보를 다시 조합하기보다 이 값을 우선 사용한다.
 
-### 2.4 ChatRoomListType
+### 2.4 마지막 메시지 미리보기
 
-| 값 | 의미 |
+| `lastMessage.messageType` | 미리보기 기준 |
 |---|---|
-| `ALL` | 모든 채팅방 |
-| `PRIVATE` | 1:1 채팅방만 |
-| `GROUP` | 그룹 채팅방만 |
+| `TEXT` | `lastMessage.content`를 표시한다. |
+| `IMAGE` | "사진" 같은 고정 문구를 표시하거나 이미지 아이콘을 사용한다. `content`는 이미지 URL이다. |
+| `SYSTEM` | `content`를 그대로 노출하지 않는다. 시스템 payload 원문일 수 있다. |
+| `lastMessage=null` | 아직 메시지가 없는 상태다. |
 
-`GET /api/v1/chat-rooms`에서 `roomType`을 생략하면 `ALL`로 처리된다.
+## 3. 채팅 상세 화면 구현 기준
 
-## 3. REST API 응답 기준
-
-### 3.1 1:1 채팅방 생성/조회
-
-`POST /api/v1/posts/{postId}/chats/private`
-
-| 필드 | 의미 | 사용 기준 |
-|---|---|---|
-| `roomId` | 생성되었거나 기존에 있던 1:1 채팅방 ID | 채팅방 상세 진입에 사용 |
-| `isCreated` | 이번 요청에서 새로 생성되었는지 여부 | `true`면 HTTP 201, `false`면 HTTP 200 응답 |
-
-같은 게시글과 사용자 조합에 이미 채팅방이 있으면 기존 방을 재사용한다.
-
-### 3.2 채팅방 목록
-
-`GET /api/v1/chat-rooms`
-
-요청 파라미터:
-
-| 필드 | 의미 | 기본값/제약 |
-|---|---|---|
-| `roomType` | 목록 필터 | 생략 시 `ALL` |
-| `size` | 페이지 크기 | 생략 시 20, 최소 1, 최대 50 |
-| `cursor` | 다음 페이지 커서 | 이전 응답의 `page.nextCursor`를 그대로 전달 |
-
-응답 최상위:
-
-| 필드 | 의미 | 사용 기준 |
-|---|---|---|
-| `selectedRoomType` | 실제 적용된 목록 필터 | 탭/필터 UI의 현재 선택값 |
-| `chatRooms` | 채팅방 목록 | `activityAt` 기준 정렬 결과 |
-| `page.hasNext` | 다음 페이지 존재 여부 | 추가 로딩 가능 여부 |
-| `page.nextCursor` | 다음 페이지 조회 커서 | `hasNext=false`면 `null` |
-
-`chatRooms[]`:
-
-| 필드 | 의미 | 사용 기준 |
-|---|---|---|
-| `chatRoomId` | 채팅방 ID | 상세 화면 진입, 이벤트 병합 key |
-| `roomType` | 채팅방 타입 | 타입별 필드 선택 기준 |
-| `status` | 채팅방 상태 | 입력 가능 여부 판단 후보 |
-| `displayName` | 목록 표시명 | `PRIVATE`는 상대 닉네임, `GROUP`은 여정 제목 |
-| `postTitle` | 1:1 채팅방의 게시글 제목 | `GROUP`에서는 `null` |
-| `thumbnailUrl` | 목록 썸네일 | `PRIVATE`는 상대 프로필, `GROUP`은 여정/게시글 이미지 |
-| `postId` | 연결 게시글 ID | `PRIVATE` 컨텍스트 이동에 사용 |
-| `journeyId` | 연결 여정 ID | `GROUP` 컨텍스트 이동에 사용 |
-| `participantCount` | 현재 채팅방 멤버 수 | 목록 인원 표시 |
-| `lastMessage` | 마지막으로 표시 가능한 메시지 | 메시지가 없으면 `null` |
-| `unreadCount` | 현재 사용자가 아직 읽지 않은 메시지 수 | 뱃지 표시 |
-| `lastReadMessageId` | 현재 사용자의 마지막 읽음 메시지 ID | 없으면 `null` |
-| `activityAt` | 목록 정렬 기준 시각 | 최근 활동 순 정렬/갱신 기준 |
-| `createdAt` | 채팅방 생성 시각 | 보조 정보 |
-
-`lastMessage`:
-
-| 필드 | 의미 | 사용 기준 |
-|---|---|---|
-| `messageId` | 마지막 메시지 ID | 상세 이동 후 위치 계산 후보 |
-| `messageType` | 마지막 메시지 타입 | 미리보기 문구 선택 기준 |
-| `content` | 마지막 메시지 원문 | `TEXT`는 텍스트, `IMAGE`는 이미지 URL, `SYSTEM`은 시스템 payload 원문 |
-| `senderId` | 발신자 ID | 시스템 메시지는 `null` 가능 |
-| `senderNickname` | 발신자 표시명 | 시스템 메시지는 `null` 가능 |
-| `createdAt` | 메시지 생성 시각 | 목록 시간 표시 |
-
-`lastMessage.messageType=SYSTEM`인 경우 `content`를 그대로 사용자에게 노출하지 않는다. 목록 미리보기는 클라이언트에서 고정 문구를 사용하거나 상세 메시지 조회의 `systemMessage.displayText` 기준으로 처리한다.
-
-### 3.3 채팅방 메시지 목록
+### 3.1 진입 시 호출
 
 `GET /api/v1/chat-rooms/{chatRoomId}/messages`
 
-요청 파라미터:
+응답은 헤더용 `roomInfo`, 페이지용 `page`, 메시지 배열 `messages`를 함께 내려준다. `messages`는 오래된 순서로 반환된다.
 
-| 필드 | 의미 | 기본값/제약 |
+### 3.2 헤더 표시
+
+| `roomInfo.roomType` | 제목 | 부제/보조 정보 |
 |---|---|---|
-| `beforeMessageId` | 이 메시지보다 과거 메시지를 조회하는 커서 | 첫 페이지에서는 생략 |
-| `size` | 페이지 크기 | 생략 시 20, 최소 1, 최대 50 |
+| `PRIVATE` | `roomInfo.opponentNickname` | `roomInfo.postTitle` |
+| `GROUP` | `roomInfo.journeyTitle` | `roomInfo.memberCount` |
 
-응답 최상위:
+`roomInfo.isActive=false`이면 메시지 입력 UI를 비활성화하는 후보로 사용한다.
 
-| 필드 | 의미 | 사용 기준 |
-|---|---|---|
-| `roomInfo` | 채팅방 헤더 정보 | `roomType`별로 표시 필드 선택 |
-| `page.size` | 요청에 적용된 페이지 크기 | 디버깅/상태 보관용 |
-| `page.hasNext` | 더 과거 메시지 존재 여부 | 위로 스크롤 추가 로딩 |
-| `page.nextCursor` | 다음 과거 페이지 커서 | 다음 요청의 `beforeMessageId`로 전달 |
-| `messages` | 메시지 목록 | 오래된 순서로 반환 |
+### 3.3 메시지 렌더링
 
-`roomInfo`:
-
-| 필드 | `PRIVATE` | `GROUP` | 사용 기준 |
-|---|---|---|---|
-| `chatRoomId` | 채팅방 ID | 채팅방 ID | 현재 방 식별자 |
-| `roomType` | `PRIVATE` | `GROUP` | 헤더 렌더링 분기 |
-| `isActive` | 활성 여부 | 활성 여부 | 입력 UI 활성화 후보 |
-| `postTitle` | 게시글 제목 | `null` | 1:1 헤더/컨텍스트 |
-| `opponentNickname` | 상대 닉네임 | `null` | 1:1 헤더 |
-| `journeyTitle` | `null` | 여정 제목 | 그룹 헤더 |
-| `memberCount` | `null` | 활성 여정 멤버 수 | 그룹 인원 표시 |
-
-`messages[]`:
-
-| 필드 | 의미 | 사용 기준 |
-|---|---|---|
-| `messageId` | 메시지 ID | 정렬, 커서, 읽음 처리 기준 |
-| `messageType` | 메시지 타입 | 말풍선 렌더링 분기 |
-| `sender` | 발신자 정보 | `SYSTEM`에서는 `null` |
-| `isMine` | 현재 사용자가 보낸 메시지인지 여부 | 좌/우 말풍선 배치 |
-| `content` | 텍스트 메시지 본문 | `TEXT`에서 사용 |
-| `images` | 이미지 메시지 목록 | `IMAGE`에서 사용 |
-| `systemMessage` | 시스템 메시지 표시 정보 | `SYSTEM`에서 사용 |
-| `unreadCount` | 해당 메시지를 아직 읽지 않은 멤버 수 | `TEXT`, `IMAGE`에서 사용 |
-| `createdAt` | 메시지 생성 시각 | 말풍선 시간 표시 |
-
-`sender`:
-
-| 필드 | 의미 |
-|---|---|
-| `userId` | 발신자 ID |
-| `nickname` | 프로필 닉네임이 있으면 닉네임, 없으면 사용자 이름 |
-| `isHost` | 연결 게시글 작성자 여부 |
-
-`systemMessage`:
-
-| 필드 | 의미 | 사용 기준 |
-|---|---|---|
-| `type` | 시스템 메시지 타입 | 시스템 이벤트 구분 |
-| `displayText` | 서버가 조립한 표시 문구 | 시스템 메시지 본문으로 사용 |
-| `actorUserId` | 액션 수행자 ID | 초대/내보내기 주체 |
-| `inviteeUserId` | 초대된 사용자 ID | `USER_INVITED`에서 사용 |
-| `userId` | 나간 사용자 ID | `USER_LEFT`에서 사용 |
-| `targetUserId` | 내보내진 사용자 ID | `USER_KICKED`에서 사용 |
-
-시스템 메시지 타입:
-
-| 값 | 표시 의미 |
-|---|---|
-| `USER_INVITED` | 사용자가 그룹 채팅방에 참여함 |
-| `USER_LEFT` | 사용자가 채팅방을 나감 |
-| `USER_KICKED` | 사용자가 채팅방에서 내보내짐 |
-| `ROOM_CLOSED` | 채팅방이 닫힘 |
-
-### 3.4 읽음 처리
-
-`PATCH /api/v1/chat-rooms/{chatRoomId}/read`
-
-요청:
-
-| 필드 | 의미 | 제약 |
-|---|---|---|
-| `lastReadMessageId` | 이 메시지까지 읽음 처리할 메시지 ID | 필수, 양수 |
-
-응답:
-
-| 필드 | 의미 | 사용 기준 |
-|---|---|---|
-| `chatRoomId` | 읽음 처리된 채팅방 ID | 현재 방 검증 |
-| `lastReadMessageId` | 서버에 반영된 마지막 읽음 메시지 ID | 로컬 읽음 위치 갱신 |
-| `updated` | 실제 읽음 위치가 전진했는지 여부 | `false`면 기존 위치와 같거나 과거 메시지를 읽음 처리한 요청 |
-
-읽음 위치가 전진한 경우에만 채팅방 토픽으로 `READ` 이벤트가 발행된다.
-
-## 4. 메시지 렌더링 기준
-
-`messageType`을 기준으로 아래 필드만 사용한다.
-
-| `messageType` | 사용 필드 | 비사용/정상 null 필드 |
+| `messageType` | 사용 필드 | 정상 null/빈 값 |
 |---|---|---|
 | `TEXT` | `sender`, `isMine`, `content`, `unreadCount`, `createdAt` | `images=[]`, `systemMessage=null` |
 | `IMAGE` | `sender`, `isMine`, `images[0].imageUrl`, `unreadCount`, `createdAt` | `content=null`, `systemMessage=null` |
 | `SYSTEM` | `systemMessage.displayText`, `createdAt` | `sender=null`, `content=null`, `images=[]`, `unreadCount=null` |
 
-`unreadCount`는 메시지 발신자를 제외하고, 메시지 생성 이후 입장한 멤버를 제외하며, 해당 메시지 ID 이상을 읽은 멤버를 제외해서 계산된다.
+`isMine=true`이면 내 말풍선, `false`이면 상대 말풍선으로 배치한다. `SYSTEM` 메시지는 `isMine=false`이며 일반 말풍선이 아니라 시스템 안내 형태로 표시한다.
 
-## 5. null 규칙
+### 3.4 읽음 표시
+
+메시지별 `unreadCount`는 해당 메시지를 아직 읽지 않은 멤버 수다.
+
+- 1:1에서 상대가 안 읽은 내 메시지는 `unreadCount=1`이다.
+- 상대가 읽었으면 `unreadCount=0`이다.
+- 그룹에서는 발신자를 제외한 안 읽은 멤버 수가 내려간다.
+- 메시지 생성 이후 입장한 멤버는 과거 메시지의 `unreadCount` 계산 대상이 아니다.
+- `SYSTEM` 메시지는 `unreadCount=null`이다.
+
+## 4. 읽음 처리 기준
+
+### 4.1 언제 호출할지
+
+채팅방 상세에서 사용자가 메시지를 실제로 확인한 시점에 아래 API를 호출한다.
+
+`PATCH /api/v1/chat-rooms/{chatRoomId}/read`
+
+```json
+{
+  "lastReadMessageId": 123
+}
+```
+
+`lastReadMessageId`는 화면에 노출된 마지막 메시지 ID를 사용한다. `TEXT`, `IMAGE`, `SYSTEM` 모두 읽음 위치 커서로 사용할 수 있다.
+
+### 4.2 응답 처리
+
+| 필드 | 의미 | 클라이언트 처리 |
+|---|---|---|
+| `chatRoomId` | 읽음 처리된 채팅방 ID | 현재 방과 일치하는지 확인한다. |
+| `lastReadMessageId` | 서버에 반영된 마지막 읽음 메시지 ID | 로컬 읽음 위치를 갱신한다. |
+| `updated` | 읽음 위치가 실제로 전진했는지 여부 | `false`면 추가 UI 변경 없이 무시 가능하다. |
+
+읽음 위치가 전진한 경우 서버는 `/topic/chat/rooms/{roomId}`로 `READ` 이벤트를 발행한다.
+
+## 5. WebSocket 처리 기준
+
+### 5.1 연결과 destination
+
+| 구분 | 경로 |
+|---|---|
+| WebSocket endpoint | `/ws/chat` |
+| 메시지 전송 | `/app/chat/rooms/{roomId}/messages` |
+| 채팅방 메시지/읽음 구독 | `/topic/chat/rooms/{roomId}` |
+| 채팅방 목록 이벤트 구독 | `/user/queue/chat-room-list` |
+
+STOMP `CONNECT`에는 `Authorization: Bearer {accessToken}` 헤더가 필요하다.
+
+### 5.2 메시지 전송 payload
+
+```json
+{
+  "messageType": "TEXT",
+  "content": "안녕하세요!"
+}
+```
+
+| `messageType` | `content` |
+|---|---|
+| `TEXT` | 텍스트 본문 |
+| `IMAGE` | 채팅 이미지 업로드 후 받은 `fileUrl` |
+
+`SYSTEM`은 서버에서만 생성하므로 클라이언트가 전송하지 않는다.
+
+### 5.3 채팅방 topic payload
+
+`/topic/chat/rooms/{roomId}`로 사용자 메시지, 시스템 메시지, 읽음 이벤트가 모두 올 수 있다.
+
+| 구분 기준 | 처리 |
+|---|---|
+| `eventType=READ` | 읽음 이벤트로 처리한다. |
+| `messageType=TEXT` | `userMessage.text`를 일반 메시지로 추가한다. |
+| `messageType=IMAGE` | `userMessage.imageUrl`을 이미지 메시지로 추가한다. |
+| `messageType=SYSTEM` | `systemMessage.type` 기준으로 시스템 안내를 추가한다. |
+
+실시간 `SYSTEM` 메시지 payload에는 REST 메시지 조회의 `systemMessage.displayText`가 없다. 즉시 표시하려면 클라이언트가 보유한 사용자 캐시와 `systemMessage.type`으로 문구를 만들고, 정확한 문구가 필요하면 REST 메시지 재조회로 보정한다.
+
+### 5.4 읽음 이벤트 payload
+
+| 필드 | 의미 |
+|---|---|
+| `eventType` | 항상 `READ` |
+| `roomId` | 채팅방 ID |
+| `readerUserId` | 읽음 처리한 사용자 ID |
+| `lastReadMessageId` | 해당 사용자가 읽은 마지막 메시지 ID |
+| `readAt` | 읽음 처리 시각 |
+
+클라이언트는 `readerUserId`의 읽음 위치를 `lastReadMessageId`까지 갱신하고, 화면에 보이는 메시지들의 읽음 수를 보정한다.
+
+### 5.5 채팅방 목록 이벤트 payload
+
+| 필드 | 의미 |
+|---|---|
+| `eventType` | `UPSERT` 또는 `REMOVE` |
+| `reason` | 변경 원인 |
+| `chatRoom` | 변경 대상 채팅방 |
+| `occurredAt` | 이벤트 발생 시각 |
+
+`UPSERT` 처리:
+
+1. 현재 필터와 `chatRoom.roomType`이 맞는지 확인한다.
+2. 같은 `chatRoomId`가 있으면 item 전체를 교체한다.
+3. 없으면 새 item으로 삽입한다.
+4. `activityAt DESC`, `chatRoomId DESC`로 재정렬한다.
+
+`REMOVE` 처리:
+
+1. 같은 `chatRoomId` item을 목록에서 제거한다.
+
+`reason`은 UI 갱신 범위를 좁히기 위한 보조 정보다.
+
+| 값 | 의미 |
+|---|---|
+| `MESSAGE_CREATED` | 새 메시지로 마지막 메시지, 안 읽은 수, 정렬 기준이 변경됨 |
+| `READ_UPDATED` | 내 읽음 위치 변경으로 안 읽은 수가 변경됨 |
+| `ROOM_META_UPDATED` | 게시글, 여정, 프로필 변경으로 제목/썸네일이 변경됨 |
+| `MEMBER_CHANGED` | 그룹 멤버 변경으로 인원 수 또는 목록 노출 여부가 변경됨 |
+
+## 6. 타입별 null 규칙
 
 | 상황 | 정상 null/빈 값 |
 |---|---|
@@ -240,100 +225,100 @@
 | `GROUP` 채팅방 목록 | `postTitle=null` |
 | 1:1 메시지 헤더 | `journeyTitle=null`, `memberCount=null` |
 | 그룹 메시지 헤더 | `postTitle=null`, `opponentNickname=null` |
-| 시스템 메시지 | `sender=null`, `content=null`, `images=[]`, `unreadCount=null` |
+| `TEXT` 메시지 | `images=[]`, `systemMessage=null` |
+| `IMAGE` 메시지 | `content=null`, `systemMessage=null` |
+| `SYSTEM` 메시지 | `sender=null`, `content=null`, `images=[]`, `unreadCount=null` |
 | 아직 읽은 메시지가 없음 | `lastReadMessageId=null` |
 
-`displayName`과 `thumbnailUrl`은 화면 표시용으로 조립된 값이다. 프론트는 목록에서 별도 타입별 조합을 다시 만들기보다 이 값을 우선 사용한다.
+## 7. enum 빠른 참조
 
-## 6. WebSocket 이벤트
-
-### 6.1 연결과 destination
-
-| 구분 | 경로 | 설명 |
-|---|---|---|
-| WebSocket endpoint | `/ws/chat` | STOMP 연결 endpoint |
-| 클라이언트 메시지 발행 | `/app/chat/rooms/{roomId}/messages` | 사용자 메시지 전송 |
-| 채팅방 메시지/읽음 구독 | `/topic/chat/rooms/{roomId}` | 방 단위 브로드캐스트 |
-| 채팅방 목록 이벤트 구독 | `/user/queue/chat-room-list` | 사용자별 목록 갱신 이벤트 |
-
-### 6.2 메시지 전송 요청
-
-클라이언트가 `/app/chat/rooms/{roomId}/messages`로 발행한다.
-
-| 필드 | 의미 |
-|---|---|
-| `messageType` | `TEXT` 또는 `IMAGE` |
-| `content` | 텍스트 본문 또는 이미지 URL |
-
-### 6.3 채팅방 토픽 메시지 payload
-
-`/topic/chat/rooms/{roomId}`에서 수신한다.
-
-| 필드 | 의미 | 사용 기준 |
-|---|---|---|
-| `messageId` | 생성된 메시지 ID | 로컬 메시지 병합 key |
-| `roomId` | 채팅방 ID | 현재 구독 방 검증 |
-| `postTitle` | 연결 게시글 제목 | 컨텍스트 표시 후보 |
-| `recruitCount` | 현재 승인 인원 수 | 모집 정보 표시 후보 |
-| `recruitCapacity` | 모집 정원 | 모집 정보 표시 후보 |
-| `messageType` | 메시지 타입 | `userMessage`/`systemMessage` 분기 |
-| `sender` | 발신자 정보 | 시스템 메시지는 `null` |
-| `userMessage` | 사용자 메시지 본문 | `TEXT`, `IMAGE`에서 사용 |
-| `systemMessage` | 시스템 메시지 payload | `SYSTEM`에서 사용 |
-| `createdAt` | 생성 시각 | 말풍선 시간 |
-
-`userMessage`:
-
-| 필드 | 사용 타입 |
-|---|---|
-| `text` | `TEXT` |
-| `imageUrl` | `IMAGE` |
-
-채팅방 토픽의 시스템 메시지는 REST 상세 조회의 `systemMessage.displayText`처럼 표시 문구를 포함하지 않는다. 클라이언트는 `systemMessage.type`과 관련 사용자 ID를 기준으로 문구를 만들거나, 이후 REST 조회 결과와 동일한 기준으로 보정한다.
-
-### 6.4 읽음 이벤트
-
-`/topic/chat/rooms/{roomId}`에서 수신한다.
-
-| 필드 | 의미 | 사용 기준 |
-|---|---|---|
-| `eventType` | 항상 `READ` | 메시지 이벤트와 구분 |
-| `roomId` | 채팅방 ID | 현재 방 검증 |
-| `readerUserId` | 읽음 처리한 사용자 ID | 상대 읽음 상태 갱신 |
-| `lastReadMessageId` | 해당 사용자가 읽은 마지막 메시지 ID | 메시지별 읽음 카운트 보정 |
-| `readAt` | 읽음 처리 시각 | 보조 정보 |
-
-### 6.5 채팅방 목록 이벤트
-
-`/user/queue/chat-room-list`에서 수신한다.
-
-| 필드 | 의미 | 사용 기준 |
-|---|---|---|
-| `eventType` | 목록 적용 방식 | `UPSERT` 또는 `REMOVE` |
-| `reason` | 변경 원인 | UI 갱신 범위 판단 후보 |
-| `chatRoom` | 변경 대상 채팅방 | 목록 item 병합 또는 제거 |
-| `occurredAt` | 이벤트 발생 시각 | 로컬 이벤트 순서 판단 후보 |
-
-`eventType`:
-
-| 값 | 적용 기준 |
-|---|---|
-| `UPSERT` | `chatRoom.chatRoomId` 기준으로 기존 item을 교체하거나 없으면 삽입 |
-| `REMOVE` | `chatRoom.chatRoomId` 기준으로 목록에서 제거 |
-
-`reason`:
+### 7.1 ChatRoomType
 
 | 값 | 의미 |
 |---|---|
-| `MESSAGE_CREATED` | 새 메시지로 목록 item이 변경됨 |
-| `READ_UPDATED` | 읽음 상태 변경으로 목록 item이 변경됨 |
-| `ROOM_META_UPDATED` | 방 제목, 이미지 등 메타 정보가 변경됨 |
-| `MEMBER_CHANGED` | 멤버 입장/퇴장/내보내기 등으로 목록 item이 변경됨 |
+| `PRIVATE` | 게시글 기준 1:1 채팅방 |
+| `GROUP` | 여정 기준 그룹 채팅방 |
 
-`UPSERT`의 `chatRoom`은 REST 목록의 `chatRooms[]`와 같은 의미의 완성된 item이다. `REMOVE`의 `chatRoom`은 제거에 필요한 `chatRoomId`, `roomType`만 포함한다.
+### 7.2 ChatMessageType
 
-## 관련 문서
+| 값 | 의미 | 클라이언트 사용 필드 |
+|---|---|---|
+| `TEXT` | 텍스트 메시지 | `content`, `userMessage.text` |
+| `IMAGE` | 이미지 메시지 | `images[0].imageUrl`, `userMessage.imageUrl` |
+| `SYSTEM` | 서버 생성 시스템 메시지 | `systemMessage` |
 
+### 7.3 ChatRoomListType
+
+| 값 | 의미 |
+|---|---|
+| `ALL` | 모든 채팅방 |
+| `PRIVATE` | 1:1 채팅방만 |
+| `GROUP` | 그룹 채팅방만 |
+
+### 7.4 ChatRoomStatus
+
+| 값 | 의미 |
+|---|---|
+| `ACTIVE` | 사용 가능한 채팅방 |
+| `CLOSED` | 닫힌 채팅방 |
+| `DELETED` | 삭제된 채팅방 |
+
+## 8. 현재 API로 부족한 부분
+
+아래 항목은 현재 구현된 채팅 API만으로는 디자인 요구를 완전히 채우기 어렵다. 다만 모두 같은 우선순위는 아니므로, 채팅 클라이언트 구현에 바로 필요한 항목과 기획/타 도메인 작업으로 분리할 항목을 구분한다.
+
+### 8.1 채팅 클라이언트 구현에서 우선 확인할 항목
+
+| 기능 | 현재 상태 | 필요 API 후보 |
+|---|---|---|
+| 채팅 탭 상단 뱃지 최초 조회 | 방별 `unreadCount`, 요청함 목록, 신청내역 목록은 각각 조회 가능하지만 화면용 요약 API는 없음 | `GET /api/v1/users/me/chat-tab-summary` |
+| 채팅 탭 상단 뱃지 실시간 갱신 | 채팅방 목록 실시간 queue는 있으나 탭 뱃지 전용 이벤트는 없음 | `SUBSCRIBE /user/queue/chat-tab-summary` |
+| 요청함/신청내역 목록 실시간 갱신 | 현재는 REST 목록 조회만 지원하고 participation 변경 이벤트를 클라이언트에 직접 push하지 않음 | 추후 participation 전용 개인 queue 또는 chat tab summary 이벤트와 함께 확장 |
+| 전송 중/실패/재시도 매칭 | 서버 broadcast는 있지만 `clientMessageId`가 없음 | WS send/broadcast payload에 `clientMessageId` 추가 |
+
+상단 뱃지는 채팅 도메인의 전체 안 읽은 수와 참여 신청 도메인의 요청함/신청내역 카운트를 함께 보여주는 화면 단위 요약 정보다. 실시간 갱신까지 필요하면 `GET /api/v1/chat-rooms`나 `/user/queue/chat-room-list`에 섞기보다 별도 summary API와 개인 queue를 둔다.
+
+예시 응답:
+
+```json
+{
+  "totalUnreadChatCount": 4,
+  "receivedParticipationCount": 3,
+  "myParticipationCount": 1
+}
+```
+
+예시 실시간 이벤트:
+
+```json
+{
+  "eventType": "SUMMARY_UPDATED",
+  "totalUnreadChatCount": 4,
+  "receivedParticipationCount": 3,
+  "myParticipationCount": 1,
+  "occurredAt": "2026-06-20T10:30:00"
+}
+```
+
+`clientMessageId`는 필수 API는 아니지만, 전송 중/실패/재시도 UI를 정확히 구현하려면 필요하다. 현재는 서버 broadcast를 수신한 뒤 메시지를 확정하는 방식으로 구현할 수 있다.
+
+요청함과 신청내역 목록은 현재 `GET /api/v1/participations`, `GET /api/v1/users/me/participations`로 snapshot을 다시 조회하는 방식만 지원한다. 신규 신청, 신청 취소, 연락 시작, 승인, 거절 같은 변경을 실시간으로 목록에 반영하려면 participation 변경 이벤트를 개인 queue로 발행하는 작업을 별도로 추가해야 한다.
+
+### 8.2 기획 확정 후 판단할 항목
+
+| 기능 | 현재 상태 | 판단 기준 |
+|---|---|---|
+| 채팅방 검색 | 검색 query가 없음 | 검색 버튼이 실제 검색 기능으로 확정되면 `GET /api/v1/chat-rooms/search?keyword=...` 같은 API가 필요하다. 단순 아이콘 또는 추후 기능이면 현재 채팅 목록 API만 사용한다. |
+
+### 8.3 타 도메인 작업으로 분리할 항목
+
+| 기능 | 현재 상태 | 담당/연계 기준 |
+|---|---|---|
+| 승인 후 사용자 자진 나가기 | `LEFT`, `USER_LEFT` 모델은 있으나 self leave API 없음 | 나의 여정 도메인에서 `DELETE /api/v1/journeys/{journeyId}/members/me` 같은 API로 구현하는 것이 자연스럽다. 구현 시 그룹 채팅 멤버십 삭제, `USER_LEFT` 시스템 메시지, 채팅방 목록 `REMOVE` 이벤트와 연계한다. |
+
+## 9. 관련 문서
+
+- `docs/003-api/001-chat-message-retrieve.md`
+- `docs/003-api/002-chat-read-receipt.md`
+- `docs/003-api/003-chat-room-list-realtime.md`
 - `docs/001-design/flows/002-participation-group-chat-flow.md`
-- `docs/001-design/flows/003-post-product-flow.md`
-- `docs/001-design/flows/004-participation-flow.md`

--- a/docs/001-design/flows/005-chat-api-response-guide.md
+++ b/docs/001-design/flows/005-chat-api-response-guide.md
@@ -1,0 +1,339 @@
+# 005. Chat API Response Guide
+
+> Swagger 응답 스키마만으로 판단하기 어려운 채팅 API 응답 데이터의 의미와 프론트엔드 사용 기준을 정리한다.
+
+---
+
+## 한 줄 요약
+
+채팅 화면은 `roomType`과 `messageType`을 먼저 판단한 뒤, 타입별 표시 필드와 null 규칙에 맞춰 렌더링한다.
+
+---
+
+## 1. 목적
+
+채팅 API는 목록, 메시지 조회, 읽음 처리, 실시간 이벤트가 함께 동작한다. Swagger는 필드 타입은 보여주지만 아래 기준은 충분히 드러내기 어렵다.
+
+- `PRIVATE`와 `GROUP` 채팅방에서 같은 필드가 서로 다른 의미를 가지는 경우
+- 메시지 타입별로 사용해야 하는 필드가 달라지는 경우
+- `null`이 정상 상태인지, 데이터 누락인지 구분해야 하는 경우
+- REST 조회 결과와 WebSocket 이벤트를 화면 상태에 적용하는 기준
+
+이 문서는 현재 백엔드 구현을 기준으로 API 소비자가 화면 표시와 상태 갱신에 사용할 수 있는 기준을 제공한다.
+
+## 2. 공통 enum
+
+### 2.1 ChatRoomType
+
+| 값 | 의미 | 주요 사용 화면 |
+|---|---|---|
+| `PRIVATE` | 게시글 기준 1:1 채팅방 | 신청자-방장 개별 연락 |
+| `GROUP` | 여정 기준 그룹 채팅방 | 승인 이후 참여자 그룹 대화 |
+
+### 2.2 ChatRoomStatus
+
+| 값 | 의미 | 프론트 사용 기준 |
+|---|---|---|
+| `ACTIVE` | 사용 가능한 채팅방 | 일반 채팅 화면으로 진입 가능 |
+| `CLOSED` | 닫힌 채팅방 | 메시지 입력 비활성화 후보 |
+| `DELETED` | 삭제된 채팅방 | 일반 조회 대상에서 제외되며 조회 시 not found 처리 |
+
+### 2.3 ChatMessageType
+
+| 값 | 의미 | 사용 필드 |
+|---|---|---|
+| `TEXT` | 일반 텍스트 메시지 | `content`, `sender`, `unreadCount` |
+| `IMAGE` | 이미지 메시지 | `images`, `sender`, `unreadCount` |
+| `SYSTEM` | 서버가 생성한 시스템 메시지 | `systemMessage` |
+
+클라이언트가 STOMP로 보낼 수 있는 타입은 `TEXT`, `IMAGE`다. `SYSTEM`은 서버에서만 생성한다.
+
+### 2.4 ChatRoomListType
+
+| 값 | 의미 |
+|---|---|
+| `ALL` | 모든 채팅방 |
+| `PRIVATE` | 1:1 채팅방만 |
+| `GROUP` | 그룹 채팅방만 |
+
+`GET /api/v1/chat-rooms`에서 `roomType`을 생략하면 `ALL`로 처리된다.
+
+## 3. REST API 응답 기준
+
+### 3.1 1:1 채팅방 생성/조회
+
+`POST /api/v1/posts/{postId}/chats/private`
+
+| 필드 | 의미 | 사용 기준 |
+|---|---|---|
+| `roomId` | 생성되었거나 기존에 있던 1:1 채팅방 ID | 채팅방 상세 진입에 사용 |
+| `isCreated` | 이번 요청에서 새로 생성되었는지 여부 | `true`면 HTTP 201, `false`면 HTTP 200 응답 |
+
+같은 게시글과 사용자 조합에 이미 채팅방이 있으면 기존 방을 재사용한다.
+
+### 3.2 채팅방 목록
+
+`GET /api/v1/chat-rooms`
+
+요청 파라미터:
+
+| 필드 | 의미 | 기본값/제약 |
+|---|---|---|
+| `roomType` | 목록 필터 | 생략 시 `ALL` |
+| `size` | 페이지 크기 | 생략 시 20, 최소 1, 최대 50 |
+| `cursor` | 다음 페이지 커서 | 이전 응답의 `page.nextCursor`를 그대로 전달 |
+
+응답 최상위:
+
+| 필드 | 의미 | 사용 기준 |
+|---|---|---|
+| `selectedRoomType` | 실제 적용된 목록 필터 | 탭/필터 UI의 현재 선택값 |
+| `chatRooms` | 채팅방 목록 | `activityAt` 기준 정렬 결과 |
+| `page.hasNext` | 다음 페이지 존재 여부 | 추가 로딩 가능 여부 |
+| `page.nextCursor` | 다음 페이지 조회 커서 | `hasNext=false`면 `null` |
+
+`chatRooms[]`:
+
+| 필드 | 의미 | 사용 기준 |
+|---|---|---|
+| `chatRoomId` | 채팅방 ID | 상세 화면 진입, 이벤트 병합 key |
+| `roomType` | 채팅방 타입 | 타입별 필드 선택 기준 |
+| `status` | 채팅방 상태 | 입력 가능 여부 판단 후보 |
+| `displayName` | 목록 표시명 | `PRIVATE`는 상대 닉네임, `GROUP`은 여정 제목 |
+| `postTitle` | 1:1 채팅방의 게시글 제목 | `GROUP`에서는 `null` |
+| `thumbnailUrl` | 목록 썸네일 | `PRIVATE`는 상대 프로필, `GROUP`은 여정/게시글 이미지 |
+| `postId` | 연결 게시글 ID | `PRIVATE` 컨텍스트 이동에 사용 |
+| `journeyId` | 연결 여정 ID | `GROUP` 컨텍스트 이동에 사용 |
+| `participantCount` | 현재 채팅방 멤버 수 | 목록 인원 표시 |
+| `lastMessage` | 마지막으로 표시 가능한 메시지 | 메시지가 없으면 `null` |
+| `unreadCount` | 현재 사용자가 아직 읽지 않은 메시지 수 | 뱃지 표시 |
+| `lastReadMessageId` | 현재 사용자의 마지막 읽음 메시지 ID | 없으면 `null` |
+| `activityAt` | 목록 정렬 기준 시각 | 최근 활동 순 정렬/갱신 기준 |
+| `createdAt` | 채팅방 생성 시각 | 보조 정보 |
+
+`lastMessage`:
+
+| 필드 | 의미 | 사용 기준 |
+|---|---|---|
+| `messageId` | 마지막 메시지 ID | 상세 이동 후 위치 계산 후보 |
+| `messageType` | 마지막 메시지 타입 | 미리보기 문구 선택 기준 |
+| `content` | 마지막 메시지 원문 | `TEXT`는 텍스트, `IMAGE`는 이미지 URL, `SYSTEM`은 시스템 payload 원문 |
+| `senderId` | 발신자 ID | 시스템 메시지는 `null` 가능 |
+| `senderNickname` | 발신자 표시명 | 시스템 메시지는 `null` 가능 |
+| `createdAt` | 메시지 생성 시각 | 목록 시간 표시 |
+
+`lastMessage.messageType=SYSTEM`인 경우 `content`를 그대로 사용자에게 노출하지 않는다. 목록 미리보기는 클라이언트에서 고정 문구를 사용하거나 상세 메시지 조회의 `systemMessage.displayText` 기준으로 처리한다.
+
+### 3.3 채팅방 메시지 목록
+
+`GET /api/v1/chat-rooms/{chatRoomId}/messages`
+
+요청 파라미터:
+
+| 필드 | 의미 | 기본값/제약 |
+|---|---|---|
+| `beforeMessageId` | 이 메시지보다 과거 메시지를 조회하는 커서 | 첫 페이지에서는 생략 |
+| `size` | 페이지 크기 | 생략 시 20, 최소 1, 최대 50 |
+
+응답 최상위:
+
+| 필드 | 의미 | 사용 기준 |
+|---|---|---|
+| `roomInfo` | 채팅방 헤더 정보 | `roomType`별로 표시 필드 선택 |
+| `page.size` | 요청에 적용된 페이지 크기 | 디버깅/상태 보관용 |
+| `page.hasNext` | 더 과거 메시지 존재 여부 | 위로 스크롤 추가 로딩 |
+| `page.nextCursor` | 다음 과거 페이지 커서 | 다음 요청의 `beforeMessageId`로 전달 |
+| `messages` | 메시지 목록 | 오래된 순서로 반환 |
+
+`roomInfo`:
+
+| 필드 | `PRIVATE` | `GROUP` | 사용 기준 |
+|---|---|---|---|
+| `chatRoomId` | 채팅방 ID | 채팅방 ID | 현재 방 식별자 |
+| `roomType` | `PRIVATE` | `GROUP` | 헤더 렌더링 분기 |
+| `isActive` | 활성 여부 | 활성 여부 | 입력 UI 활성화 후보 |
+| `postTitle` | 게시글 제목 | `null` | 1:1 헤더/컨텍스트 |
+| `opponentNickname` | 상대 닉네임 | `null` | 1:1 헤더 |
+| `journeyTitle` | `null` | 여정 제목 | 그룹 헤더 |
+| `memberCount` | `null` | 활성 여정 멤버 수 | 그룹 인원 표시 |
+
+`messages[]`:
+
+| 필드 | 의미 | 사용 기준 |
+|---|---|---|
+| `messageId` | 메시지 ID | 정렬, 커서, 읽음 처리 기준 |
+| `messageType` | 메시지 타입 | 말풍선 렌더링 분기 |
+| `sender` | 발신자 정보 | `SYSTEM`에서는 `null` |
+| `isMine` | 현재 사용자가 보낸 메시지인지 여부 | 좌/우 말풍선 배치 |
+| `content` | 텍스트 메시지 본문 | `TEXT`에서 사용 |
+| `images` | 이미지 메시지 목록 | `IMAGE`에서 사용 |
+| `systemMessage` | 시스템 메시지 표시 정보 | `SYSTEM`에서 사용 |
+| `unreadCount` | 해당 메시지를 아직 읽지 않은 멤버 수 | `TEXT`, `IMAGE`에서 사용 |
+| `createdAt` | 메시지 생성 시각 | 말풍선 시간 표시 |
+
+`sender`:
+
+| 필드 | 의미 |
+|---|---|
+| `userId` | 발신자 ID |
+| `nickname` | 프로필 닉네임이 있으면 닉네임, 없으면 사용자 이름 |
+| `isHost` | 연결 게시글 작성자 여부 |
+
+`systemMessage`:
+
+| 필드 | 의미 | 사용 기준 |
+|---|---|---|
+| `type` | 시스템 메시지 타입 | 시스템 이벤트 구분 |
+| `displayText` | 서버가 조립한 표시 문구 | 시스템 메시지 본문으로 사용 |
+| `actorUserId` | 액션 수행자 ID | 초대/내보내기 주체 |
+| `inviteeUserId` | 초대된 사용자 ID | `USER_INVITED`에서 사용 |
+| `userId` | 나간 사용자 ID | `USER_LEFT`에서 사용 |
+| `targetUserId` | 내보내진 사용자 ID | `USER_KICKED`에서 사용 |
+
+시스템 메시지 타입:
+
+| 값 | 표시 의미 |
+|---|---|
+| `USER_INVITED` | 사용자가 그룹 채팅방에 참여함 |
+| `USER_LEFT` | 사용자가 채팅방을 나감 |
+| `USER_KICKED` | 사용자가 채팅방에서 내보내짐 |
+| `ROOM_CLOSED` | 채팅방이 닫힘 |
+
+### 3.4 읽음 처리
+
+`PATCH /api/v1/chat-rooms/{chatRoomId}/read`
+
+요청:
+
+| 필드 | 의미 | 제약 |
+|---|---|---|
+| `lastReadMessageId` | 이 메시지까지 읽음 처리할 메시지 ID | 필수, 양수 |
+
+응답:
+
+| 필드 | 의미 | 사용 기준 |
+|---|---|---|
+| `chatRoomId` | 읽음 처리된 채팅방 ID | 현재 방 검증 |
+| `lastReadMessageId` | 서버에 반영된 마지막 읽음 메시지 ID | 로컬 읽음 위치 갱신 |
+| `updated` | 실제 읽음 위치가 전진했는지 여부 | `false`면 기존 위치와 같거나 과거 메시지를 읽음 처리한 요청 |
+
+읽음 위치가 전진한 경우에만 채팅방 토픽으로 `READ` 이벤트가 발행된다.
+
+## 4. 메시지 렌더링 기준
+
+`messageType`을 기준으로 아래 필드만 사용한다.
+
+| `messageType` | 사용 필드 | 비사용/정상 null 필드 |
+|---|---|---|
+| `TEXT` | `sender`, `isMine`, `content`, `unreadCount`, `createdAt` | `images=[]`, `systemMessage=null` |
+| `IMAGE` | `sender`, `isMine`, `images[0].imageUrl`, `unreadCount`, `createdAt` | `content=null`, `systemMessage=null` |
+| `SYSTEM` | `systemMessage.displayText`, `createdAt` | `sender=null`, `content=null`, `images=[]`, `unreadCount=null` |
+
+`unreadCount`는 메시지 발신자를 제외하고, 메시지 생성 이후 입장한 멤버를 제외하며, 해당 메시지 ID 이상을 읽은 멤버를 제외해서 계산된다.
+
+## 5. null 규칙
+
+| 상황 | 정상 null/빈 값 |
+|---|---|
+| 채팅방 목록에 아직 메시지가 없음 | `lastMessage=null` |
+| `PRIVATE` 채팅방 목록 | `journeyId=null` 가능 |
+| `GROUP` 채팅방 목록 | `postTitle=null` |
+| 1:1 메시지 헤더 | `journeyTitle=null`, `memberCount=null` |
+| 그룹 메시지 헤더 | `postTitle=null`, `opponentNickname=null` |
+| 시스템 메시지 | `sender=null`, `content=null`, `images=[]`, `unreadCount=null` |
+| 아직 읽은 메시지가 없음 | `lastReadMessageId=null` |
+
+`displayName`과 `thumbnailUrl`은 화면 표시용으로 조립된 값이다. 프론트는 목록에서 별도 타입별 조합을 다시 만들기보다 이 값을 우선 사용한다.
+
+## 6. WebSocket 이벤트
+
+### 6.1 연결과 destination
+
+| 구분 | 경로 | 설명 |
+|---|---|---|
+| WebSocket endpoint | `/ws/chat` | STOMP 연결 endpoint |
+| 클라이언트 메시지 발행 | `/app/chat/rooms/{roomId}/messages` | 사용자 메시지 전송 |
+| 채팅방 메시지/읽음 구독 | `/topic/chat/rooms/{roomId}` | 방 단위 브로드캐스트 |
+| 채팅방 목록 이벤트 구독 | `/user/queue/chat-room-list` | 사용자별 목록 갱신 이벤트 |
+
+### 6.2 메시지 전송 요청
+
+클라이언트가 `/app/chat/rooms/{roomId}/messages`로 발행한다.
+
+| 필드 | 의미 |
+|---|---|
+| `messageType` | `TEXT` 또는 `IMAGE` |
+| `content` | 텍스트 본문 또는 이미지 URL |
+
+### 6.3 채팅방 토픽 메시지 payload
+
+`/topic/chat/rooms/{roomId}`에서 수신한다.
+
+| 필드 | 의미 | 사용 기준 |
+|---|---|---|
+| `messageId` | 생성된 메시지 ID | 로컬 메시지 병합 key |
+| `roomId` | 채팅방 ID | 현재 구독 방 검증 |
+| `postTitle` | 연결 게시글 제목 | 컨텍스트 표시 후보 |
+| `recruitCount` | 현재 승인 인원 수 | 모집 정보 표시 후보 |
+| `recruitCapacity` | 모집 정원 | 모집 정보 표시 후보 |
+| `messageType` | 메시지 타입 | `userMessage`/`systemMessage` 분기 |
+| `sender` | 발신자 정보 | 시스템 메시지는 `null` |
+| `userMessage` | 사용자 메시지 본문 | `TEXT`, `IMAGE`에서 사용 |
+| `systemMessage` | 시스템 메시지 payload | `SYSTEM`에서 사용 |
+| `createdAt` | 생성 시각 | 말풍선 시간 |
+
+`userMessage`:
+
+| 필드 | 사용 타입 |
+|---|---|
+| `text` | `TEXT` |
+| `imageUrl` | `IMAGE` |
+
+채팅방 토픽의 시스템 메시지는 REST 상세 조회의 `systemMessage.displayText`처럼 표시 문구를 포함하지 않는다. 클라이언트는 `systemMessage.type`과 관련 사용자 ID를 기준으로 문구를 만들거나, 이후 REST 조회 결과와 동일한 기준으로 보정한다.
+
+### 6.4 읽음 이벤트
+
+`/topic/chat/rooms/{roomId}`에서 수신한다.
+
+| 필드 | 의미 | 사용 기준 |
+|---|---|---|
+| `eventType` | 항상 `READ` | 메시지 이벤트와 구분 |
+| `roomId` | 채팅방 ID | 현재 방 검증 |
+| `readerUserId` | 읽음 처리한 사용자 ID | 상대 읽음 상태 갱신 |
+| `lastReadMessageId` | 해당 사용자가 읽은 마지막 메시지 ID | 메시지별 읽음 카운트 보정 |
+| `readAt` | 읽음 처리 시각 | 보조 정보 |
+
+### 6.5 채팅방 목록 이벤트
+
+`/user/queue/chat-room-list`에서 수신한다.
+
+| 필드 | 의미 | 사용 기준 |
+|---|---|---|
+| `eventType` | 목록 적용 방식 | `UPSERT` 또는 `REMOVE` |
+| `reason` | 변경 원인 | UI 갱신 범위 판단 후보 |
+| `chatRoom` | 변경 대상 채팅방 | 목록 item 병합 또는 제거 |
+| `occurredAt` | 이벤트 발생 시각 | 로컬 이벤트 순서 판단 후보 |
+
+`eventType`:
+
+| 값 | 적용 기준 |
+|---|---|
+| `UPSERT` | `chatRoom.chatRoomId` 기준으로 기존 item을 교체하거나 없으면 삽입 |
+| `REMOVE` | `chatRoom.chatRoomId` 기준으로 목록에서 제거 |
+
+`reason`:
+
+| 값 | 의미 |
+|---|---|
+| `MESSAGE_CREATED` | 새 메시지로 목록 item이 변경됨 |
+| `READ_UPDATED` | 읽음 상태 변경으로 목록 item이 변경됨 |
+| `ROOM_META_UPDATED` | 방 제목, 이미지 등 메타 정보가 변경됨 |
+| `MEMBER_CHANGED` | 멤버 입장/퇴장/내보내기 등으로 목록 item이 변경됨 |
+
+`UPSERT`의 `chatRoom`은 REST 목록의 `chatRooms[]`와 같은 의미의 완성된 item이다. `REMOVE`의 `chatRoom`은 제거에 필요한 `chatRoomId`, `roomType`만 포함한다.
+
+## 관련 문서
+
+- `docs/001-design/flows/002-participation-group-chat-flow.md`
+- `docs/001-design/flows/003-post-product-flow.md`
+- `docs/001-design/flows/004-participation-flow.md`

--- a/docs/003-api/README.md
+++ b/docs/003-api/README.md
@@ -8,6 +8,7 @@ Swagger보다 상세한 설계 배경, 처리 흐름, 테스트 케이스가 필
 | [채팅 메시지 조회 API](./001-chat-message-retrieve.md) | 커서 기반 메시지 조회, roomInfo, unreadCount 설계 |
 | [채팅 읽음 처리 API](./002-chat-read-receipt.md) | lastReadMessageId 갱신, READ 이벤트, unreadCount 연동 설계 |
 | [채팅방 목록 실시간 갱신](./003-chat-room-list-realtime.md) | 개인 WebSocket queue 기반 채팅방 목록 UPSERT/REMOVE 이벤트 설계 |
+| [채팅 API 클라이언트 구현 가이드](../001-design/flows/005-chat-api-response-guide.md) | 모바일 채팅 화면 구현을 위한 API 호출 순서, 렌더링 기준, 미지원 API 정리 |
 
 ## 작성 기준
 

--- a/src/main/java/com/dduru/gildongmu/chat/controller/ChatApiDocs.java
+++ b/src/main/java/com/dduru/gildongmu/chat/controller/ChatApiDocs.java
@@ -25,7 +25,11 @@ import org.springframework.web.bind.annotation.RequestBody;
 @SecurityRequirement(name = "JWT")
 public interface ChatApiDocs {
 
-    @Operation(summary = "1:1 채팅방 생성/조회", description = "게시글 단위로 1:1 채팅방을 생성(201)하거나 이미 있을 시 기존 방을 조회(200)해서 리턴합니다.")
+    @Operation(
+            summary = "1:1 채팅방 생성/조회",
+            description = "게시글 단위로 현재 사용자와 게시글 작성자 사이의 1:1 채팅방을 생성합니다. " +
+                    "이미 존재하면 기존 방을 재사용하며 isCreated=false와 함께 HTTP 200을 반환하고, 새로 생성되면 isCreated=true와 함께 HTTP 201을 반환합니다."
+    )
     @ApiResponse(responseCode = "200", description = "기존 채팅방 조회")
     @ApiResponse(responseCode = "201", description = "신규 채팅방 생성")
     @ApiErrorResponses({
@@ -41,7 +45,9 @@ public interface ChatApiDocs {
 
     @Operation(
             summary = "채팅방 메시지 목록 조회",
-            description = "채팅방의 메시지를 beforeMessageId 커서 기준으로 조회합니다. 응답 메시지는 오래된 순서로 반환합니다."
+            description = "채팅방의 메시지를 beforeMessageId 커서 기준으로 조회합니다. " +
+                    "첫 페이지는 beforeMessageId 없이 호출하고, 다음 과거 페이지는 page.nextCursor를 beforeMessageId로 전달합니다. " +
+                    "응답 메시지는 오래된 순서로 반환되며 messageType에 따라 content(TEXT), images(IMAGE), systemMessage(SYSTEM) 중 하나를 사용합니다."
     )
     @ApiResponse(responseCode = "200", description = "조회 성공")
     @ApiErrorResponses({
@@ -60,7 +66,8 @@ public interface ChatApiDocs {
 
     @Operation(
             summary = "채팅방 메시지 읽음 처리",
-            description = "현재 사용자의 채팅방 읽음 위치를 lastReadMessageId까지 갱신합니다. 기존 읽음 위치보다 같거나 과거인 경우 updated=false로 응답합니다."
+            description = "현재 사용자의 채팅방 읽음 위치를 lastReadMessageId까지 갱신합니다. " +
+                    "읽음 위치가 실제로 전진한 경우 updated=true이며, 기존 읽음 위치와 같거나 과거 메시지를 요청한 경우 updated=false로 응답합니다."
     )
     @ApiResponse(responseCode = "200", description = "읽음 처리 성공")
     @ApiErrorResponses({
@@ -78,7 +85,10 @@ public interface ChatApiDocs {
 
     @Operation(
             summary = "채팅방 목록 조회",
-            description = "현재 사용자가 참여 중인 ACTIVE 채팅방 목록을 마지막 활동 시각 기준으로 조회합니다. roomType 필터와 base64 cursor 페이지네이션을 지원합니다."
+            description = "현재 사용자가 참여 중인 ACTIVE 채팅방 목록을 마지막 활동 시각 기준으로 조회합니다. " +
+                    "roomType은 ALL, PRIVATE, GROUP을 지원하며 생략 시 ALL입니다. " +
+                    "다음 페이지 조회 시에는 이전 응답의 page.nextCursor를 cursor로 그대로 전달합니다. " +
+                    "목록 표시는 displayName, thumbnailUrl, lastMessage, unreadCount, activityAt 값을 우선 사용합니다."
     )
     @ApiResponse(responseCode = "200", description = "조회 성공")
     @ApiErrorResponses({

--- a/src/main/java/com/dduru/gildongmu/chat/domain/enums/ChatMessageType.java
+++ b/src/main/java/com/dduru/gildongmu/chat/domain/enums/ChatMessageType.java
@@ -1,5 +1,8 @@
 package com.dduru.gildongmu.chat.domain.enums;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "채팅 메시지 타입. TEXT는 텍스트, IMAGE는 이미지, SYSTEM은 서버가 생성한 시스템 메시지입니다.")
 public enum ChatMessageType {
     TEXT,
     IMAGE,

--- a/src/main/java/com/dduru/gildongmu/chat/domain/enums/ChatRoomStatus.java
+++ b/src/main/java/com/dduru/gildongmu/chat/domain/enums/ChatRoomStatus.java
@@ -1,5 +1,8 @@
 package com.dduru.gildongmu.chat.domain.enums;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "채팅방 상태. ACTIVE는 사용 가능, CLOSED는 닫힘, DELETED는 삭제되어 일반 조회 대상에서 제외됩니다.")
 public enum ChatRoomStatus {
     ACTIVE,
     CLOSED,

--- a/src/main/java/com/dduru/gildongmu/chat/domain/enums/ChatRoomType.java
+++ b/src/main/java/com/dduru/gildongmu/chat/domain/enums/ChatRoomType.java
@@ -1,5 +1,8 @@
 package com.dduru.gildongmu.chat.domain.enums;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "채팅방 타입. PRIVATE은 게시글 기준 1:1 채팅방, GROUP은 여정 기준 그룹 채팅방입니다.")
 public enum ChatRoomType {
     PRIVATE,
     GROUP

--- a/src/main/java/com/dduru/gildongmu/chat/dto/request/ChatMessageRetrieveRequest.java
+++ b/src/main/java/com/dduru/gildongmu/chat/dto/request/ChatMessageRetrieveRequest.java
@@ -1,12 +1,20 @@
 package com.dduru.gildongmu.chat.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.Positive;
 
+@Schema(description = "채팅방 메시지 목록 조회 조건")
 public record ChatMessageRetrieveRequest(
+        @Schema(
+                description = "이 메시지 ID보다 오래된 메시지를 조회합니다. 첫 페이지 조회 시에는 생략합니다.",
+                example = "120"
+        )
         @Positive(message = "beforeMessageId는 1 이상이어야 합니다.")
         Long beforeMessageId,
+
+        @Schema(description = "페이지 크기. 생략 시 20, 최대 50", example = "20")
         @Min(value = 1, message = "size는 1 이상 50 이하로 입력해야 합니다.")
         @Max(value = 50, message = "size는 1 이상 50 이하로 입력해야 합니다.")
         Integer size

--- a/src/main/java/com/dduru/gildongmu/chat/dto/request/ChatReadRequest.java
+++ b/src/main/java/com/dduru/gildongmu/chat/dto/request/ChatReadRequest.java
@@ -1,9 +1,12 @@
 package com.dduru.gildongmu.chat.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 
+@Schema(description = "채팅방 읽음 처리 요청")
 public record ChatReadRequest(
+        @Schema(description = "현재 사용자가 이 메시지까지 읽었음을 서버에 반영할 메시지 ID", example = "120")
         @NotNull(message = "lastReadMessageId는 필수입니다.")
         @Positive(message = "lastReadMessageId는 1 이상이어야 합니다.")
         Long lastReadMessageId

--- a/src/main/java/com/dduru/gildongmu/chat/dto/request/ChatRoomListRequest.java
+++ b/src/main/java/com/dduru/gildongmu/chat/dto/request/ChatRoomListRequest.java
@@ -4,7 +4,13 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 
+@Schema(description = "채팅방 목록 조회 조건")
 public record ChatRoomListRequest(
+        @Schema(
+                description = "조회할 채팅방 타입. 생략 시 ALL로 조회합니다.",
+                example = "ALL",
+                allowableValues = {"ALL", "PRIVATE", "GROUP"}
+        )
         ChatRoomListType roomType,
 
         @Min(value = 1, message = "size는 1 이상 50 이하로 입력해야 합니다.")

--- a/src/main/java/com/dduru/gildongmu/chat/dto/request/ChatRoomListType.java
+++ b/src/main/java/com/dduru/gildongmu/chat/dto/request/ChatRoomListType.java
@@ -1,7 +1,9 @@
 package com.dduru.gildongmu.chat.dto.request;
 
 import com.dduru.gildongmu.chat.domain.enums.ChatRoomType;
+import io.swagger.v3.oas.annotations.media.Schema;
 
+@Schema(description = "채팅방 목록 필터. ALL은 전체, PRIVATE은 1:1 채팅방, GROUP은 그룹 채팅방입니다.")
 public enum ChatRoomListType {
     ALL,
     PRIVATE,

--- a/src/main/java/com/dduru/gildongmu/chat/dto/response/ChatMessageImageResponse.java
+++ b/src/main/java/com/dduru/gildongmu/chat/dto/response/ChatMessageImageResponse.java
@@ -1,6 +1,10 @@
 package com.dduru.gildongmu.chat.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "채팅 이미지 메시지 정보")
 public record ChatMessageImageResponse(
+        @Schema(description = "이미지 URL", example = "https://example.com/images/chat-image.png")
         String imageUrl
 ) {
     public static ChatMessageImageResponse from(String imageUrl) {

--- a/src/main/java/com/dduru/gildongmu/chat/dto/response/ChatMessageItemResponse.java
+++ b/src/main/java/com/dduru/gildongmu/chat/dto/response/ChatMessageItemResponse.java
@@ -4,20 +4,39 @@ import com.dduru.gildongmu.chat.domain.ChatMessage;
 import com.dduru.gildongmu.chat.domain.enums.ChatMessageType;
 import com.dduru.gildongmu.chat.dto.ws.ChatSystemMessagePayload;
 import com.dduru.gildongmu.user.domain.User;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 
+@Schema(description = "채팅 메시지 항목. messageType에 따라 content, images, systemMessage 중 하나를 사용합니다.")
 public record ChatMessageItemResponse(
+        @Schema(description = "메시지 ID", example = "120")
         Long messageId,
+
+        @Schema(description = "메시지 타입", example = "TEXT", allowableValues = {"TEXT", "IMAGE", "SYSTEM"})
         ChatMessageType messageType,
+
+        @Schema(description = "발신자 정보. SYSTEM 메시지는 null", nullable = true)
         ChatMessageSenderResponse sender,
+
+        @Schema(description = "현재 사용자가 보낸 메시지인지 여부. SYSTEM 메시지는 false", example = "true")
         boolean isMine,
+
+        @Schema(description = "TEXT 메시지 본문. IMAGE와 SYSTEM 메시지는 null", example = "안녕하세요!", nullable = true)
         String content,
+
+        @Schema(description = "IMAGE 메시지 이미지 목록. TEXT와 SYSTEM 메시지는 빈 배열")
         List<ChatMessageImageResponse> images,
+
+        @Schema(description = "SYSTEM 메시지 표시 정보. TEXT와 IMAGE 메시지는 null", nullable = true)
         ChatSystemMessageResponse systemMessage,
+
+        @Schema(description = "이 메시지를 아직 읽지 않은 멤버 수. TEXT와 IMAGE에서 사용하며 SYSTEM 메시지는 null", example = "2", nullable = true)
         Integer unreadCount,
+
+        @Schema(description = "메시지 생성 시각")
         LocalDateTime createdAt
 ) {
     public static ChatMessageItemResponse forText(

--- a/src/main/java/com/dduru/gildongmu/chat/dto/response/ChatMessagePageResponse.java
+++ b/src/main/java/com/dduru/gildongmu/chat/dto/response/ChatMessagePageResponse.java
@@ -1,8 +1,16 @@
 package com.dduru.gildongmu.chat.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "채팅 메시지 페이지 정보")
 public record ChatMessagePageResponse(
+        @Schema(description = "요청에 적용된 페이지 크기", example = "20")
         int size,
+
+        @Schema(description = "더 과거 메시지 존재 여부", example = "true")
         boolean hasNext,
+
+        @Schema(description = "다음 과거 페이지 조회 커서. 다음 요청의 beforeMessageId로 전달하며 hasNext=false이면 null", example = "100", nullable = true)
         Long nextCursor
 ) {
 }

--- a/src/main/java/com/dduru/gildongmu/chat/dto/response/ChatMessageSenderResponse.java
+++ b/src/main/java/com/dduru/gildongmu/chat/dto/response/ChatMessageSenderResponse.java
@@ -1,10 +1,17 @@
 package com.dduru.gildongmu.chat.dto.response;
 
 import com.dduru.gildongmu.user.domain.User;
+import io.swagger.v3.oas.annotations.media.Schema;
 
+@Schema(description = "채팅 메시지 발신자 정보")
 public record ChatMessageSenderResponse(
+        @Schema(description = "발신자 회원 ID", example = "33")
         Long userId,
+
+        @Schema(description = "발신자 표시명. 프로필 닉네임이 있으면 닉네임, 없으면 사용자 이름", example = "여행메이트")
         String nickname,
+
+        @Schema(description = "연결 게시글 작성자 여부", example = "false")
         boolean isHost
 ) {
     public static ChatMessageSenderResponse from(User sender, Long hostUserId) {

--- a/src/main/java/com/dduru/gildongmu/chat/dto/response/ChatMessagesResponse.java
+++ b/src/main/java/com/dduru/gildongmu/chat/dto/response/ChatMessagesResponse.java
@@ -1,10 +1,18 @@
 package com.dduru.gildongmu.chat.dto.response;
 
+        import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.List;
 
+@Schema(description = "채팅방 메시지 목록 응답")
 public record ChatMessagesResponse(
+        @Schema(description = "채팅방 상세 헤더 정보")
         ChatRoomInfoResponse roomInfo,
+
+        @Schema(description = "메시지 목록 페이지 정보")
         ChatMessagePageResponse page,
+
+        @Schema(description = "오래된 순서로 정렬된 메시지 목록")
         List<ChatMessageItemResponse> messages
 ) {
 }

--- a/src/main/java/com/dduru/gildongmu/chat/dto/response/ChatReadResponse.java
+++ b/src/main/java/com/dduru/gildongmu/chat/dto/response/ChatReadResponse.java
@@ -1,8 +1,16 @@
 package com.dduru.gildongmu.chat.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "채팅방 읽음 처리 응답")
 public record ChatReadResponse(
+        @Schema(description = "읽음 처리된 채팅방 ID", example = "10")
         Long chatRoomId,
+
+        @Schema(description = "서버에 반영된 마지막 읽음 메시지 ID", example = "120")
         Long lastReadMessageId,
+
+        @Schema(description = "읽음 위치가 실제로 전진했는지 여부. false이면 기존 읽음 위치와 같거나 과거 메시지를 요청한 경우입니다.", example = "true")
         Boolean updated
 ) {
 }

--- a/src/main/java/com/dduru/gildongmu/chat/dto/response/ChatRoomInfoResponse.java
+++ b/src/main/java/com/dduru/gildongmu/chat/dto/response/ChatRoomInfoResponse.java
@@ -1,14 +1,29 @@
 package com.dduru.gildongmu.chat.dto.response;
 
 import com.dduru.gildongmu.chat.domain.enums.ChatRoomType;
+import io.swagger.v3.oas.annotations.media.Schema;
 
+@Schema(description = "채팅방 상세 헤더 정보")
 public record ChatRoomInfoResponse(
+        @Schema(description = "채팅방 ID", example = "10")
         Long chatRoomId,
+
+        @Schema(description = "채팅방 타입. 타입에 따라 헤더 표시 필드가 달라집니다.", example = "GROUP", allowableValues = {"PRIVATE", "GROUP"})
         ChatRoomType roomType,
+
+        @Schema(description = "채팅방 활성 여부. false이면 메시지 입력 비활성화 후보로 사용합니다.", example = "true")
         boolean isActive,
+
+        @Schema(description = "PRIVATE 채팅방의 게시글 제목. GROUP은 null", example = "제주 애월 2박 3일", nullable = true)
         String postTitle,
+
+        @Schema(description = "PRIVATE 채팅방 상대 닉네임. GROUP은 null", example = "여행메이트", nullable = true)
         String opponentNickname,
+
+        @Schema(description = "GROUP 채팅방 여정 제목. PRIVATE은 null", example = "제주 애월 2박 3일 함께가기", nullable = true)
         String journeyTitle,
+
+        @Schema(description = "GROUP 채팅방 활성 여정 멤버 수. PRIVATE은 null", example = "4", nullable = true)
         Integer memberCount
 ) {
 }

--- a/src/main/java/com/dduru/gildongmu/chat/dto/response/ChatRoomLastMessageResponse.java
+++ b/src/main/java/com/dduru/gildongmu/chat/dto/response/ChatRoomLastMessageResponse.java
@@ -1,15 +1,28 @@
 package com.dduru.gildongmu.chat.dto.response;
 
 import com.dduru.gildongmu.chat.domain.enums.ChatMessageType;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
 
+@Schema(description = "채팅방 목록에 표시되는 마지막 메시지 요약")
 public record ChatRoomLastMessageResponse(
+        @Schema(description = "마지막 메시지 ID", example = "120")
         Long messageId,
+
+        @Schema(description = "마지막 메시지 타입", example = "TEXT", allowableValues = {"TEXT", "IMAGE", "SYSTEM"})
         ChatMessageType messageType,
+
+        @Schema(description = "마지막 메시지 원문. TEXT는 텍스트, IMAGE는 이미지 URL, SYSTEM은 시스템 payload 원문이므로 그대로 사용자에게 노출하지 않습니다.", example = "안녕하세요!")
         String content,
+
+        @Schema(description = "발신자 ID. 시스템 메시지는 null일 수 있습니다.", example = "33", nullable = true)
         Long senderId,
+
+        @Schema(description = "발신자 표시명. 시스템 메시지는 null일 수 있습니다.", example = "여행메이트", nullable = true)
         String senderNickname,
+
+        @Schema(description = "마지막 메시지 생성 시각")
         LocalDateTime createdAt
 ) {
 }

--- a/src/main/java/com/dduru/gildongmu/chat/dto/response/ChatRoomListItemResponse.java
+++ b/src/main/java/com/dduru/gildongmu/chat/dto/response/ChatRoomListItemResponse.java
@@ -6,22 +6,48 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
 
+@Schema(description = "채팅방 목록 항목")
 public record ChatRoomListItemResponse(
+        @Schema(description = "채팅방 ID", example = "10")
         Long chatRoomId,
+
+        @Schema(description = "채팅방 타입. PRIVATE은 1:1 채팅방, GROUP은 여정 그룹 채팅방", example = "PRIVATE", allowableValues = {"PRIVATE", "GROUP"})
         ChatRoomType roomType,
+
+        @Schema(description = "채팅방 상태", example = "ACTIVE", allowableValues = {"ACTIVE", "CLOSED", "DELETED"})
         ChatRoomStatus status,
+
         @Schema(description = "채팅 목록 표시명. PRIVATE은 상대 유저 닉네임, GROUP은 여정 제목", example = "여행메이트")
         String displayName,
+
         @Schema(description = "PRIVATE 채팅방의 게시글 제목. GROUP은 null", example = "제주 애월 2박 3일")
         String postTitle,
+
+        @Schema(description = "목록 썸네일 URL. PRIVATE은 상대 프로필 이미지, GROUP은 여정 이미지 또는 게시글 이미지", example = "https://example.com/images/chat-thumbnail.png")
         String thumbnailUrl,
+
+        @Schema(description = "연결된 게시글 ID. PRIVATE에서 주로 사용하며 GROUP에서도 원 게시글 컨텍스트가 있으면 내려갈 수 있습니다.", example = "101")
         Long postId,
+
+        @Schema(description = "연결된 여정 ID. GROUP에서 사용하며 PRIVATE은 null일 수 있습니다.", example = "55", nullable = true)
         Long journeyId,
+
+        @Schema(description = "현재 채팅방 멤버 수", example = "4")
         int participantCount,
+
+        @Schema(description = "마지막으로 표시 가능한 메시지. 메시지가 아직 없으면 null", nullable = true)
         ChatRoomLastMessageResponse lastMessage,
+
+        @Schema(description = "현재 사용자가 아직 읽지 않은 메시지 수", example = "3")
         long unreadCount,
+
+        @Schema(description = "현재 사용자의 마지막 읽음 메시지 ID. 아직 읽은 메시지가 없으면 null", example = "120", nullable = true)
         Long lastReadMessageId,
+
+        @Schema(description = "목록 정렬 기준이 되는 마지막 활동 시각")
         LocalDateTime activityAt,
+
+        @Schema(description = "채팅방 생성 시각")
         LocalDateTime createdAt
 ) {
 }

--- a/src/main/java/com/dduru/gildongmu/chat/dto/response/ChatRoomListPageResponse.java
+++ b/src/main/java/com/dduru/gildongmu/chat/dto/response/ChatRoomListPageResponse.java
@@ -1,7 +1,13 @@
 package com.dduru.gildongmu.chat.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "채팅방 목록 페이지 정보")
 public record ChatRoomListPageResponse(
+        @Schema(description = "다음 페이지 조회 커서. hasNext=false이면 null", example = "eyJhY3Rpdml0eUF0IjoiMjAyNi0wNi0xOVQxMjozNDo1NiIsImNoYXRSb29tSWQiOjEwfQ==", nullable = true)
         String nextCursor,
+
+        @Schema(description = "다음 페이지 존재 여부", example = "true")
         boolean hasNext
 ) {
 }

--- a/src/main/java/com/dduru/gildongmu/chat/dto/response/ChatRoomListResponse.java
+++ b/src/main/java/com/dduru/gildongmu/chat/dto/response/ChatRoomListResponse.java
@@ -1,12 +1,19 @@
 package com.dduru.gildongmu.chat.dto.response;
 
 import com.dduru.gildongmu.chat.dto.request.ChatRoomListType;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.List;
 
+@Schema(description = "채팅방 목록 응답")
 public record ChatRoomListResponse(
+        @Schema(description = "실제로 적용된 채팅방 목록 필터", example = "ALL", allowableValues = {"ALL", "PRIVATE", "GROUP"})
         ChatRoomListType selectedRoomType,
+
+        @Schema(description = "현재 사용자가 참여 중인 ACTIVE 채팅방 목록")
         List<ChatRoomListItemResponse> chatRooms,
+
+        @Schema(description = "채팅방 목록 페이지 정보")
         ChatRoomListPageResponse page
 ) {
 }

--- a/src/main/java/com/dduru/gildongmu/chat/dto/response/ChatSystemMessageResponse.java
+++ b/src/main/java/com/dduru/gildongmu/chat/dto/response/ChatSystemMessageResponse.java
@@ -4,15 +4,28 @@ import com.dduru.gildongmu.chat.constants.ChatMessageConstants;
 import com.dduru.gildongmu.chat.dto.ws.ChatSystemMessagePayload;
 import com.dduru.gildongmu.chat.system.ChatSystemMessageType;
 import com.dduru.gildongmu.user.domain.User;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.Map;
 
+@Schema(description = "시스템 메시지 표시 정보")
 public record ChatSystemMessageResponse(
+        @Schema(description = "시스템 메시지 타입", example = "USER_INVITED", allowableValues = {"USER_INVITED", "USER_LEFT", "USER_KICKED", "ROOM_CLOSED"})
         ChatSystemMessageType type,
+
+        @Schema(description = "클라이언트가 그대로 표시할 수 있는 시스템 메시지 문구", example = "여행메이트 님이 그룹 채팅방에 참여했습니다.")
         String displayText,
+
+        @Schema(description = "액션 수행자 회원 ID. 초대/내보내기 이벤트에서 사용", example = "1", nullable = true)
         Long actorUserId,
+
+        @Schema(description = "초대된 회원 ID. USER_INVITED에서 사용", example = "33", nullable = true)
         Long inviteeUserId,
+
+        @Schema(description = "채팅방을 나간 회원 ID. USER_LEFT에서 사용", example = "33", nullable = true)
         Long userId,
+
+        @Schema(description = "내보내진 회원 ID. USER_KICKED에서 사용", example = "33", nullable = true)
         Long targetUserId
 ) {
     public static ChatSystemMessageResponse from(

--- a/src/main/java/com/dduru/gildongmu/chat/dto/response/GroupChatInviteMemberResponse.java
+++ b/src/main/java/com/dduru/gildongmu/chat/dto/response/GroupChatInviteMemberResponse.java
@@ -1,7 +1,13 @@
 package com.dduru.gildongmu.chat.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "그룹 채팅방 멤버 초대 응답")
 public record GroupChatInviteMemberResponse(
-            Long roomId,
-            boolean isNewInvitee
+        @Schema(description = "그룹 채팅방 ID", example = "20")
+        Long roomId,
+
+        @Schema(description = "이번 요청으로 신규 초대되었는지 여부. 이미 멤버였으면 false", example = "true")
+        boolean isNewInvitee
 ) {
 }

--- a/src/main/java/com/dduru/gildongmu/chat/dto/response/PrivateChatRoomCreateResponse.java
+++ b/src/main/java/com/dduru/gildongmu/chat/dto/response/PrivateChatRoomCreateResponse.java
@@ -2,11 +2,12 @@ package com.dduru.gildongmu.chat.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
+@Schema(description = "1:1 채팅방 생성 또는 기존 방 조회 응답")
 public record PrivateChatRoomCreateResponse(
         @Schema(description = "채팅방 ID", example = "1")
         Long roomId,
 
-        @Schema(description = "방 생성 여부", example = "true")
+        @Schema(description = "이번 요청에서 새 채팅방이 생성되었는지 여부. true이면 HTTP 201, false이면 기존 방 조회로 HTTP 200", example = "true")
         boolean isCreated
 ) {
 }

--- a/src/main/java/com/dduru/gildongmu/chat/dto/ws/ChatMessageBroadcastPayload.java
+++ b/src/main/java/com/dduru/gildongmu/chat/dto/ws/ChatMessageBroadcastPayload.java
@@ -7,6 +7,7 @@ import com.dduru.gildongmu.post.domain.Post;
 import com.dduru.gildongmu.profile.utils.ProfileImageResolver;
 import com.dduru.gildongmu.user.domain.User;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 import java.time.LocalDateTime;
@@ -16,16 +17,36 @@ import java.time.LocalDateTime;
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Builder
+@Schema(description = "WebSocket 채팅방 토픽 메시지 payload")
 public record ChatMessageBroadcastPayload(
+        @Schema(description = "생성된 메시지 ID", example = "120")
         Long messageId,
+
+        @Schema(description = "채팅방 ID", example = "10")
         Long roomId,
+
+        @Schema(description = "연결 게시글 제목", example = "제주 애월 2박 3일")
         String postTitle,
+
+        @Schema(description = "현재 승인 인원 수", example = "2")
         int recruitCount,
+
+        @Schema(description = "모집 정원", example = "4")
         int recruitCapacity,
+
+        @Schema(description = "메시지 타입", example = "TEXT", allowableValues = {"TEXT", "IMAGE", "SYSTEM"})
         ChatMessageType messageType,
+
+        @Schema(description = "발신자 정보. SYSTEM 메시지는 null", nullable = true)
         ChatMessageSenderPayload sender,
+
+        @Schema(description = "사용자 메시지 payload. TEXT와 IMAGE에서 사용", nullable = true)
         ChatUserMessagePayload userMessage,
+
+        @Schema(description = "시스템 메시지 payload. SYSTEM에서 사용", nullable = true)
         ChatSystemMessagePayload systemMessage,
+
+        @Schema(description = "메시지 생성 시각")
         LocalDateTime createdAt
 ) {
     public static ChatMessageBroadcastPayload ofUserMessage(ChatMessage message, Post post, User sender, ProfileImageResolver profileImageResolver) {

--- a/src/main/java/com/dduru/gildongmu/chat/dto/ws/ChatMessageSendRequest.java
+++ b/src/main/java/com/dduru/gildongmu/chat/dto/ws/ChatMessageSendRequest.java
@@ -1,16 +1,20 @@
 package com.dduru.gildongmu.chat.dto.ws;
 
 import com.dduru.gildongmu.chat.domain.enums.ChatMessageType;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 
 /**
  * STOMP 클라이언트 전송 페이로드. {@link ChatMessageType#SYSTEM} 은 서버에서만 생성한다.
  * content 검증은 messageType 에 따라 달라서 서비스 계층의 전용 validator가 담당한다.
  */
+@Schema(description = "STOMP 채팅 메시지 전송 요청. SYSTEM은 서버에서만 생성하므로 클라이언트는 TEXT 또는 IMAGE만 전송합니다.")
 public record ChatMessageSendRequest(
+        @Schema(description = "전송할 메시지 타입", example = "TEXT", allowableValues = {"TEXT", "IMAGE"})
         @NotNull(message = "메세지 타입은 필수입니다.")
         ChatMessageType messageType,
 
+        @Schema(description = "TEXT는 메시지 본문, IMAGE는 이미지 URL", example = "안녕하세요!")
         String content
 ) {
 }

--- a/src/main/java/com/dduru/gildongmu/chat/dto/ws/ChatMessageSenderPayload.java
+++ b/src/main/java/com/dduru/gildongmu/chat/dto/ws/ChatMessageSenderPayload.java
@@ -3,11 +3,20 @@ package com.dduru.gildongmu.chat.dto.ws;
 import com.dduru.gildongmu.profile.dto.response.ProfileImageInfo;
 import com.dduru.gildongmu.profile.utils.ProfileImageResolver;
 import com.dduru.gildongmu.user.domain.User;
+import io.swagger.v3.oas.annotations.media.Schema;
 
+@Schema(description = "WebSocket 채팅 메시지 발신자 payload")
 public record ChatMessageSenderPayload(
+        @Schema(description = "발신자 회원 ID", example = "33")
         Long id,
+
+        @Schema(description = "발신자 이름", example = "여행메이트")
         String name,
+
+        @Schema(description = "발신자 프로필 이미지 정보")
         ProfileImageInfo profileImageInfo,
+
+        @Schema(description = "연결 게시글 작성자 여부", example = "false")
         boolean isHost
 ) {
 

--- a/src/main/java/com/dduru/gildongmu/chat/dto/ws/ChatReadEventPayload.java
+++ b/src/main/java/com/dduru/gildongmu/chat/dto/ws/ChatReadEventPayload.java
@@ -1,12 +1,24 @@
 package com.dduru.gildongmu.chat.dto.ws;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.time.LocalDateTime;
 
+@Schema(description = "WebSocket 읽음 이벤트 payload")
 public record ChatReadEventPayload(
+        @Schema(description = "이벤트 타입. 읽음 이벤트는 항상 READ", example = "READ")
         String eventType,
+
+        @Schema(description = "채팅방 ID", example = "10")
         Long roomId,
+
+        @Schema(description = "읽음 처리한 회원 ID", example = "33")
         Long readerUserId,
+
+        @Schema(description = "해당 회원이 읽은 마지막 메시지 ID", example = "120")
         Long lastReadMessageId,
+
+        @Schema(description = "읽음 처리 시각")
         LocalDateTime readAt
 ) {
     private static final String READ_EVENT_TYPE = "READ";

--- a/src/main/java/com/dduru/gildongmu/chat/dto/ws/ChatSystemMessagePayload.java
+++ b/src/main/java/com/dduru/gildongmu/chat/dto/ws/ChatSystemMessagePayload.java
@@ -2,13 +2,24 @@ package com.dduru.gildongmu.chat.dto.ws;
 
 import com.dduru.gildongmu.chat.system.ChatSystemMessageType;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "WebSocket 시스템 메시지 payload")
 public record ChatSystemMessagePayload(
+        @Schema(description = "시스템 메시지 타입", example = "USER_INVITED", allowableValues = {"USER_INVITED", "USER_LEFT", "USER_KICKED", "ROOM_CLOSED"})
         ChatSystemMessageType type,
+
+        @Schema(description = "액션 수행자 회원 ID", example = "1", nullable = true)
         Long actorUserId,
+
+        @Schema(description = "초대된 회원 ID", example = "33", nullable = true)
         Long inviteeUserId,
+
+        @Schema(description = "채팅방을 나간 회원 ID", example = "33", nullable = true)
         Long userId,
+
+        @Schema(description = "내보내진 회원 ID", example = "33", nullable = true)
         Long targetUserId
 ) {
 

--- a/src/main/java/com/dduru/gildongmu/chat/dto/ws/ChatUserMessagePayload.java
+++ b/src/main/java/com/dduru/gildongmu/chat/dto/ws/ChatUserMessagePayload.java
@@ -3,10 +3,15 @@ package com.dduru.gildongmu.chat.dto.ws;
 import com.dduru.gildongmu.chat.domain.enums.ChatMessageType;
 import com.dduru.gildongmu.chat.exception.ChatSystemMessageSendAccessDeniedException;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "WebSocket 사용자 메시지 payload. 메시지 타입에 따라 text 또는 imageUrl 중 하나만 사용합니다.")
 public record ChatUserMessagePayload(
+        @Schema(description = "TEXT 메시지 본문", example = "안녕하세요!", nullable = true)
         String text,
+
+        @Schema(description = "IMAGE 메시지 이미지 URL", example = "https://example.com/images/chat-image.png", nullable = true)
         String imageUrl
 ) {
 

--- a/src/main/java/com/dduru/gildongmu/chat/dto/ws/roomlist/ChatRoomListEventPayload.java
+++ b/src/main/java/com/dduru/gildongmu/chat/dto/ws/roomlist/ChatRoomListEventPayload.java
@@ -2,6 +2,7 @@ package com.dduru.gildongmu.chat.dto.ws.roomlist;
 
 import com.dduru.gildongmu.chat.domain.enums.ChatRoomType;
 import com.dduru.gildongmu.chat.dto.response.ChatRoomListItemResponse;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
 
@@ -10,10 +11,18 @@ import java.time.LocalDateTime;
  * <p>
  * {@code UPSERT}는 완성된 채팅방 item을 포함하고, {@code REMOVE}는 목록 제거에 필요한 최소 채팅방 식별 정보만 포함한다.
  */
+@Schema(description = "WebSocket 사용자별 채팅방 목록 변경 이벤트 payload")
 public record ChatRoomListEventPayload(
+        @Schema(description = "목록 적용 방식", example = "UPSERT", allowableValues = {"UPSERT", "REMOVE"})
         ChatRoomListEventType eventType,
+
+        @Schema(description = "목록 변경 원인", example = "MESSAGE_CREATED", allowableValues = {"MESSAGE_CREATED", "READ_UPDATED", "ROOM_META_UPDATED", "MEMBER_CHANGED"})
         ChatRoomListEventReason reason,
+
+        @Schema(description = "변경 대상 채팅방. UPSERT는 완성된 item, REMOVE는 chatRoomId와 roomType만 포함")
         ChatRoomListEventRoomPayload chatRoom,
+
+        @Schema(description = "이벤트 발생 시각")
         LocalDateTime occurredAt
 ) {
     public static ChatRoomListEventPayload upsert(

--- a/src/main/java/com/dduru/gildongmu/chat/dto/ws/roomlist/ChatRoomListEventReason.java
+++ b/src/main/java/com/dduru/gildongmu/chat/dto/ws/roomlist/ChatRoomListEventReason.java
@@ -1,10 +1,13 @@
 package com.dduru.gildongmu.chat.dto.ws.roomlist;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 /**
  * 채팅방 목록 item이 변경된 도메인 원인을 나타낸다.
  * <p>
  * 클라이언트가 동일한 {@link ChatRoomListEventType} 안에서도 메시지, 읽음, 메타데이터, 멤버 변경을 구분할 수 있게 한다.
  */
+@Schema(description = "채팅방 목록 실시간 이벤트 발생 원인")
 public enum ChatRoomListEventReason {
     MESSAGE_CREATED,
     READ_UPDATED,

--- a/src/main/java/com/dduru/gildongmu/chat/dto/ws/roomlist/ChatRoomListEventRoomPayload.java
+++ b/src/main/java/com/dduru/gildongmu/chat/dto/ws/roomlist/ChatRoomListEventRoomPayload.java
@@ -5,6 +5,7 @@ import com.dduru.gildongmu.chat.domain.enums.ChatRoomType;
 import com.dduru.gildongmu.chat.dto.response.ChatRoomLastMessageResponse;
 import com.dduru.gildongmu.chat.dto.response.ChatRoomListItemResponse;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
 import lombok.Builder;
 
@@ -18,20 +19,48 @@ import java.time.LocalDateTime;
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Builder(access = AccessLevel.PRIVATE)
+@Schema(description = "채팅방 목록 이벤트 안의 채팅방 item. UPSERT는 전체 필드, REMOVE는 chatRoomId와 roomType만 포함합니다.")
 public record ChatRoomListEventRoomPayload(
+        @Schema(description = "채팅방 ID", example = "10")
         Long chatRoomId,
+
+        @Schema(description = "채팅방 타입", example = "GROUP", allowableValues = {"PRIVATE", "GROUP"})
         ChatRoomType roomType,
+
+        @Schema(description = "채팅방 상태. REMOVE 이벤트에서는 생략됩니다.", example = "ACTIVE", allowableValues = {"ACTIVE", "CLOSED", "DELETED"}, nullable = true)
         ChatRoomStatus status,
+
+        @Schema(description = "목록 표시명. PRIVATE은 상대 유저 닉네임, GROUP은 여정 제목", example = "제주 애월 2박 3일 함께가기", nullable = true)
         String displayName,
+
+        @Schema(description = "PRIVATE 채팅방의 게시글 제목. GROUP은 null", example = "제주 애월 2박 3일", nullable = true)
         String postTitle,
+
+        @Schema(description = "목록 썸네일 URL", example = "https://example.com/images/chat-thumbnail.png", nullable = true)
         String thumbnailUrl,
+
+        @Schema(description = "연결 게시글 ID", example = "101", nullable = true)
         Long postId,
+
+        @Schema(description = "연결 여정 ID", example = "55", nullable = true)
         Long journeyId,
+
+        @Schema(description = "현재 채팅방 멤버 수", example = "4", nullable = true)
         Integer participantCount,
+
+        @Schema(description = "마지막으로 표시 가능한 메시지. 메시지가 없으면 null", nullable = true)
         ChatRoomLastMessageResponse lastMessage,
+
+        @Schema(description = "현재 사용자가 아직 읽지 않은 메시지 수", example = "3", nullable = true)
         Long unreadCount,
+
+        @Schema(description = "현재 사용자의 마지막 읽음 메시지 ID", example = "120", nullable = true)
         Long lastReadMessageId,
+
+        @Schema(description = "목록 정렬 기준이 되는 마지막 활동 시각", nullable = true)
         LocalDateTime activityAt,
+
+        @Schema(description = "채팅방 생성 시각", nullable = true)
         LocalDateTime createdAt
 ) {
     public static ChatRoomListEventRoomPayload from(ChatRoomListItemResponse chatRoom) {

--- a/src/main/java/com/dduru/gildongmu/chat/dto/ws/roomlist/ChatRoomListEventType.java
+++ b/src/main/java/com/dduru/gildongmu/chat/dto/ws/roomlist/ChatRoomListEventType.java
@@ -1,10 +1,13 @@
 package com.dduru.gildongmu.chat.dto.ws.roomlist;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 /**
  * 채팅방 목록 실시간 이벤트가 클라이언트 목록에 적용되는 방식을 구분한다.
  * <p>
  * {@code UPSERT}는 채팅방 item을 삽입하거나 교체하고, {@code REMOVE}는 목록에서 제거한다.
  */
+@Schema(description = "채팅방 목록 실시간 이벤트 적용 방식. UPSERT는 삽입/교체, REMOVE는 제거입니다.")
 public enum ChatRoomListEventType {
     UPSERT,
     REMOVE

--- a/src/main/java/com/dduru/gildongmu/chat/system/ChatSystemMessageType.java
+++ b/src/main/java/com/dduru/gildongmu/chat/system/ChatSystemMessageType.java
@@ -1,5 +1,8 @@
 package com.dduru.gildongmu.chat.system;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "시스템 메시지 타입")
 public enum ChatSystemMessageType {
     USER_INVITED("%s 님이 그룹 채팅방에 참여했습니다."),
     USER_LEFT("%s 님이 채팅방을 나갔습니다."),


### PR DESCRIPTION
## 🔎 작업 내용
* 채팅 API 응답 데이터 정의와 프론트 사용 기준 문서 추가
* 채팅 REST API 설명을 커서, 읽음 처리, 목록 표시 기준까지 확인할 수 있도록 보강
* 채팅 요청/응답 DTO, enum, WebSocket payload DTO에 Swagger `@Schema` 설명과 예시 추가

## ➕ 이슈 링크
* Closed #278

## 📸 스크린샷
없음

## 😎 리뷰 요구사항
> Swagger에서 채팅 응답 필드의 의미, 타입별 null 규칙, enum 설명이 충분히 전달되는지 확인 부탁드립니다.

## 🧑‍💻 예정 작업
- 없음

## 📝 체크리스트
- [x] 브랜치 이름은 `feat/개발내용` 형식으로 작성했는가?
- [x] 커밋 메시지는 `feat(scope): 커밋 내용` 형식으로 작성했는가?
- [x] 작업 전 Issue를 작성했는가?
- [x] `dev` 브랜치로 병합을 요청했는가?
- [x] 불필요한 주석과 공백은 제거했는가?
- [ ] 코드 리뷰어의 피드백을 반영했는가?
- [x] 테스트를 진행했는가?
- [ ] 테스트 코드를 작성했는가?