### PR TITLE
feat: 알림 저장 및 조회 API 구현

### DIFF
--- a/docs/001-design/flows/005-notification-flow.md
+++ b/docs/001-design/flows/005-notification-flow.md
@@ -109,21 +109,15 @@ NotificationEventListener (REQUIRES_NEW transaction)
 
 ## 4. JOURNEY_NOTICE 중복 발송 방지
 
-공지 지정 → 공지 해제 → 공지 재지정 사이클에서 알림을 중복 발송하지 않는다.
-
-**서비스 레벨**: `updatePostNotice()`에서 `nextNotice && !journeyPost.isNotice()`인 경우에만 이벤트를 발행한다 (비공지 → 공지 전환 시점만).
-
-**리스너 레벨**: `JourneyNoticeCreatedEvent` 수신 시, 동일한 `journeyPostId`에 대해
-`JOURNEY_NOTICE` 타입 알림이 이미 존재하면 저장을 건너뛴다.
+**서비스 레벨**에서만 처리한다. `updatePostNotice()`에서 `nextNotice && !journeyPost.isNotice()`인 경우에만 이벤트를 발행한다 (비공지 → 공지 전환 시점에만).
 
 ```
-journeyPost.isNotice() == false → true 전환 시 → 이벤트 발행
+journeyPost.isNotice() == false → true 전환 시에만 이벤트 발행
     ↓
-NotificationEventListener
-    existsByTypeAndResourceTypeAndResourceId(JOURNEY_NOTICE, JOURNEY_POST, journeyPostId)
-    → true: 건너뜀 (이미 발송된 게시글)
-    → false: 알림 저장
+NotificationEventListener → 수신자 조회 → 알림 저장
 ```
+
+공지 해제 후 재지정 시에는 이벤트가 다시 발행되어 알림이 재발송된다. 이는 의도된 동작이다.
 
 ---
 

--- a/docs/001-design/flows/005-notification-flow.md
+++ b/docs/001-design/flows/005-notification-flow.md
@@ -1,0 +1,184 @@
+# 005. Notification Flow
+
+> 알림 서비스는 도메인 이벤트를 수신해 수신자에게 인앱 알림을 생성·저장하고,
+> 사용자가 알림함에서 조회·읽음 처리하는 흐름이다.
+
+이 문서는 `알림` 기능을 처음 보는 사람이 아래를 한 번에 이해할 수 있도록 정리한 제품 흐름 문서다.
+
+- 알림이 어떤 경로로 생성되는지 (도메인 이벤트 → 리스너)
+- 알림 타입별 수신자 결정 규칙
+- 조회 API의 커서 페이지네이션 방식
+- 예외 처리 및 격리 정책
+
+---
+
+## 1. 핵심 컨셉
+
+### 알림 생성은 API가 아닌 이벤트 기반이다
+
+직접 알림을 생성하는 엔드포인트는 없다. 각 도메인 서비스가 동작을 완료한 뒤
+`ApplicationEventPublisher`로 이벤트를 발행하면, `NotificationEventListener`가
+수신해 수신자를 결정하고 `notifications` 테이블에 저장한다.
+
+### 이벤트에 필요한 정보를 모두 싣는다
+
+리스너에서 DB를 재조회하지 않도록, 이벤트 객체에 알림 문구 생성·수신자 결정에
+필요한 정보를 함께 실어 보낸다.
+
+예) `ScheduleUpdatedEvent` → `scheduleId`, `journeyId`, `scheduleTitle`, `actorUserId` 포함
+→ 리스너는 재조회 없이 body를 조립하고 여정 멤버 ID만 조회해 저장한다.
+
+### 알림 저장 실패는 본문 트랜잭션에 영향을 주지 않는다
+
+`@TransactionalEventListener(AFTER_COMMIT)` + 리스너 내부 `try-catch`로 격리한다.
+본문 트랜잭션이 커밋된 후에만 리스너가 실행되므로, 알림 저장이 실패해도
+매칭/일정 처리 결과는 그대로 유지된다.
+
+---
+
+## 2. 알림 생성 흐름
+
+```
+도메인 서비스 (write transaction)
+  │
+  ├── 비즈니스 로직 완료
+  ├── eventPublisher.publishEvent(XxxEvent)  ← 이벤트 발행
+  └── commit
+
+                          ↓ AFTER_COMMIT
+
+NotificationEventListener (REQUIRES_NEW transaction)
+  │
+  ├── 수신자 결정
+  ├── 알림 문구(body) 조립
+  ├── notificationRepository.save() / saveAll()
+  └── 예외 발생 시 log.error()만 남기고 무시
+```
+
+### 이벤트 발행 지점 목록
+
+| 도메인 서비스 | 메서드 | 발행 이벤트 |
+|---|---|---|
+| `ParticipationApplicantService` | `participate()` | `MatchAppliedEvent` |
+| `ParticipationCommandService` | `approveParticipation()` | `MatchApprovedEvent` |
+| `ParticipationCommandService` | `rejectParticipation()` | `MatchRejectedEvent` |
+| `JourneyPostService` | `updatePostNotice()` | `JourneyNoticeCreatedEvent` |
+| `JourneyScheduleService` | `createSchedule()` | `ScheduleCreatedEvent` |
+| `JourneyScheduleService` | `updateSchedule()` | `ScheduleUpdatedEvent` |
+| `JourneyScheduleService` | `deleteSchedule()` | `ScheduleCanceledEvent` |
+
+---
+
+## 3. 알림 타입별 규칙
+
+### 수신자 결정
+
+| 타입 | 수신자 | 결정 방식 |
+|---|---|---|
+| `MATCH_APPLIED` | 모집글 작성자 1명 | 이벤트에 `recipientUserId` 포함 |
+| `MATCH_APPROVED` | 신청자 1명 | 이벤트에 `applicantUserId` 포함 |
+| `MATCH_REJECTED` | 신청자 1명 | 이벤트에 `applicantUserId` 포함 |
+| `JOURNEY_NOTICE` | 여정 ACTIVE 멤버 전원 (행위자 제외) | `JourneyMemberRepository`로 조회 |
+| `SCHEDULE_CREATED / UPDATED / CANCELED` | 여정 ACTIVE 멤버 전원 (행위자 제외) | `JourneyMemberRepository`로 조회 |
+
+> 행위자 본인은 항상 수신자에서 제외된다.
+
+### 알림 문구(body)
+
+| 타입 | body 예시 |
+|---|---|
+| `MATCH_APPLIED` | `[시부야 자유여행] 에 새로운 참여 신청이 도착했습니다.` |
+| `MATCH_APPROVED` | `[시부야 자유여행] 여행 참여가 승인되었습니다.` |
+| `MATCH_REJECTED` | `참여 신청이 검토되었으나 함께하기 어렵게 되었습니다.` |
+| `JOURNEY_NOTICE` | `[시부야 자유여행] 새 공지가 등록되었습니다.` |
+| `SCHEDULE_CREATED` | `[시부야 스크램블 집합] 일정이 추가되었습니다.` |
+| `SCHEDULE_UPDATED` | `[시부야 스크램블 집합] 일정이 변경되었습니다.` |
+| `SCHEDULE_CANCELED` | `[시부야 스크램블 집합] 일정이 취소되었습니다.` |
+
+### resourceType / resourceId (탭 시 이동 대상)
+
+| 타입 | resourceType | resourceId |
+|---|---|---|
+| `MATCH_APPLIED` | `MATCH` | `participationId` |
+| `MATCH_APPROVED` | `JOURNEY` | `journeyId` (승인된 여정으로 이동) |
+| `MATCH_REJECTED` | `MATCH` | `participationId` |
+| `JOURNEY_NOTICE` | `JOURNEY_POST` | `journeyPostId` |
+| `SCHEDULE_*` | `SCHEDULE` | `scheduleId` |
+
+---
+
+## 4. JOURNEY_NOTICE 중복 발송 방지
+
+공지 지정 → 공지 해제 → 공지 재지정 사이클에서 알림을 중복 발송하지 않는다.
+
+**서비스 레벨**: `updatePostNotice()`에서 `nextNotice && !journeyPost.isNotice()`인 경우에만 이벤트를 발행한다 (비공지 → 공지 전환 시점만).
+
+**리스너 레벨**: `JourneyNoticeCreatedEvent` 수신 시, 동일한 `journeyPostId`에 대해
+`JOURNEY_NOTICE` 타입 알림이 이미 존재하면 저장을 건너뛴다.
+
+```
+journeyPost.isNotice() == false → true 전환 시 → 이벤트 발행
+    ↓
+NotificationEventListener
+    existsByTypeAndResourceTypeAndResourceId(JOURNEY_NOTICE, JOURNEY_POST, journeyPostId)
+    → true: 건너뜀 (이미 발송된 게시글)
+    → false: 알림 저장
+```
+
+---
+
+## 5. 조회 API 흐름
+
+### 알림 목록 (커서 페이지네이션)
+
+`GET /api/v1/notifications?cursor={lastId}&size={n}`
+
+```
+NotificationController
+  └── NotificationQueryService.getNotifications(userId, cursor, size)
+        ├── size 클램프: null → 20, 초과 → 50
+        ├── NotificationRepository.findByRecipientIdWithCursor(userId, cursor, size+1)
+        │     WHERE recipient_user_id = ? AND id < cursor (cursor 없으면 전체)
+        │     ORDER BY id DESC
+        └── NotificationListResponse.of(fetched, requestedSize)
+              ├── size+1 개 fetch → hasNext 결정
+              ├── hasNext=true: nextCursor = 마지막 항목 id
+              └── hasNext=false: nextCursor = null (필드 생략 아님)
+```
+
+### 읽음 처리
+
+```
+PATCH /{notificationId}/read
+  └── NotificationService.markAsRead(userId, notificationId)
+        ├── 알림 존재 확인 → NotificationNotFoundException (404)
+        ├── recipient.id == userId 검증 → NotificationAccessDeniedException (403)
+        └── isRead == false일 때만 markAsRead(now) 호출 (멱등)
+
+PATCH /read-all
+  └── NotificationService.markAllAsRead(userId)
+        └── UPDATE notifications SET is_read=1, read_at=? WHERE recipient_user_id=? AND is_read=0
+```
+
+---
+
+## 6. 예외 처리
+
+| 상황 | 에러 코드 | HTTP |
+|---|---|---|
+| 존재하지 않는 알림 ID | `NOTIFICATION_NOT_FOUND` | 404 |
+| 타인의 알림 읽음 처리 시도 | `NOTIFICATION_ACCESS_DENIED` | 403 |
+| 이미 읽은 알림 재요청 | 에러 없음 (200 멱등) | 200 |
+| 수신자 0명 (행위자 제외 후) | 알림 미생성, 정상 처리 | — |
+| 알림 저장 실패 | 로그만 남기고 무시 (본문 트랜잭션 영향 없음) | — |
+
+---
+
+## 7. 현재 범위 제외 항목 (2차)
+
+- FCM 푸시 발송
+- 알림 on/off 설정
+- `SCHEDULE_UPCOMING` — 시간 기반 스케줄러 + 푸시 연동 필요
+- 채팅 새 메시지 알림 — 디바운스/그룹핑 + 푸시 연동 필요
+- 시스템 공지/이벤트 (어드민 발송)
+- 90일 경과 알림 자동 삭제 배치

--- a/docs/001-design/flows/005-notification-flow.md
+++ b/docs/001-design/flows/005-notification-flow.md
@@ -25,8 +25,8 @@
 리스너에서 DB를 재조회하지 않도록, 이벤트 객체에 알림 문구 생성·수신자 결정에
 필요한 정보를 함께 실어 보낸다.
 
-예) `ScheduleUpdatedEvent` → `scheduleId`, `journeyId`, `scheduleTitle`, `actorUserId` 포함
-→ 리스너는 재조회 없이 body를 조립하고 여정 멤버 ID만 조회해 저장한다.
+예) `MatchAppliedEvent` → 이벤트 발행 시점에 신청자 닉네임을 조회해 포함
+→ 리스너는 재조회 없이 body를 조립한다.
 
 ### 알림 저장 실패는 본문 트랜잭션에 영향을 주지 않는다
 
@@ -61,7 +61,6 @@ NotificationEventListener (REQUIRES_NEW transaction)
 |---|---|---|
 | `ParticipationApplicantService` | `participate()` | `MatchAppliedEvent` |
 | `ParticipationCommandService` | `approveParticipation()` | `MatchApprovedEvent` |
-| `ParticipationCommandService` | `rejectParticipation()` | `MatchRejectedEvent` |
 | `JourneyPostService` | `updatePostNotice()` | `JourneyNoticeCreatedEvent` |
 | `JourneyScheduleService` | `createSchedule()` | `ScheduleCreatedEvent` |
 | `JourneyScheduleService` | `updateSchedule()` | `ScheduleUpdatedEvent` |
@@ -77,7 +76,6 @@ NotificationEventListener (REQUIRES_NEW transaction)
 |---|---|---|
 | `MATCH_APPLIED` | 모집글 작성자 1명 | 이벤트에 `recipientUserId` 포함 |
 | `MATCH_APPROVED` | 신청자 1명 | 이벤트에 `applicantUserId` 포함 |
-| `MATCH_REJECTED` | 신청자 1명 | 이벤트에 `applicantUserId` 포함 |
 | `JOURNEY_NOTICE` | 여정 ACTIVE 멤버 전원 (행위자 제외) | `JourneyMemberRepository`로 조회 |
 | `SCHEDULE_CREATED / UPDATED / CANCELED` | 여정 ACTIVE 멤버 전원 (행위자 제외) | `JourneyMemberRepository`로 조회 |
 
@@ -85,15 +83,17 @@ NotificationEventListener (REQUIRES_NEW transaction)
 
 ### 알림 문구(body)
 
-| 타입 | body 예시 |
+| 타입 | body |
 |---|---|
-| `MATCH_APPLIED` | `[시부야 자유여행] 에 새로운 참여 신청이 도착했습니다.` |
-| `MATCH_APPROVED` | `[시부야 자유여행] 여행 참여가 승인되었습니다.` |
-| `MATCH_REJECTED` | `참여 신청이 검토되었으나 함께하기 어렵게 되었습니다.` |
-| `JOURNEY_NOTICE` | `[시부야 자유여행] 새 공지가 등록되었습니다.` |
-| `SCHEDULE_CREATED` | `[시부야 스크램블 집합] 일정이 추가되었습니다.` |
-| `SCHEDULE_UPDATED` | `[시부야 스크램블 집합] 일정이 변경되었습니다.` |
-| `SCHEDULE_CANCELED` | `[시부야 스크램블 집합] 일정이 취소되었습니다.` |
+| `MATCH_APPLIED` | `{닉네임} 님이 매칭을 신청했습니다.` |
+| `MATCH_APPROVED` | `{닉네임} 님과 매칭이 성사되었습니다.` |
+| `JOURNEY_NOTICE` | `[{여행지/방 이름}] 에 공지가 등록되었습니다.` |
+| `SCHEDULE_CREATED` | `여행 일정이 생성되었습니다.` |
+| `SCHEDULE_UPDATED` | `여행 일정이 변경되었습니다. 확인해주세요.` |
+| `SCHEDULE_CANCELED` | `여행 일정이 취소되었습니다.` |
+
+> `MATCH_APPLIED`의 닉네임은 신청자, `MATCH_APPROVED`의 닉네임은 승인자(모집글 작성자)이다.
+> 닉네임은 이벤트 발행 시점에 `ProfileRepository`로 조회해 이벤트에 포함한다.
 
 ### resourceType / resourceId (탭 시 이동 대상)
 
@@ -101,7 +101,6 @@ NotificationEventListener (REQUIRES_NEW transaction)
 |---|---|---|
 | `MATCH_APPLIED` | `MATCH` | `participationId` |
 | `MATCH_APPROVED` | `JOURNEY` | `journeyId` (승인된 여정으로 이동) |
-| `MATCH_REJECTED` | `MATCH` | `participationId` |
 | `JOURNEY_NOTICE` | `JOURNEY_POST` | `journeyPostId` |
 | `SCHEDULE_*` | `SCHEDULE` | `scheduleId` |
 

--- a/src/main/java/com/dduru/gildongmu/common/exception/ErrorCode.java
+++ b/src/main/java/com/dduru/gildongmu/common/exception/ErrorCode.java
@@ -163,7 +163,11 @@ public enum ErrorCode {
     CHAT_TEXT_REQUIRED(HttpStatus.BAD_REQUEST, "메시지 내용은 필수입니다."),
     CHAT_TEXT_BLANK(HttpStatus.BAD_REQUEST, "공백만 있는 메시지는 전송할 수 없습니다."),
     CHAT_TEXT_TOO_LONG(HttpStatus.BAD_REQUEST, "메시지가 너무 깁니다."),
-    CHAT_SYSTEM_MESSAGE_SEND_ACCESS_DENIED(HttpStatus.BAD_REQUEST, "SYSTEM 은 사용자 메시지로 처리되지 않습니다.");
+    CHAT_SYSTEM_MESSAGE_SEND_ACCESS_DENIED(HttpStatus.BAD_REQUEST, "SYSTEM 은 사용자 메시지로 처리되지 않습니다."),
+
+    // 알림 (NOTIFICATION)
+    NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "알림을 찾을 수 없습니다."),
+    NOTIFICATION_ACCESS_DENIED(HttpStatus.FORBIDDEN, "해당 알림에 접근할 수 없습니다.");
 
     private final int status;
     private final String message;

--- a/src/main/java/com/dduru/gildongmu/journey/event/JourneyNoticeCreatedEvent.java
+++ b/src/main/java/com/dduru/gildongmu/journey/event/JourneyNoticeCreatedEvent.java
@@ -1,0 +1,9 @@
+package com.dduru.gildongmu.journey.event;
+
+public record JourneyNoticeCreatedEvent(
+        Long journeyPostId,
+        Long journeyId,
+        String journeyTitle,
+        Long actorUserId
+) {
+}

--- a/src/main/java/com/dduru/gildongmu/journey/event/ScheduleCanceledEvent.java
+++ b/src/main/java/com/dduru/gildongmu/journey/event/ScheduleCanceledEvent.java
@@ -1,0 +1,9 @@
+package com.dduru.gildongmu.journey.event;
+
+public record ScheduleCanceledEvent(
+        Long scheduleId,
+        Long journeyId,
+        String scheduleTitle,
+        Long actorUserId
+) {
+}

--- a/src/main/java/com/dduru/gildongmu/journey/event/ScheduleCreatedEvent.java
+++ b/src/main/java/com/dduru/gildongmu/journey/event/ScheduleCreatedEvent.java
@@ -1,0 +1,9 @@
+package com.dduru.gildongmu.journey.event;
+
+public record ScheduleCreatedEvent(
+        Long scheduleId,
+        Long journeyId,
+        String scheduleTitle,
+        Long actorUserId
+) {
+}

--- a/src/main/java/com/dduru/gildongmu/journey/event/ScheduleUpdatedEvent.java
+++ b/src/main/java/com/dduru/gildongmu/journey/event/ScheduleUpdatedEvent.java
@@ -1,0 +1,9 @@
+package com.dduru.gildongmu.journey.event;
+
+public record ScheduleUpdatedEvent(
+        Long scheduleId,
+        Long journeyId,
+        String scheduleTitle,
+        Long actorUserId
+) {
+}

--- a/src/main/java/com/dduru/gildongmu/journey/repository/JourneyMemberRepository.java
+++ b/src/main/java/com/dduru/gildongmu/journey/repository/JourneyMemberRepository.java
@@ -135,4 +135,16 @@ public interface JourneyMemberRepository extends JpaRepository<JourneyMember, Lo
             @Param("postId") Long postId,
             @Param("status") JourneyMemberStatus status
     );
+
+    @Query("""
+            SELECT jm.user.id
+            FROM JourneyMember jm
+            WHERE jm.journey.id = :journeyId
+              AND jm.status = 'ACTIVE'
+              AND jm.user.id <> :excludeUserId
+            """)
+    List<Long> findActiveUserIdsByJourneyIdExcludingUser(
+            @Param("journeyId") Long journeyId,
+            @Param("excludeUserId") Long excludeUserId
+    );
 }

--- a/src/main/java/com/dduru/gildongmu/journey/service/JourneyPostService.java
+++ b/src/main/java/com/dduru/gildongmu/journey/service/JourneyPostService.java
@@ -254,7 +254,6 @@ public class JourneyPostService {
 
         // 새 공지를 추가하는 경로만 직렬화해 여정당 공지 최대 5개 정책을 보장한다.
         journeyRepository.getByIdWithLockOrThrow(journeyId);
-        validateActiveHost(journeyId, userId);
 
         long noticeCount = journeyPostRepository.countActiveNoticesByJourneyId(journeyId);
         if (noticeCount >= NOTICE_LIMIT) {

--- a/src/main/java/com/dduru/gildongmu/journey/service/JourneyPostService.java
+++ b/src/main/java/com/dduru/gildongmu/journey/service/JourneyPostService.java
@@ -13,6 +13,7 @@ import com.dduru.gildongmu.journey.dto.request.JourneyPostUpdateRequest;
 import com.dduru.gildongmu.journey.dto.response.JourneyPostListResponse;
 import com.dduru.gildongmu.journey.dto.response.JourneyPostNoticeUpdateResponse;
 import com.dduru.gildongmu.journey.dto.response.JourneyPostResponse;
+import com.dduru.gildongmu.journey.event.JourneyNoticeCreatedEvent;
 import com.dduru.gildongmu.journey.exception.InvalidJourneyPostException;
 import com.dduru.gildongmu.journey.exception.JourneyAccessDeniedException;
 import com.dduru.gildongmu.journey.exception.JourneyHostNotFoundException;
@@ -28,6 +29,7 @@ import com.dduru.gildongmu.user.domain.User;
 import com.dduru.gildongmu.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -54,6 +56,7 @@ public class JourneyPostService {
     private final S3ImageUrlValidator s3ImageUrlValidator;
     private final ProfileImageResolver profileImageResolver;
     private final TimeProvider timeProvider;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Transactional(readOnly = true)
     public JourneyPostListResponse retrievePosts(Long journeyId, Long userId, JourneyPostListRequest request) {
@@ -158,9 +161,18 @@ public class JourneyPostService {
 
         JourneyPost journeyPost = journeyPostRepository.getActivePostByIdAndJourneyIdOrThrow(journeyPostId, journeyId);
         boolean nextNotice = Boolean.TRUE.equals(request.isNotice());
+        boolean isNewNoticeDesignation = nextNotice && !journeyPost.isNotice();
         validateNoticeLimitBeforeMarking(journeyId, userId, journeyPost, nextNotice);
 
         journeyPost.updateNoticeStatus(nextNotice);
+
+        if (isNewNoticeDesignation) {
+            Journey journey = journeyRepository.getByIdOrThrow(journeyId);
+            eventPublisher.publishEvent(new JourneyNoticeCreatedEvent(
+                    journeyPostId, journeyId, journey.getTitle(), userId
+            ));
+        }
+
         log.info("나의 여정 게시글 공지 상태 변경됨 - journeyId={}, journeyPostId={}, isNotice={}, userId={}",
                 journeyId, journeyPostId, nextNotice, userId);
         return JourneyPostNoticeUpdateResponse.from(journeyPost);

--- a/src/main/java/com/dduru/gildongmu/journey/service/JourneyScheduleService.java
+++ b/src/main/java/com/dduru/gildongmu/journey/service/JourneyScheduleService.java
@@ -8,6 +8,9 @@ import com.dduru.gildongmu.journey.domain.enums.ScheduleCategory;
 import com.dduru.gildongmu.journey.dto.request.JourneyScheduleCreateRequest;
 import com.dduru.gildongmu.journey.dto.request.JourneyScheduleUpdateRequest;
 import com.dduru.gildongmu.journey.dto.response.JourneyScheduleListResponse;
+import com.dduru.gildongmu.journey.event.ScheduleCanceledEvent;
+import com.dduru.gildongmu.journey.event.ScheduleCreatedEvent;
+import com.dduru.gildongmu.journey.event.ScheduleUpdatedEvent;
 import com.dduru.gildongmu.journey.exception.InvalidJourneyScheduleException;
 import com.dduru.gildongmu.journey.exception.JourneyAccessDeniedException;
 import com.dduru.gildongmu.journey.repository.JourneyMemberRepository;
@@ -16,6 +19,7 @@ import com.dduru.gildongmu.journey.repository.JourneyScheduleRepository;
 import com.dduru.gildongmu.post.domain.Post;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -34,6 +38,7 @@ public class JourneyScheduleService {
     private final JourneyMemberRepository journeyMemberRepository;
     private final JourneyScheduleRepository journeyScheduleRepository;
     private final TimeProvider timeProvider;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Transactional(readOnly = true)
     public JourneyScheduleListResponse retrieveSchedules(Long journeyId, Long userId) {
@@ -53,6 +58,9 @@ public class JourneyScheduleService {
         JourneySchedule schedule = createJourneySchedule(journey, dayOffset, request);
         journeyScheduleRepository.saveAndFlush(schedule);
 
+        eventPublisher.publishEvent(new ScheduleCreatedEvent(
+                schedule.getId(), journeyId, schedule.getTitle(), userId
+        ));
         log.info("나의 여정 일정 생성됨 - journeyId={}, scheduleId={}, userId={}",
                 journeyId, schedule.getId(), userId);
 
@@ -90,6 +98,9 @@ public class JourneyScheduleService {
         schedule.update(title, category, dayOffset, applyStartTimePatch, startValue, applyEndTimePatch, endValue, placeName, applyMemoPatch, memo);
         journeyScheduleRepository.flush();
 
+        eventPublisher.publishEvent(new ScheduleUpdatedEvent(
+                scheduleId, journeyId, schedule.getTitle(), userId
+        ));
         log.info("나의 여정 일정 수정됨 - journeyId={}, scheduleId={}, userId={}",
                 journeyId, scheduleId, userId);
 
@@ -101,8 +112,12 @@ public class JourneyScheduleService {
         getAccessibleJourneyWithPost(journeyId, userId);
 
         JourneySchedule schedule = journeyScheduleRepository.getActiveByIdAndJourneyIdOrThrow(scheduleId, journeyId);
+        String scheduleTitle = schedule.getTitle();
         schedule.delete(userId, timeProvider.now());
 
+        eventPublisher.publishEvent(new ScheduleCanceledEvent(
+                scheduleId, journeyId, scheduleTitle, userId
+        ));
         log.info("나의 여정 일정 삭제됨 - journeyId={}, scheduleId={}, userId={}",
                 journeyId, scheduleId, userId);
     }

--- a/src/main/java/com/dduru/gildongmu/notification/controller/NotificationApiDocs.java
+++ b/src/main/java/com/dduru/gildongmu/notification/controller/NotificationApiDocs.java
@@ -1,0 +1,60 @@
+package com.dduru.gildongmu.notification.controller;
+
+import com.dduru.gildongmu.common.annotation.ApiErrorResponses;
+import com.dduru.gildongmu.common.dto.ApiResult;
+import com.dduru.gildongmu.common.exception.ErrorCode;
+import com.dduru.gildongmu.notification.dto.request.NotificationListRequest;
+import com.dduru.gildongmu.notification.dto.response.NotificationListResponse;
+import com.dduru.gildongmu.notification.dto.response.NotificationReadResponse;
+import com.dduru.gildongmu.notification.dto.response.UnreadCountResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@Tag(name = "Notifications", description = "알림 API")
+@SecurityRequirement(name = "JWT")
+public interface NotificationApiDocs {
+
+    @Operation(
+            summary = "알림 목록 조회",
+            description = "본인에게 도착한 알림을 최신순(커서 페이지네이션)으로 조회합니다. cursor 미전달 시 최신부터 조회합니다."
+    )
+    @ApiResponse(responseCode = "200", description = "조회 성공")
+    @ApiErrorResponses({ErrorCode.UNAUTHORIZED})
+    ResponseEntity<ApiResult<NotificationListResponse>> getNotifications(
+            @Parameter(hidden = true) Long userId,
+            @Valid @ParameterObject NotificationListRequest request
+    );
+
+    @Operation(summary = "안 읽은 알림 개수 조회")
+    @ApiResponse(responseCode = "200", description = "조회 성공")
+    @ApiErrorResponses({ErrorCode.UNAUTHORIZED})
+    ResponseEntity<ApiResult<UnreadCountResponse>> getUnreadCount(
+            @Parameter(hidden = true) Long userId
+    );
+
+    @Operation(summary = "단건 읽음 처리", description = "본인에게 도착한 알림 1건을 읽음 처리합니다. 이미 읽은 알림은 멱등 처리됩니다.")
+    @ApiResponse(responseCode = "200", description = "읽음 처리 성공")
+    @ApiErrorResponses({
+            ErrorCode.UNAUTHORIZED,
+            ErrorCode.NOTIFICATION_NOT_FOUND,
+            ErrorCode.NOTIFICATION_ACCESS_DENIED
+    })
+    ResponseEntity<ApiResult<NotificationReadResponse>> markAsRead(
+            @Parameter(hidden = true) Long userId,
+            @Parameter(description = "알림 ID", required = true) @PathVariable Long notificationId
+    );
+
+    @Operation(summary = "전체 읽음 처리", description = "본인의 모든 미읽음 알림을 일괄 읽음 처리합니다.")
+    @ApiResponse(responseCode = "200", description = "전체 읽음 처리 성공")
+    @ApiErrorResponses({ErrorCode.UNAUTHORIZED})
+    ResponseEntity<ApiResult<NotificationReadResponse>> markAllAsRead(
+            @Parameter(hidden = true) Long userId
+    );
+}

--- a/src/main/java/com/dduru/gildongmu/notification/controller/NotificationController.java
+++ b/src/main/java/com/dduru/gildongmu/notification/controller/NotificationController.java
@@ -1,0 +1,61 @@
+package com.dduru.gildongmu.notification.controller;
+
+import com.dduru.gildongmu.common.annotation.CurrentUser;
+import com.dduru.gildongmu.common.dto.ApiResult;
+import com.dduru.gildongmu.notification.dto.request.NotificationListRequest;
+import com.dduru.gildongmu.notification.dto.response.NotificationListResponse;
+import com.dduru.gildongmu.notification.dto.response.NotificationReadResponse;
+import com.dduru.gildongmu.notification.dto.response.UnreadCountResponse;
+import com.dduru.gildongmu.notification.service.NotificationQueryService;
+import com.dduru.gildongmu.notification.service.NotificationService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/notifications")
+@RequiredArgsConstructor
+public class NotificationController implements NotificationApiDocs {
+
+    private final NotificationQueryService notificationQueryService;
+    private final NotificationService notificationService;
+
+    @GetMapping
+    public ResponseEntity<ApiResult<NotificationListResponse>> getNotifications(
+            @CurrentUser Long userId,
+            @Valid @ModelAttribute NotificationListRequest request
+    ) {
+        return ResponseEntity.ok(ApiResult.ok(
+                notificationQueryService.getNotifications(userId, request.cursor(), request.sizeOrDefault())
+        ));
+    }
+
+    @GetMapping("/unread-count")
+    public ResponseEntity<ApiResult<UnreadCountResponse>> getUnreadCount(
+            @CurrentUser Long userId
+    ) {
+        return ResponseEntity.ok(ApiResult.ok(
+                notificationQueryService.getUnreadCount(userId)
+        ));
+    }
+
+    @PatchMapping("/{notificationId}/read")
+    public ResponseEntity<ApiResult<NotificationReadResponse>> markAsRead(
+            @CurrentUser Long userId,
+            @PathVariable Long notificationId
+    ) {
+        return ResponseEntity.ok(ApiResult.ok(
+                notificationService.markAsRead(userId, notificationId)
+        ));
+    }
+
+    @PatchMapping("/read-all")
+    public ResponseEntity<ApiResult<NotificationReadResponse>> markAllAsRead(
+            @CurrentUser Long userId
+    ) {
+        return ResponseEntity.ok(ApiResult.ok(
+                notificationService.markAllAsRead(userId)
+        ));
+    }
+}

--- a/src/main/java/com/dduru/gildongmu/notification/controller/NotificationController.java
+++ b/src/main/java/com/dduru/gildongmu/notification/controller/NotificationController.java
@@ -14,48 +14,44 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/api/v1/notifications")
 @RequiredArgsConstructor
+@RequestMapping("/api/v1/notifications")
 public class NotificationController implements NotificationApiDocs {
 
     private final NotificationQueryService notificationQueryService;
     private final NotificationService notificationService;
 
+    @Override
     @GetMapping
     public ResponseEntity<ApiResult<NotificationListResponse>> getNotifications(
             @CurrentUser Long userId,
             @Valid @ModelAttribute NotificationListRequest request
     ) {
-        return ResponseEntity.ok(ApiResult.ok(
-                notificationQueryService.getNotifications(userId, request.cursor(), request.sizeOrDefault())
-        ));
+        return ResponseEntity.ok(ApiResult.ok(notificationQueryService.getNotifications(userId, request.cursor(), request.sizeOrDefault())));
     }
 
+    @Override
     @GetMapping("/unread-count")
     public ResponseEntity<ApiResult<UnreadCountResponse>> getUnreadCount(
             @CurrentUser Long userId
     ) {
-        return ResponseEntity.ok(ApiResult.ok(
-                notificationQueryService.getUnreadCount(userId)
-        ));
+        return ResponseEntity.ok(ApiResult.ok(notificationQueryService.getUnreadCount(userId)));
     }
 
+    @Override
     @PatchMapping("/{notificationId}/read")
     public ResponseEntity<ApiResult<NotificationReadResponse>> markAsRead(
             @CurrentUser Long userId,
             @PathVariable Long notificationId
     ) {
-        return ResponseEntity.ok(ApiResult.ok(
-                notificationService.markAsRead(userId, notificationId)
-        ));
+        return ResponseEntity.ok(ApiResult.ok(notificationService.markAsRead(userId, notificationId)));
     }
 
+    @Override
     @PatchMapping("/read-all")
     public ResponseEntity<ApiResult<NotificationReadResponse>> markAllAsRead(
             @CurrentUser Long userId
     ) {
-        return ResponseEntity.ok(ApiResult.ok(
-                notificationService.markAllAsRead(userId)
-        ));
+        return ResponseEntity.ok(ApiResult.ok(notificationService.markAllAsRead(userId)));
     }
 }

--- a/src/main/java/com/dduru/gildongmu/notification/domain/Notification.java
+++ b/src/main/java/com/dduru/gildongmu/notification/domain/Notification.java
@@ -1,0 +1,69 @@
+package com.dduru.gildongmu.notification.domain;
+
+import com.dduru.gildongmu.common.entity.BaseTimeEntity;
+import com.dduru.gildongmu.notification.domain.enums.NotificationType;
+import com.dduru.gildongmu.notification.domain.enums.ResourceType;
+import com.dduru.gildongmu.user.domain.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "notifications")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Notification extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "recipient_user_id", nullable = false)
+    private User recipient;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private NotificationType type;
+
+    @Column(nullable = false, length = 500)
+    private String body;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "resource_type", nullable = false)
+    private ResourceType resourceType;
+
+    @Column(name = "resource_id", nullable = false)
+    private Long resourceId;
+
+    @Column(name = "is_read", nullable = false)
+    private boolean read;
+
+    @Column(name = "read_at")
+    private LocalDateTime readAt;
+
+    public static Notification create(
+            User recipient,
+            NotificationType type,
+            String body,
+            ResourceType resourceType,
+            Long resourceId
+    ) {
+        Notification n = new Notification();
+        n.recipient = recipient;
+        n.type = type;
+        n.body = body;
+        n.resourceType = resourceType;
+        n.resourceId = resourceId;
+        n.read = false;
+        return n;
+    }
+
+    public void markAsRead(LocalDateTime now) {
+        this.read = true;
+        this.readAt = now;
+    }
+}

--- a/src/main/java/com/dduru/gildongmu/notification/domain/enums/NotificationType.java
+++ b/src/main/java/com/dduru/gildongmu/notification/domain/enums/NotificationType.java
@@ -3,7 +3,6 @@ package com.dduru.gildongmu.notification.domain.enums;
 public enum NotificationType {
     MATCH_APPLIED,
     MATCH_APPROVED,
-    MATCH_REJECTED,
     JOURNEY_NOTICE,
     SCHEDULE_CREATED,
     SCHEDULE_UPDATED,

--- a/src/main/java/com/dduru/gildongmu/notification/domain/enums/NotificationType.java
+++ b/src/main/java/com/dduru/gildongmu/notification/domain/enums/NotificationType.java
@@ -1,0 +1,11 @@
+package com.dduru.gildongmu.notification.domain.enums;
+
+public enum NotificationType {
+    MATCH_APPLIED,
+    MATCH_APPROVED,
+    MATCH_REJECTED,
+    JOURNEY_NOTICE,
+    SCHEDULE_CREATED,
+    SCHEDULE_UPDATED,
+    SCHEDULE_CANCELED
+}

--- a/src/main/java/com/dduru/gildongmu/notification/domain/enums/ResourceType.java
+++ b/src/main/java/com/dduru/gildongmu/notification/domain/enums/ResourceType.java
@@ -1,0 +1,8 @@
+package com.dduru.gildongmu.notification.domain.enums;
+
+public enum ResourceType {
+    JOURNEY,
+    JOURNEY_POST,
+    SCHEDULE,
+    MATCH
+}

--- a/src/main/java/com/dduru/gildongmu/notification/dto/request/NotificationListRequest.java
+++ b/src/main/java/com/dduru/gildongmu/notification/dto/request/NotificationListRequest.java
@@ -1,12 +1,16 @@
 package com.dduru.gildongmu.notification.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.Positive;
 
+@Schema(description = "알림 목록 조회 요청")
 public record NotificationListRequest(
+        @Schema(description = "마지막으로 조회한 알림 ID (첫 요청 시 생략)", example = "42")
         @Positive(message = "cursor는 1 이상이어야 합니다.")
         Long cursor,
+        @Schema(description = "조회 개수 (기본값 20, 최대 50)", example = "20")
         @Min(value = 1, message = "size는 1 이상 50 이하로 입력해야 합니다.")
         @Max(value = 50, message = "size는 1 이상 50 이하로 입력해야 합니다.")
         Integer size

--- a/src/main/java/com/dduru/gildongmu/notification/dto/request/NotificationListRequest.java
+++ b/src/main/java/com/dduru/gildongmu/notification/dto/request/NotificationListRequest.java
@@ -1,0 +1,19 @@
+package com.dduru.gildongmu.notification.dto.request;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Positive;
+
+public record NotificationListRequest(
+        @Positive(message = "cursor는 1 이상이어야 합니다.")
+        Long cursor,
+        @Min(value = 1, message = "size는 1 이상 50 이하로 입력해야 합니다.")
+        @Max(value = 50, message = "size는 1 이상 50 이하로 입력해야 합니다.")
+        Integer size
+) {
+    public static final int DEFAULT_SIZE = 20;
+
+    public int sizeOrDefault() {
+        return size == null ? DEFAULT_SIZE : size;
+    }
+}

--- a/src/main/java/com/dduru/gildongmu/notification/dto/response/NotificationInfo.java
+++ b/src/main/java/com/dduru/gildongmu/notification/dto/response/NotificationInfo.java
@@ -1,0 +1,31 @@
+package com.dduru.gildongmu.notification.dto.response;
+
+import com.dduru.gildongmu.notification.domain.Notification;
+import com.dduru.gildongmu.notification.domain.enums.NotificationType;
+import com.dduru.gildongmu.notification.domain.enums.ResourceType;
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import java.time.LocalDateTime;
+
+public record NotificationInfo(
+        Long notificationId,
+        NotificationType type,
+        String body,
+        ResourceType resourceType,
+        Long resourceId,
+        boolean isRead,
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+        LocalDateTime createdAt
+) {
+    public static NotificationInfo from(Notification notification) {
+        return new NotificationInfo(
+                notification.getId(),
+                notification.getType(),
+                notification.getBody(),
+                notification.getResourceType(),
+                notification.getResourceId(),
+                notification.isRead(),
+                notification.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/dduru/gildongmu/notification/dto/response/NotificationInfo.java
+++ b/src/main/java/com/dduru/gildongmu/notification/dto/response/NotificationInfo.java
@@ -4,16 +4,25 @@ import com.dduru.gildongmu.notification.domain.Notification;
 import com.dduru.gildongmu.notification.domain.enums.NotificationType;
 import com.dduru.gildongmu.notification.domain.enums.ResourceType;
 import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
 
+@Schema(description = "알림 단건 정보")
 public record NotificationInfo(
+        @Schema(description = "알림 ID", example = "1")
         Long notificationId,
+        @Schema(description = "알림 타입", example = "MATCH_APPLIED")
         NotificationType type,
+        @Schema(description = "알림 본문", example = "[일본 여행 모집]에 새로운 참여 신청이 도착했습니다.")
         String body,
+        @Schema(description = "연결된 리소스 타입", example = "MATCH")
         ResourceType resourceType,
+        @Schema(description = "연결된 리소스 ID", example = "10")
         Long resourceId,
+        @Schema(description = "읽음 여부", example = "false")
         boolean isRead,
+        @Schema(description = "생성 일시", example = "2025-07-01T10:00:00")
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
         LocalDateTime createdAt
 ) {

--- a/src/main/java/com/dduru/gildongmu/notification/dto/response/NotificationListResponse.java
+++ b/src/main/java/com/dduru/gildongmu/notification/dto/response/NotificationListResponse.java
@@ -1,0 +1,24 @@
+package com.dduru.gildongmu.notification.dto.response;
+
+import com.dduru.gildongmu.notification.domain.Notification;
+
+import java.util.List;
+
+public record NotificationListResponse(
+        List<NotificationInfo> notifications,
+        Long nextCursor,
+        boolean hasNext,
+        int size
+) {
+    public static NotificationListResponse of(List<Notification> fetched, int requestedSize) {
+        boolean hasNext = fetched.size() > requestedSize;
+        List<Notification> items = hasNext ? fetched.subList(0, requestedSize) : fetched;
+        Long nextCursor = hasNext ? items.get(items.size() - 1).getId() : null;
+        return new NotificationListResponse(
+                items.stream().map(NotificationInfo::from).toList(),
+                nextCursor,
+                hasNext,
+                items.size()
+        );
+    }
+}

--- a/src/main/java/com/dduru/gildongmu/notification/dto/response/NotificationListResponse.java
+++ b/src/main/java/com/dduru/gildongmu/notification/dto/response/NotificationListResponse.java
@@ -1,13 +1,19 @@
 package com.dduru.gildongmu.notification.dto.response;
 
 import com.dduru.gildongmu.notification.domain.Notification;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.List;
 
+@Schema(description = "알림 목록 조회 응답")
 public record NotificationListResponse(
+        @Schema(description = "알림 목록")
         List<NotificationInfo> notifications,
+        @Schema(description = "다음 페이지 커서 (마지막 페이지면 null)", example = "41")
         Long nextCursor,
+        @Schema(description = "다음 페이지 존재 여부", example = "true")
         boolean hasNext,
+        @Schema(description = "현재 페이지 알림 수", example = "20")
         int size
 ) {
     public static NotificationListResponse of(List<Notification> fetched, int requestedSize) {

--- a/src/main/java/com/dduru/gildongmu/notification/dto/response/NotificationReadResponse.java
+++ b/src/main/java/com/dduru/gildongmu/notification/dto/response/NotificationReadResponse.java
@@ -1,0 +1,8 @@
+package com.dduru.gildongmu.notification.dto.response;
+
+public record NotificationReadResponse(boolean success) {
+
+    public static NotificationReadResponse ok() {
+        return new NotificationReadResponse(true);
+    }
+}

--- a/src/main/java/com/dduru/gildongmu/notification/dto/response/NotificationReadResponse.java
+++ b/src/main/java/com/dduru/gildongmu/notification/dto/response/NotificationReadResponse.java
@@ -1,6 +1,12 @@
 package com.dduru.gildongmu.notification.dto.response;
 
-public record NotificationReadResponse(boolean success) {
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "알림 읽음 처리 응답")
+public record NotificationReadResponse(
+        @Schema(description = "처리 성공 여부", example = "true")
+        boolean success
+) {
 
     public static NotificationReadResponse ok() {
         return new NotificationReadResponse(true);

--- a/src/main/java/com/dduru/gildongmu/notification/dto/response/UnreadCountResponse.java
+++ b/src/main/java/com/dduru/gildongmu/notification/dto/response/UnreadCountResponse.java
@@ -1,4 +1,10 @@
 package com.dduru.gildongmu.notification.dto.response;
 
-public record UnreadCountResponse(long unreadCount) {
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "안 읽은 알림 개수 응답")
+public record UnreadCountResponse(
+        @Schema(description = "안 읽은 알림 개수", example = "3")
+        long unreadCount
+) {
 }

--- a/src/main/java/com/dduru/gildongmu/notification/dto/response/UnreadCountResponse.java
+++ b/src/main/java/com/dduru/gildongmu/notification/dto/response/UnreadCountResponse.java
@@ -1,0 +1,4 @@
+package com.dduru.gildongmu.notification.dto.response;
+
+public record UnreadCountResponse(long unreadCount) {
+}

--- a/src/main/java/com/dduru/gildongmu/notification/exception/NotificationAccessDeniedException.java
+++ b/src/main/java/com/dduru/gildongmu/notification/exception/NotificationAccessDeniedException.java
@@ -1,0 +1,11 @@
+package com.dduru.gildongmu.notification.exception;
+
+import com.dduru.gildongmu.common.exception.BusinessException;
+import com.dduru.gildongmu.common.exception.ErrorCode;
+
+public class NotificationAccessDeniedException extends BusinessException {
+
+    public NotificationAccessDeniedException() {
+        super(ErrorCode.NOTIFICATION_ACCESS_DENIED);
+    }
+}

--- a/src/main/java/com/dduru/gildongmu/notification/exception/NotificationNotFoundException.java
+++ b/src/main/java/com/dduru/gildongmu/notification/exception/NotificationNotFoundException.java
@@ -1,0 +1,11 @@
+package com.dduru.gildongmu.notification.exception;
+
+import com.dduru.gildongmu.common.exception.BusinessException;
+import com.dduru.gildongmu.common.exception.ErrorCode;
+
+public class NotificationNotFoundException extends BusinessException {
+
+    public NotificationNotFoundException() {
+        super(ErrorCode.NOTIFICATION_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/dduru/gildongmu/notification/listener/NotificationEventListener.java
+++ b/src/main/java/com/dduru/gildongmu/notification/listener/NotificationEventListener.java
@@ -65,7 +65,7 @@ public class NotificationEventListener {
             );
             notificationRepository.save(notification);
         } catch (Exception e) {
-            log.error("MATCH_APPROVED 알림 저장 실패 - participationId={}", event.participationId(), e);
+            log.error("MATCH_APPROVED 알림 저장 실패 - journeyId={}", event.journeyId(), e);
         }
     }
 

--- a/src/main/java/com/dduru/gildongmu/notification/listener/NotificationEventListener.java
+++ b/src/main/java/com/dduru/gildongmu/notification/listener/NotificationEventListener.java
@@ -1,0 +1,191 @@
+package com.dduru.gildongmu.notification.listener;
+
+import com.dduru.gildongmu.journey.event.JourneyNoticeCreatedEvent;
+import com.dduru.gildongmu.journey.event.ScheduleCanceledEvent;
+import com.dduru.gildongmu.journey.event.ScheduleCreatedEvent;
+import com.dduru.gildongmu.journey.event.ScheduleUpdatedEvent;
+import com.dduru.gildongmu.journey.repository.JourneyMemberRepository;
+import com.dduru.gildongmu.notification.domain.Notification;
+import com.dduru.gildongmu.notification.domain.enums.NotificationType;
+import com.dduru.gildongmu.notification.domain.enums.ResourceType;
+import com.dduru.gildongmu.notification.repository.NotificationRepository;
+import com.dduru.gildongmu.participation.event.MatchAppliedEvent;
+import com.dduru.gildongmu.participation.event.MatchApprovedEvent;
+import com.dduru.gildongmu.participation.event.MatchRejectedEvent;
+import com.dduru.gildongmu.user.domain.User;
+import com.dduru.gildongmu.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NotificationEventListener {
+
+    private final NotificationRepository notificationRepository;
+    private final JourneyMemberRepository journeyMemberRepository;
+    private final UserRepository userRepository;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void handleMatchApplied(MatchAppliedEvent event) {
+        try {
+            User recipient = userRepository.getReferenceById(event.recipientUserId());
+            Notification notification = Notification.create(
+                    recipient,
+                    NotificationType.MATCH_APPLIED,
+                    "[" + event.postTitle() + "]에 새로운 참여 신청이 도착했습니다.",
+                    ResourceType.MATCH,
+                    event.participationId()
+            );
+            notificationRepository.save(notification);
+        } catch (Exception e) {
+            log.error("MATCH_APPLIED 알림 저장 실패 - participationId={}", event.participationId(), e);
+        }
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void handleMatchApproved(MatchApprovedEvent event) {
+        try {
+            User recipient = userRepository.getReferenceById(event.applicantUserId());
+            Notification notification = Notification.create(
+                    recipient,
+                    NotificationType.MATCH_APPROVED,
+                    "[" + event.journeyTitle() + "] 여행 참여가 승인되었습니다.",
+                    ResourceType.JOURNEY,
+                    event.journeyId()
+            );
+            notificationRepository.save(notification);
+        } catch (Exception e) {
+            log.error("MATCH_APPROVED 알림 저장 실패 - participationId={}", event.participationId(), e);
+        }
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void handleMatchRejected(MatchRejectedEvent event) {
+        try {
+            User recipient = userRepository.getReferenceById(event.applicantUserId());
+            Notification notification = Notification.create(
+                    recipient,
+                    NotificationType.MATCH_REJECTED,
+                    "참여 신청이 검토되었으나 함께하기 어렵게 되었습니다.",
+                    ResourceType.MATCH,
+                    event.participationId()
+            );
+            notificationRepository.save(notification);
+        } catch (Exception e) {
+            log.error("MATCH_REJECTED 알림 저장 실패 - participationId={}", event.participationId(), e);
+        }
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void handleJourneyNoticeCreated(JourneyNoticeCreatedEvent event) {
+        try {
+            // 동일 게시글에 이미 공지 알림이 발송된 경우 재발송하지 않음
+            if (notificationRepository.existsByTypeAndResourceTypeAndResourceId(
+                    NotificationType.JOURNEY_NOTICE, ResourceType.JOURNEY_POST, event.journeyPostId())) {
+                return;
+            }
+
+            List<Long> recipientIds = journeyMemberRepository
+                    .findActiveUserIdsByJourneyIdExcludingUser(event.journeyId(), event.actorUserId());
+            if (recipientIds.isEmpty()) {
+                return;
+            }
+
+            String body = "[" + event.journeyTitle() + "] 새 공지가 등록되었습니다.";
+            List<Notification> notifications = recipientIds.stream()
+                    .map(id -> Notification.create(
+                            userRepository.getReferenceById(id),
+                            NotificationType.JOURNEY_NOTICE,
+                            body,
+                            ResourceType.JOURNEY_POST,
+                            event.journeyPostId()
+                    ))
+                    .toList();
+            notificationRepository.saveAll(notifications);
+        } catch (Exception e) {
+            log.error("JOURNEY_NOTICE 알림 저장 실패 - journeyPostId={}", event.journeyPostId(), e);
+        }
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void handleScheduleCreated(ScheduleCreatedEvent event) {
+        try {
+            saveScheduleNotifications(
+                    event.journeyId(), event.actorUserId(),
+                    NotificationType.SCHEDULE_CREATED,
+                    "[" + event.scheduleTitle() + "] 일정이 추가되었습니다.",
+                    event.scheduleId()
+            );
+        } catch (Exception e) {
+            log.error("SCHEDULE_CREATED 알림 저장 실패 - scheduleId={}", event.scheduleId(), e);
+        }
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void handleScheduleUpdated(ScheduleUpdatedEvent event) {
+        try {
+            saveScheduleNotifications(
+                    event.journeyId(), event.actorUserId(),
+                    NotificationType.SCHEDULE_UPDATED,
+                    "[" + event.scheduleTitle() + "] 일정이 변경되었습니다.",
+                    event.scheduleId()
+            );
+        } catch (Exception e) {
+            log.error("SCHEDULE_UPDATED 알림 저장 실패 - scheduleId={}", event.scheduleId(), e);
+        }
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void handleScheduleCanceled(ScheduleCanceledEvent event) {
+        try {
+            saveScheduleNotifications(
+                    event.journeyId(), event.actorUserId(),
+                    NotificationType.SCHEDULE_CANCELED,
+                    "[" + event.scheduleTitle() + "] 일정이 취소되었습니다.",
+                    event.scheduleId()
+            );
+        } catch (Exception e) {
+            log.error("SCHEDULE_CANCELED 알림 저장 실패 - scheduleId={}", event.scheduleId(), e);
+        }
+    }
+
+    private void saveScheduleNotifications(
+            Long journeyId,
+            Long actorUserId,
+            NotificationType type,
+            String body,
+            Long scheduleId
+    ) {
+        List<Long> recipientIds = journeyMemberRepository
+                .findActiveUserIdsByJourneyIdExcludingUser(journeyId, actorUserId);
+        if (recipientIds.isEmpty()) {
+            return;
+        }
+
+        List<Notification> notifications = recipientIds.stream()
+                .map(id -> Notification.create(
+                        userRepository.getReferenceById(id),
+                        type,
+                        body,
+                        ResourceType.SCHEDULE,
+                        scheduleId
+                ))
+                .toList();
+        notificationRepository.saveAll(notifications);
+    }
+}

--- a/src/main/java/com/dduru/gildongmu/notification/listener/NotificationEventListener.java
+++ b/src/main/java/com/dduru/gildongmu/notification/listener/NotificationEventListener.java
@@ -11,7 +11,6 @@ import com.dduru.gildongmu.notification.domain.enums.ResourceType;
 import com.dduru.gildongmu.notification.repository.NotificationRepository;
 import com.dduru.gildongmu.participation.event.MatchAppliedEvent;
 import com.dduru.gildongmu.participation.event.MatchApprovedEvent;
-import com.dduru.gildongmu.participation.event.MatchRejectedEvent;
 import com.dduru.gildongmu.user.domain.User;
 import com.dduru.gildongmu.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -38,14 +37,13 @@ public class NotificationEventListener {
     public void handleMatchApplied(MatchAppliedEvent event) {
         try {
             User recipient = userRepository.getReferenceById(event.recipientUserId());
-            Notification notification = Notification.create(
+            notificationRepository.save(Notification.create(
                     recipient,
                     NotificationType.MATCH_APPLIED,
-                    "[" + event.postTitle() + "]에 새로운 참여 신청이 도착했습니다.",
+                    event.actorNickname() + " 님이 매칭을 신청했습니다.",
                     ResourceType.MATCH,
                     event.participationId()
-            );
-            notificationRepository.save(notification);
+            ));
         } catch (Exception e) {
             log.error("MATCH_APPLIED 알림 저장 실패 - participationId={}", event.participationId(), e);
         }
@@ -56,34 +54,15 @@ public class NotificationEventListener {
     public void handleMatchApproved(MatchApprovedEvent event) {
         try {
             User recipient = userRepository.getReferenceById(event.applicantUserId());
-            Notification notification = Notification.create(
+            notificationRepository.save(Notification.create(
                     recipient,
                     NotificationType.MATCH_APPROVED,
-                    "[" + event.journeyTitle() + "] 여행 참여가 승인되었습니다.",
+                    event.approverNickname() + " 님과 매칭이 성사되었습니다.",
                     ResourceType.JOURNEY,
                     event.journeyId()
-            );
-            notificationRepository.save(notification);
+            ));
         } catch (Exception e) {
             log.error("MATCH_APPROVED 알림 저장 실패 - journeyId={}", event.journeyId(), e);
-        }
-    }
-
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void handleMatchRejected(MatchRejectedEvent event) {
-        try {
-            User recipient = userRepository.getReferenceById(event.applicantUserId());
-            Notification notification = Notification.create(
-                    recipient,
-                    NotificationType.MATCH_REJECTED,
-                    "참여 신청이 검토되었으나 함께하기 어렵게 되었습니다.",
-                    ResourceType.MATCH,
-                    event.participationId()
-            );
-            notificationRepository.save(notification);
-        } catch (Exception e) {
-            log.error("MATCH_REJECTED 알림 저장 실패 - participationId={}", event.participationId(), e);
         }
     }
 
@@ -97,7 +76,7 @@ public class NotificationEventListener {
                 return;
             }
 
-            String body = "[" + event.journeyTitle() + "] 새 공지가 등록되었습니다.";
+            String body = "[" + event.journeyTitle() + "] 에 공지가 등록되었습니다.";
             List<Notification> notifications = recipientIds.stream()
                     .map(id -> Notification.create(
                             userRepository.getReferenceById(id),
@@ -117,12 +96,8 @@ public class NotificationEventListener {
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void handleScheduleCreated(ScheduleCreatedEvent event) {
         try {
-            saveScheduleNotifications(
-                    event.journeyId(), event.actorUserId(),
-                    NotificationType.SCHEDULE_CREATED,
-                    "[" + event.scheduleTitle() + "] 일정이 추가되었습니다.",
-                    event.scheduleId()
-            );
+            saveScheduleNotifications(event.journeyId(), event.actorUserId(),
+                    NotificationType.SCHEDULE_CREATED, "여행 일정이 생성되었습니다.", event.scheduleId());
         } catch (Exception e) {
             log.error("SCHEDULE_CREATED 알림 저장 실패 - scheduleId={}", event.scheduleId(), e);
         }
@@ -132,12 +107,8 @@ public class NotificationEventListener {
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void handleScheduleUpdated(ScheduleUpdatedEvent event) {
         try {
-            saveScheduleNotifications(
-                    event.journeyId(), event.actorUserId(),
-                    NotificationType.SCHEDULE_UPDATED,
-                    "[" + event.scheduleTitle() + "] 일정이 변경되었습니다.",
-                    event.scheduleId()
-            );
+            saveScheduleNotifications(event.journeyId(), event.actorUserId(),
+                    NotificationType.SCHEDULE_UPDATED, "여행 일정이 변경되었습니다. 확인해주세요.", event.scheduleId());
         } catch (Exception e) {
             log.error("SCHEDULE_UPDATED 알림 저장 실패 - scheduleId={}", event.scheduleId(), e);
         }
@@ -147,24 +118,15 @@ public class NotificationEventListener {
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void handleScheduleCanceled(ScheduleCanceledEvent event) {
         try {
-            saveScheduleNotifications(
-                    event.journeyId(), event.actorUserId(),
-                    NotificationType.SCHEDULE_CANCELED,
-                    "[" + event.scheduleTitle() + "] 일정이 취소되었습니다.",
-                    event.scheduleId()
-            );
+            saveScheduleNotifications(event.journeyId(), event.actorUserId(),
+                    NotificationType.SCHEDULE_CANCELED, "여행 일정이 취소되었습니다.", event.scheduleId());
         } catch (Exception e) {
             log.error("SCHEDULE_CANCELED 알림 저장 실패 - scheduleId={}", event.scheduleId(), e);
         }
     }
 
-    private void saveScheduleNotifications(
-            Long journeyId,
-            Long actorUserId,
-            NotificationType type,
-            String body,
-            Long scheduleId
-    ) {
+    private void saveScheduleNotifications(Long journeyId, Long actorUserId,
+                                           NotificationType type, String body, Long scheduleId) {
         List<Long> recipientIds = journeyMemberRepository
                 .findActiveUserIdsByJourneyIdExcludingUser(journeyId, actorUserId);
         if (recipientIds.isEmpty()) {
@@ -174,10 +136,7 @@ public class NotificationEventListener {
         List<Notification> notifications = recipientIds.stream()
                 .map(id -> Notification.create(
                         userRepository.getReferenceById(id),
-                        type,
-                        body,
-                        ResourceType.SCHEDULE,
-                        scheduleId
+                        type, body, ResourceType.SCHEDULE, scheduleId
                 ))
                 .toList();
         notificationRepository.saveAll(notifications);

--- a/src/main/java/com/dduru/gildongmu/notification/listener/NotificationEventListener.java
+++ b/src/main/java/com/dduru/gildongmu/notification/listener/NotificationEventListener.java
@@ -8,16 +8,13 @@ import com.dduru.gildongmu.journey.repository.JourneyMemberRepository;
 import com.dduru.gildongmu.notification.domain.Notification;
 import com.dduru.gildongmu.notification.domain.enums.NotificationType;
 import com.dduru.gildongmu.notification.domain.enums.ResourceType;
-import com.dduru.gildongmu.notification.repository.NotificationRepository;
+import com.dduru.gildongmu.notification.service.NotificationPersistService;
 import com.dduru.gildongmu.participation.event.MatchAppliedEvent;
 import com.dduru.gildongmu.participation.event.MatchApprovedEvent;
-import com.dduru.gildongmu.user.domain.User;
 import com.dduru.gildongmu.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Propagation;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
@@ -28,17 +25,15 @@ import java.util.List;
 @RequiredArgsConstructor
 public class NotificationEventListener {
 
-    private final NotificationRepository notificationRepository;
+    private final NotificationPersistService notificationPersistService;
     private final JourneyMemberRepository journeyMemberRepository;
     private final UserRepository userRepository;
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void handleMatchApplied(MatchAppliedEvent event) {
         try {
-            User recipient = userRepository.getReferenceById(event.recipientUserId());
-            notificationRepository.save(Notification.create(
-                    recipient,
+            notificationPersistService.save(Notification.create(
+                    userRepository.getReferenceById(event.recipientUserId()),
                     NotificationType.MATCH_APPLIED,
                     event.actorNickname() + " 님이 매칭을 신청했습니다.",
                     ResourceType.MATCH,
@@ -50,12 +45,10 @@ public class NotificationEventListener {
     }
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void handleMatchApproved(MatchApprovedEvent event) {
         try {
-            User recipient = userRepository.getReferenceById(event.applicantUserId());
-            notificationRepository.save(Notification.create(
-                    recipient,
+            notificationPersistService.save(Notification.create(
+                    userRepository.getReferenceById(event.applicantUserId()),
                     NotificationType.MATCH_APPROVED,
                     event.approverNickname() + " 님과 매칭이 성사되었습니다.",
                     ResourceType.JOURNEY,
@@ -67,14 +60,11 @@ public class NotificationEventListener {
     }
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void handleJourneyNoticeCreated(JourneyNoticeCreatedEvent event) {
         try {
             List<Long> recipientIds = journeyMemberRepository
                     .findActiveUserIdsByJourneyIdExcludingUser(event.journeyId(), event.actorUserId());
-            if (recipientIds.isEmpty()) {
-                return;
-            }
+            if (recipientIds.isEmpty()) return;
 
             String body = "[" + event.journeyTitle() + "] 에 공지가 등록되었습니다.";
             List<Notification> notifications = recipientIds.stream()
@@ -86,14 +76,13 @@ public class NotificationEventListener {
                             event.journeyPostId()
                     ))
                     .toList();
-            notificationRepository.saveAll(notifications);
+            notificationPersistService.saveAll(notifications);
         } catch (Exception e) {
             log.error("JOURNEY_NOTICE 알림 저장 실패 - journeyPostId={}", event.journeyPostId(), e);
         }
     }
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void handleScheduleCreated(ScheduleCreatedEvent event) {
         try {
             saveScheduleNotifications(event.journeyId(), event.actorUserId(),
@@ -104,7 +93,6 @@ public class NotificationEventListener {
     }
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void handleScheduleUpdated(ScheduleUpdatedEvent event) {
         try {
             saveScheduleNotifications(event.journeyId(), event.actorUserId(),
@@ -115,7 +103,6 @@ public class NotificationEventListener {
     }
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void handleScheduleCanceled(ScheduleCanceledEvent event) {
         try {
             saveScheduleNotifications(event.journeyId(), event.actorUserId(),
@@ -129,9 +116,7 @@ public class NotificationEventListener {
                                            NotificationType type, String body, Long scheduleId) {
         List<Long> recipientIds = journeyMemberRepository
                 .findActiveUserIdsByJourneyIdExcludingUser(journeyId, actorUserId);
-        if (recipientIds.isEmpty()) {
-            return;
-        }
+        if (recipientIds.isEmpty()) return;
 
         List<Notification> notifications = recipientIds.stream()
                 .map(id -> Notification.create(
@@ -139,6 +124,6 @@ public class NotificationEventListener {
                         type, body, ResourceType.SCHEDULE, scheduleId
                 ))
                 .toList();
-        notificationRepository.saveAll(notifications);
+        notificationPersistService.saveAll(notifications);
     }
 }

--- a/src/main/java/com/dduru/gildongmu/notification/listener/NotificationEventListener.java
+++ b/src/main/java/com/dduru/gildongmu/notification/listener/NotificationEventListener.java
@@ -91,12 +91,6 @@ public class NotificationEventListener {
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void handleJourneyNoticeCreated(JourneyNoticeCreatedEvent event) {
         try {
-            // 동일 게시글에 이미 공지 알림이 발송된 경우 재발송하지 않음
-            if (notificationRepository.existsByTypeAndResourceTypeAndResourceId(
-                    NotificationType.JOURNEY_NOTICE, ResourceType.JOURNEY_POST, event.journeyPostId())) {
-                return;
-            }
-
             List<Long> recipientIds = journeyMemberRepository
                     .findActiveUserIdsByJourneyIdExcludingUser(event.journeyId(), event.actorUserId());
             if (recipientIds.isEmpty()) {

--- a/src/main/java/com/dduru/gildongmu/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/dduru/gildongmu/notification/repository/NotificationRepository.java
@@ -1,0 +1,53 @@
+package com.dduru.gildongmu.notification.repository;
+
+import com.dduru.gildongmu.notification.domain.Notification;
+import com.dduru.gildongmu.notification.domain.enums.NotificationType;
+import com.dduru.gildongmu.notification.domain.enums.ResourceType;
+import com.dduru.gildongmu.notification.exception.NotificationNotFoundException;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+    @Query("""
+            SELECT n FROM Notification n
+            WHERE n.recipient.id = :userId
+              AND (:cursor IS NULL OR n.id < :cursor)
+            ORDER BY n.id DESC
+            """)
+    List<Notification> findByRecipientIdWithCursor(
+            @Param("userId") Long userId,
+            @Param("cursor") Long cursor,
+            Pageable pageable
+    );
+
+    long countByRecipient_IdAndReadFalse(Long recipientId);
+
+    Optional<Notification> findByIdAndRecipient_Id(Long id, Long recipientId);
+
+    @Modifying
+    @Query("""
+            UPDATE Notification n
+            SET n.read = true, n.readAt = :now
+            WHERE n.recipient.id = :userId AND n.read = false
+            """)
+    int markAllAsReadByRecipientId(@Param("userId") Long userId, @Param("now") LocalDateTime now);
+
+    boolean existsByTypeAndResourceTypeAndResourceId(
+            NotificationType type,
+            ResourceType resourceType,
+            Long resourceId
+    );
+
+    default Notification getByIdAndRecipientIdOrThrow(Long id, Long recipientId) {
+        return findByIdAndRecipient_Id(id, recipientId)
+                .orElseThrow(NotificationNotFoundException::new);
+    }
+}

--- a/src/main/java/com/dduru/gildongmu/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/dduru/gildongmu/notification/repository/NotificationRepository.java
@@ -1,8 +1,6 @@
 package com.dduru.gildongmu.notification.repository;
 
 import com.dduru.gildongmu.notification.domain.Notification;
-import com.dduru.gildongmu.notification.domain.enums.NotificationType;
-import com.dduru.gildongmu.notification.domain.enums.ResourceType;
 import com.dduru.gildongmu.notification.exception.NotificationNotFoundException;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -39,12 +37,6 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
             WHERE n.recipient.id = :userId AND n.read = false
             """)
     int markAllAsReadByRecipientId(@Param("userId") Long userId, @Param("now") LocalDateTime now);
-
-    boolean existsByTypeAndResourceTypeAndResourceId(
-            NotificationType type,
-            ResourceType resourceType,
-            Long resourceId
-    );
 
     default Notification getByIdAndRecipientIdOrThrow(Long id, Long recipientId) {
         return findByIdAndRecipient_Id(id, recipientId)

--- a/src/main/java/com/dduru/gildongmu/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/dduru/gildongmu/notification/repository/NotificationRepository.java
@@ -1,7 +1,6 @@
 package com.dduru.gildongmu.notification.repository;
 
 import com.dduru.gildongmu.notification.domain.Notification;
-import com.dduru.gildongmu.notification.exception.NotificationNotFoundException;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -10,7 +9,6 @@ import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
 
@@ -28,18 +26,11 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
 
     long countByRecipient_IdAndReadFalse(Long recipientId);
 
-    Optional<Notification> findByIdAndRecipient_Id(Long id, Long recipientId);
-
-    @Modifying
+    @Modifying(clearAutomatically = true)
     @Query("""
             UPDATE Notification n
             SET n.read = true, n.readAt = :now
             WHERE n.recipient.id = :userId AND n.read = false
             """)
     int markAllAsReadByRecipientId(@Param("userId") Long userId, @Param("now") LocalDateTime now);
-
-    default Notification getByIdAndRecipientIdOrThrow(Long id, Long recipientId) {
-        return findByIdAndRecipient_Id(id, recipientId)
-                .orElseThrow(NotificationNotFoundException::new);
-    }
 }

--- a/src/main/java/com/dduru/gildongmu/notification/service/NotificationPersistService.java
+++ b/src/main/java/com/dduru/gildongmu/notification/service/NotificationPersistService.java
@@ -1,0 +1,26 @@
+package com.dduru.gildongmu.notification.service;
+
+import com.dduru.gildongmu.notification.domain.Notification;
+import com.dduru.gildongmu.notification.repository.NotificationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(propagation = Propagation.REQUIRES_NEW)
+public class NotificationPersistService {
+
+    private final NotificationRepository notificationRepository;
+
+    public void save(Notification notification) {
+        notificationRepository.save(notification);
+    }
+
+    public void saveAll(List<Notification> notifications) {
+        notificationRepository.saveAll(notifications);
+    }
+}

--- a/src/main/java/com/dduru/gildongmu/notification/service/NotificationQueryService.java
+++ b/src/main/java/com/dduru/gildongmu/notification/service/NotificationQueryService.java
@@ -1,0 +1,33 @@
+package com.dduru.gildongmu.notification.service;
+
+import com.dduru.gildongmu.notification.domain.Notification;
+import com.dduru.gildongmu.notification.dto.response.NotificationListResponse;
+import com.dduru.gildongmu.notification.dto.response.UnreadCountResponse;
+import com.dduru.gildongmu.notification.repository.NotificationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class NotificationQueryService {
+
+    private final NotificationRepository notificationRepository;
+
+    public NotificationListResponse getNotifications(Long userId, Long cursor, int size) {
+        List<Notification> fetched = notificationRepository.findByRecipientIdWithCursor(
+                userId, cursor, PageRequest.of(0, size + 1)
+        );
+        return NotificationListResponse.of(fetched, size);
+    }
+
+    public UnreadCountResponse getUnreadCount(Long userId) {
+        long count = notificationRepository.countByRecipient_IdAndReadFalse(userId);
+        return new UnreadCountResponse(count);
+    }
+}

--- a/src/main/java/com/dduru/gildongmu/notification/service/NotificationService.java
+++ b/src/main/java/com/dduru/gildongmu/notification/service/NotificationService.java
@@ -1,0 +1,40 @@
+package com.dduru.gildongmu.notification.service;
+
+import com.dduru.gildongmu.common.time.TimeProvider;
+import com.dduru.gildongmu.notification.domain.Notification;
+import com.dduru.gildongmu.notification.dto.response.NotificationReadResponse;
+import com.dduru.gildongmu.notification.exception.NotificationAccessDeniedException;
+import com.dduru.gildongmu.notification.exception.NotificationNotFoundException;
+import com.dduru.gildongmu.notification.repository.NotificationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class NotificationService {
+
+    private final NotificationRepository notificationRepository;
+    private final TimeProvider timeProvider;
+
+    public NotificationReadResponse markAsRead(Long userId, Long notificationId) {
+        Notification notification = notificationRepository.findById(notificationId)
+                .orElseThrow(NotificationNotFoundException::new);
+
+        if (!notification.getRecipient().getId().equals(userId)) {
+            throw new NotificationAccessDeniedException();
+        }
+
+        if (!notification.isRead()) {
+            notification.markAsRead(timeProvider.now());
+        }
+
+        return NotificationReadResponse.ok();
+    }
+
+    public NotificationReadResponse markAllAsRead(Long userId) {
+        notificationRepository.markAllAsReadByRecipientId(userId, timeProvider.now());
+        return NotificationReadResponse.ok();
+    }
+}

--- a/src/main/java/com/dduru/gildongmu/participation/event/MatchAppliedEvent.java
+++ b/src/main/java/com/dduru/gildongmu/participation/event/MatchAppliedEvent.java
@@ -1,0 +1,9 @@
+package com.dduru.gildongmu.participation.event;
+
+public record MatchAppliedEvent(
+        Long participationId,
+        Long actorUserId,
+        Long recipientUserId,
+        String postTitle
+) {
+}

--- a/src/main/java/com/dduru/gildongmu/participation/event/MatchAppliedEvent.java
+++ b/src/main/java/com/dduru/gildongmu/participation/event/MatchAppliedEvent.java
@@ -4,6 +4,7 @@ public record MatchAppliedEvent(
         Long participationId,
         Long actorUserId,
         Long recipientUserId,
-        String postTitle
+        String postTitle,
+        String actorNickname
 ) {
 }

--- a/src/main/java/com/dduru/gildongmu/participation/event/MatchApprovedEvent.java
+++ b/src/main/java/com/dduru/gildongmu/participation/event/MatchApprovedEvent.java
@@ -1,0 +1,9 @@
+package com.dduru.gildongmu.participation.event;
+
+public record MatchApprovedEvent(
+        Long participationId,
+        Long applicantUserId,
+        Long journeyId,
+        String journeyTitle
+) {
+}

--- a/src/main/java/com/dduru/gildongmu/participation/event/MatchApprovedEvent.java
+++ b/src/main/java/com/dduru/gildongmu/participation/event/MatchApprovedEvent.java
@@ -4,6 +4,7 @@ public record MatchApprovedEvent(
         Long participationId,
         Long applicantUserId,
         Long journeyId,
-        String journeyTitle
+        String journeyTitle,
+        String approverNickname
 ) {
 }

--- a/src/main/java/com/dduru/gildongmu/participation/event/MatchRejectedEvent.java
+++ b/src/main/java/com/dduru/gildongmu/participation/event/MatchRejectedEvent.java
@@ -1,7 +1,0 @@
-package com.dduru.gildongmu.participation.event;
-
-public record MatchRejectedEvent(
-        Long participationId,
-        Long applicantUserId
-) {
-}

--- a/src/main/java/com/dduru/gildongmu/participation/event/MatchRejectedEvent.java
+++ b/src/main/java/com/dduru/gildongmu/participation/event/MatchRejectedEvent.java
@@ -1,0 +1,7 @@
+package com.dduru.gildongmu.participation.event;
+
+public record MatchRejectedEvent(
+        Long participationId,
+        Long applicantUserId
+) {
+}

--- a/src/main/java/com/dduru/gildongmu/participation/service/ParticipationApplicantService.java
+++ b/src/main/java/com/dduru/gildongmu/participation/service/ParticipationApplicantService.java
@@ -21,6 +21,7 @@ import com.dduru.gildongmu.post.domain.Post;
 import com.dduru.gildongmu.post.dto.response.MyParticipationStatus;
 import com.dduru.gildongmu.post.dto.response.ParticipantInfo;
 import com.dduru.gildongmu.post.repository.PostRepository;
+import com.dduru.gildongmu.profile.repository.ProfileRepository;
 import com.dduru.gildongmu.profile.utils.ProfileImageResolver;
 import com.dduru.gildongmu.user.domain.User;
 import com.dduru.gildongmu.user.repository.UserRepository;
@@ -49,6 +50,7 @@ public class ParticipationApplicantService {
     private final UserRepository userRepository;
     private final ChatRoomRepository chatRoomRepository;
     private final ProfileImageResolver profileImageResolver;
+    private final ProfileRepository profileRepository;
     private final JourneyMemberRepository journeyMemberRepository;
     private final ApplicationEventPublisher eventPublisher;
 
@@ -61,8 +63,11 @@ public class ParticipationApplicantService {
         Participation participation = Participation.createParticipation(post, applicant, request.message());
         Participation saved = saveParticipationOrThrowDuplicate(participation, postId, userId);
 
+        String actorNickname = profileRepository.findByUser_Id(userId)
+                .map(p -> p.getNickname())
+                .orElse("알 수 없음");
         eventPublisher.publishEvent(new MatchAppliedEvent(
-                saved.getId(), userId, post.getUser().getId(), post.getTitle()
+                saved.getId(), userId, post.getUser().getId(), post.getTitle(), actorNickname
         ));
 
         log.info("참여신청 완료 - participationId: {}, postId: {}, userId: {}", saved.getId(), postId, userId);

--- a/src/main/java/com/dduru/gildongmu/participation/service/ParticipationApplicantService.java
+++ b/src/main/java/com/dduru/gildongmu/participation/service/ParticipationApplicantService.java
@@ -12,6 +12,7 @@ import com.dduru.gildongmu.participation.dto.request.ParticipationRequest;
 import com.dduru.gildongmu.participation.dto.response.ChatRoomIds;
 import com.dduru.gildongmu.participation.dto.response.MyParticipationResponse;
 import com.dduru.gildongmu.participation.dto.response.ParticipationCreateResponse;
+import com.dduru.gildongmu.participation.event.MatchAppliedEvent;
 import com.dduru.gildongmu.participation.exception.DuplicateParticipationException;
 import com.dduru.gildongmu.participation.exception.ParticipationApplicantAccessDeniedException;
 import com.dduru.gildongmu.participation.exception.SelfParticipationNotAllowedException;
@@ -25,6 +26,7 @@ import com.dduru.gildongmu.user.domain.User;
 import com.dduru.gildongmu.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -48,6 +50,7 @@ public class ParticipationApplicantService {
     private final ChatRoomRepository chatRoomRepository;
     private final ProfileImageResolver profileImageResolver;
     private final JourneyMemberRepository journeyMemberRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     public ParticipationCreateResponse participate(Long userId, Long postId, ParticipationRequest request) {
         Post post = postRepository.getActiveByIdWithLockOrThrow(postId);
@@ -57,6 +60,10 @@ public class ParticipationApplicantService {
 
         Participation participation = Participation.createParticipation(post, applicant, request.message());
         Participation saved = saveParticipationOrThrowDuplicate(participation, postId, userId);
+
+        eventPublisher.publishEvent(new MatchAppliedEvent(
+                saved.getId(), userId, post.getUser().getId(), post.getTitle()
+        ));
 
         log.info("참여신청 완료 - participationId: {}, postId: {}, userId: {}", saved.getId(), postId, userId);
         return new ParticipationCreateResponse(saved.getId(), saved.getStatus());

--- a/src/main/java/com/dduru/gildongmu/participation/service/ParticipationCommandService.java
+++ b/src/main/java/com/dduru/gildongmu/participation/service/ParticipationCommandService.java
@@ -14,6 +14,8 @@ import com.dduru.gildongmu.participation.dto.request.ParticipationRetrieveReques
 import com.dduru.gildongmu.participation.dto.response.ParticipationApproveResponse;
 import com.dduru.gildongmu.participation.dto.response.ParticipationContactResponse;
 import com.dduru.gildongmu.participation.dto.response.ParticipationRetrieveResponse;
+import com.dduru.gildongmu.participation.event.MatchApprovedEvent;
+import com.dduru.gildongmu.participation.event.MatchRejectedEvent;
 import com.dduru.gildongmu.participation.repository.ParticipationRepository;
 import com.dduru.gildongmu.post.domain.Post;
 import com.dduru.gildongmu.post.exception.PostAccessDeniedException;
@@ -21,6 +23,7 @@ import com.dduru.gildongmu.post.repository.PostRepository;
 import com.dduru.gildongmu.profile.utils.ProfileImageResolver;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -47,6 +50,7 @@ public class ParticipationCommandService {
     private final JourneyRepository journeyRepository;
     private final JourneyMemberRepository journeyMemberRepository;
     private final TimeProvider timeProvider;
+    private final ApplicationEventPublisher eventPublisher;
 
     public ParticipationContactResponse contactParticipation(Long userId, Long participationId) {
         Participation participation = participationRepository.getByIdWithLockOrThrow(participationId);
@@ -87,6 +91,9 @@ public class ParticipationCommandService {
                         () -> journeyMemberRepository.save(JourneyMember.createMember(journey, participation.getUser(), timeProvider.now()))
                 );
         GroupChatInviteMemberResponse response = groupChatRoomService.inviteMemberOrGetRoom(userId, journey.getId(), participantUserId);
+        eventPublisher.publishEvent(new MatchApprovedEvent(
+                participation.getId(), participantUserId, journey.getId(), journey.getTitle()
+        ));
         loggingStatusChange(participation);
 
         return new ParticipationApproveResponse(
@@ -105,6 +112,9 @@ public class ParticipationCommandService {
         lockedPost.validateIsOpen();
 
         participation.reject();
+        eventPublisher.publishEvent(new MatchRejectedEvent(
+                participation.getId(), participation.getUser().getId()
+        ));
         loggingStatusChange(participation);
     }
 

--- a/src/main/java/com/dduru/gildongmu/participation/service/ParticipationCommandService.java
+++ b/src/main/java/com/dduru/gildongmu/participation/service/ParticipationCommandService.java
@@ -15,11 +15,11 @@ import com.dduru.gildongmu.participation.dto.response.ParticipationApproveRespon
 import com.dduru.gildongmu.participation.dto.response.ParticipationContactResponse;
 import com.dduru.gildongmu.participation.dto.response.ParticipationRetrieveResponse;
 import com.dduru.gildongmu.participation.event.MatchApprovedEvent;
-import com.dduru.gildongmu.participation.event.MatchRejectedEvent;
 import com.dduru.gildongmu.participation.repository.ParticipationRepository;
 import com.dduru.gildongmu.post.domain.Post;
 import com.dduru.gildongmu.post.exception.PostAccessDeniedException;
 import com.dduru.gildongmu.post.repository.PostRepository;
+import com.dduru.gildongmu.profile.repository.ProfileRepository;
 import com.dduru.gildongmu.profile.utils.ProfileImageResolver;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -47,6 +47,7 @@ public class ParticipationCommandService {
     private final ParticipationRepository participationRepository;
     private final PostRepository postRepository;
     private final ProfileImageResolver profileImageResolver;
+    private final ProfileRepository profileRepository;
     private final JourneyRepository journeyRepository;
     private final JourneyMemberRepository journeyMemberRepository;
     private final TimeProvider timeProvider;
@@ -91,8 +92,11 @@ public class ParticipationCommandService {
                         () -> journeyMemberRepository.save(JourneyMember.createMember(journey, participation.getUser(), timeProvider.now()))
                 );
         GroupChatInviteMemberResponse response = groupChatRoomService.inviteMemberOrGetRoom(userId, journey.getId(), participantUserId);
+        String approverNickname = profileRepository.findByUser_Id(userId)
+                .map(p -> p.getNickname())
+                .orElse("알 수 없음");
         eventPublisher.publishEvent(new MatchApprovedEvent(
-                participation.getId(), participantUserId, journey.getId(), journey.getTitle()
+                participation.getId(), participantUserId, journey.getId(), journey.getTitle(), approverNickname
         ));
         loggingStatusChange(participation);
 
@@ -112,9 +116,6 @@ public class ParticipationCommandService {
         lockedPost.validateIsOpen();
 
         participation.reject();
-        eventPublisher.publishEvent(new MatchRejectedEvent(
-                participation.getId(), participation.getUser().getId()
-        ));
         loggingStatusChange(participation);
     }
 

--- a/src/main/resources/db/migration/V24__notifications.sql
+++ b/src/main/resources/db/migration/V24__notifications.sql
@@ -7,7 +7,7 @@ CREATE TABLE IF NOT EXISTS notifications
     resource_type     VARCHAR(50)  NOT NULL,
     resource_id       BIGINT       NOT NULL,
     is_read           TINYINT(1)   NOT NULL DEFAULT 0,
-    created_at        DATETIME(6)  NOT NULL,
+    created_at        DATETIME(6)  NULL,
     modified_at       DATETIME(6)  NULL,
     read_at           DATETIME(6)  NULL,
     CONSTRAINT fk_notifications_user FOREIGN KEY (recipient_user_id) REFERENCES users (id),

--- a/src/main/resources/db/migration/V24__notifications.sql
+++ b/src/main/resources/db/migration/V24__notifications.sql
@@ -1,0 +1,17 @@
+CREATE TABLE IF NOT EXISTS notifications
+(
+    id                BIGINT AUTO_INCREMENT PRIMARY KEY,
+    recipient_user_id BIGINT       NOT NULL,
+    type              VARCHAR(50)  NOT NULL,
+    body              VARCHAR(500) NOT NULL,
+    resource_type     VARCHAR(50)  NOT NULL,
+    resource_id       BIGINT       NOT NULL,
+    is_read           TINYINT(1)   NOT NULL DEFAULT 0,
+    created_at        DATETIME(6)  NULL,
+    modified_at       DATETIME(6)  NULL,
+    read_at           DATETIME(6)  NULL,
+    CONSTRAINT fk_notifications_user FOREIGN KEY (recipient_user_id) REFERENCES users (id),
+    INDEX idx_notifications_recipient (recipient_user_id, id)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci;

--- a/src/main/resources/db/migration/V24__notifications.sql
+++ b/src/main/resources/db/migration/V24__notifications.sql
@@ -7,7 +7,7 @@ CREATE TABLE IF NOT EXISTS notifications
     resource_type     VARCHAR(50)  NOT NULL,
     resource_id       BIGINT       NOT NULL,
     is_read           TINYINT(1)   NOT NULL DEFAULT 0,
-    created_at        DATETIME(6)  NULL,
+    created_at        DATETIME(6)  NOT NULL,
     modified_at       DATETIME(6)  NULL,
     read_at           DATETIME(6)  NULL,
     CONSTRAINT fk_notifications_user FOREIGN KEY (recipient_user_id) REFERENCES users (id),

--- a/src/test/java/com/dduru/gildongmu/journey/service/JourneyPostServiceTest.java
+++ b/src/test/java/com/dduru/gildongmu/journey/service/JourneyPostServiceTest.java
@@ -35,6 +35,7 @@ import com.dduru.gildongmu.user.domain.User;
 import com.dduru.gildongmu.user.domain.enums.OauthType;
 import com.dduru.gildongmu.user.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
+import org.springframework.context.ApplicationEventPublisher;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -79,6 +80,8 @@ class JourneyPostServiceTest {
     private ProfileImageResolver profileImageResolver;
     @Mock
     private TimeProvider timeProvider;
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
 
     private JourneyPostService journeyPostService;
 
@@ -96,7 +99,8 @@ class JourneyPostServiceTest {
                 userRepository,
                 new S3ImageUrlValidator(s3Properties),
                 profileImageResolver,
-                timeProvider
+                timeProvider,
+                eventPublisher
         );
     }
 
@@ -333,6 +337,7 @@ class JourneyPostServiceTest {
             when(journeyPostRepository.getActivePostByIdAndJourneyIdOrThrow(journeyPostId, journeyId))
                     .thenReturn(journeyPost);
             when(journeyPostRepository.countActiveNoticesByJourneyId(journeyId)).thenReturn(2L);
+            when(journeyRepository.getByIdOrThrow(journeyId)).thenReturn(journey);
 
             JourneyPostNoticeUpdateResponse response = journeyPostService.updatePostNotice(
                     journeyId,

--- a/src/test/java/com/dduru/gildongmu/journey/service/JourneyScheduleServiceTest.java
+++ b/src/test/java/com/dduru/gildongmu/journey/service/JourneyScheduleServiceTest.java
@@ -17,6 +17,7 @@ import com.dduru.gildongmu.journey.exception.JourneyScheduleNotFoundException;
 import com.dduru.gildongmu.journey.repository.JourneyMemberRepository;
 import com.dduru.gildongmu.journey.repository.JourneyRepository;
 import com.dduru.gildongmu.journey.repository.JourneyScheduleRepository;
+import org.springframework.context.ApplicationEventPublisher;
 import com.dduru.gildongmu.post.domain.Post;
 import com.dduru.gildongmu.post.domain.enums.CompanionType;
 import com.dduru.gildongmu.profile.domain.Profile;
@@ -62,6 +63,8 @@ class JourneyScheduleServiceTest {
     private JourneyScheduleRepository journeyScheduleRepository;
     @Mock
     private TimeProvider timeProvider;
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
 
     private JourneyScheduleService journeyScheduleService;
 
@@ -71,7 +74,8 @@ class JourneyScheduleServiceTest {
                 journeyRepository,
                 journeyMemberRepository,
                 journeyScheduleRepository,
-                timeProvider
+                timeProvider,
+                eventPublisher
         );
     }
 

--- a/src/test/java/com/dduru/gildongmu/notification/listener/NotificationEventListenerTest.java
+++ b/src/test/java/com/dduru/gildongmu/notification/listener/NotificationEventListenerTest.java
@@ -11,7 +11,6 @@ import com.dduru.gildongmu.notification.domain.enums.ResourceType;
 import com.dduru.gildongmu.notification.repository.NotificationRepository;
 import com.dduru.gildongmu.participation.event.MatchAppliedEvent;
 import com.dduru.gildongmu.participation.event.MatchApprovedEvent;
-import com.dduru.gildongmu.participation.event.MatchRejectedEvent;
 import com.dduru.gildongmu.user.domain.User;
 import com.dduru.gildongmu.user.domain.enums.OauthType;
 import com.dduru.gildongmu.user.repository.UserRepository;
@@ -61,24 +60,25 @@ class NotificationEventListenerTest {
     class HandleMatchApplied {
 
         @Test
-        @DisplayName("이벤트를 수신하면 모집글 작성자에게 알림 1건을 저장한다")
+        @DisplayName("이벤트를 수신하면 모집글 작성자에게 닉네임이 포함된 알림 1건을 저장한다")
         void savesNotificationForPostOwner() {
             Long participationId = 1L;
             Long actorUserId = 10L;
             Long recipientUserId = 20L;
             String postTitle = "일본 여행 모집";
+            String actorNickname = "여행자닉네임";
             User recipient = createUser(recipientUserId);
 
             when(userRepository.getReferenceById(recipientUserId)).thenReturn(recipient);
 
-            listener.handleMatchApplied(new MatchAppliedEvent(participationId, actorUserId, recipientUserId, postTitle));
+            listener.handleMatchApplied(new MatchAppliedEvent(participationId, actorUserId, recipientUserId, postTitle, actorNickname));
 
             ArgumentCaptor<Notification> captor = ArgumentCaptor.forClass(Notification.class);
             verify(notificationRepository).save(captor.capture());
 
             Notification saved = captor.getValue();
             assertThat(saved.getType()).isEqualTo(NotificationType.MATCH_APPLIED);
-            assertThat(saved.getBody()).isEqualTo("[일본 여행 모집]에 새로운 참여 신청이 도착했습니다.");
+            assertThat(saved.getBody()).isEqualTo("여행자닉네임 님이 매칭을 신청했습니다.");
             assertThat(saved.getResourceType()).isEqualTo(ResourceType.MATCH);
             assertThat(saved.getResourceId()).isEqualTo(participationId);
             assertThat(saved.isRead()).isFalse();
@@ -90,7 +90,7 @@ class NotificationEventListenerTest {
             when(userRepository.getReferenceById(any())).thenThrow(new RuntimeException("DB 오류"));
 
             assertThatCode(() ->
-                    listener.handleMatchApplied(new MatchAppliedEvent(1L, 10L, 20L, "test"))
+                    listener.handleMatchApplied(new MatchAppliedEvent(1L, 10L, 20L, "test", "닉네임"))
             ).doesNotThrowAnyException();
         }
     }
@@ -100,24 +100,25 @@ class NotificationEventListenerTest {
     class HandleMatchApproved {
 
         @Test
-        @DisplayName("이벤트를 수신하면 신청자에게 JOURNEY 타입 알림을 저장한다")
+        @DisplayName("이벤트를 수신하면 신청자에게 승인자 닉네임이 포함된 JOURNEY 타입 알림을 저장한다")
         void savesNotificationForApplicantWithJourneyResource() {
             Long participationId = 1L;
             Long applicantUserId = 10L;
             Long journeyId = 30L;
             String journeyTitle = "도쿄 여정";
+            String approverNickname = "호스트닉네임";
             User applicant = createUser(applicantUserId);
 
             when(userRepository.getReferenceById(applicantUserId)).thenReturn(applicant);
 
-            listener.handleMatchApproved(new MatchApprovedEvent(participationId, applicantUserId, journeyId, journeyTitle));
+            listener.handleMatchApproved(new MatchApprovedEvent(participationId, applicantUserId, journeyId, journeyTitle, approverNickname));
 
             ArgumentCaptor<Notification> captor = ArgumentCaptor.forClass(Notification.class);
             verify(notificationRepository).save(captor.capture());
 
             Notification saved = captor.getValue();
             assertThat(saved.getType()).isEqualTo(NotificationType.MATCH_APPROVED);
-            assertThat(saved.getBody()).isEqualTo("[도쿄 여정] 여행 참여가 승인되었습니다.");
+            assertThat(saved.getBody()).isEqualTo("호스트닉네임 님과 매칭이 성사되었습니다.");
             assertThat(saved.getResourceType()).isEqualTo(ResourceType.JOURNEY);
             assertThat(saved.getResourceId()).isEqualTo(journeyId);
         }
@@ -128,34 +129,8 @@ class NotificationEventListenerTest {
             when(userRepository.getReferenceById(any())).thenThrow(new RuntimeException("DB 오류"));
 
             assertThatCode(() ->
-                    listener.handleMatchApproved(new MatchApprovedEvent(1L, 10L, 30L, "여정"))
+                    listener.handleMatchApproved(new MatchApprovedEvent(1L, 10L, 30L, "여정", "닉네임"))
             ).doesNotThrowAnyException();
-        }
-    }
-
-    @Nested
-    @DisplayName("MATCH_REJECTED 이벤트")
-    class HandleMatchRejected {
-
-        @Test
-        @DisplayName("이벤트를 수신하면 신청자에게 완곡한 문구의 알림을 저장한다")
-        void savesNotificationWithPoliteBody() {
-            Long participationId = 1L;
-            Long applicantUserId = 10L;
-            User applicant = createUser(applicantUserId);
-
-            when(userRepository.getReferenceById(applicantUserId)).thenReturn(applicant);
-
-            listener.handleMatchRejected(new MatchRejectedEvent(participationId, applicantUserId));
-
-            ArgumentCaptor<Notification> captor = ArgumentCaptor.forClass(Notification.class);
-            verify(notificationRepository).save(captor.capture());
-
-            Notification saved = captor.getValue();
-            assertThat(saved.getType()).isEqualTo(NotificationType.MATCH_REJECTED);
-            assertThat(saved.getBody()).isEqualTo("참여 신청이 검토되었으나 함께하기 어렵게 되었습니다.");
-            assertThat(saved.getResourceType()).isEqualTo(ResourceType.MATCH);
-            assertThat(saved.getResourceId()).isEqualTo(participationId);
         }
     }
 
@@ -207,7 +182,7 @@ class NotificationEventListenerTest {
             assertThat(saved).hasSize(2);
             assertThat(saved).allSatisfy(n -> {
                 assertThat(n.getType()).isEqualTo(NotificationType.JOURNEY_NOTICE);
-                assertThat(n.getBody()).isEqualTo("[시부야 여정] 새 공지가 등록되었습니다.");
+                assertThat(n.getBody()).isEqualTo("[시부야 여정] 에 공지가 등록되었습니다.");
                 assertThat(n.getResourceType()).isEqualTo(ResourceType.JOURNEY_POST);
                 assertThat(n.getResourceId()).isEqualTo(journeyPostId);
                 assertThat(n.isRead()).isFalse();
@@ -235,19 +210,18 @@ class NotificationEventListenerTest {
     class HandleScheduleCreated {
 
         @Test
-        @DisplayName("ACTIVE 멤버 전원(행위자 제외)에게 일정 추가 알림을 저장한다")
+        @DisplayName("ACTIVE 멤버 전원(행위자 제외)에게 일정 생성 알림을 저장한다")
         void savesNotificationsForAllActiveMembers() {
             Long scheduleId = 7L;
             Long journeyId = 1L;
             Long actorUserId = 10L;
-            String scheduleTitle = "시부야 스크램블 집합";
 
             when(journeyMemberRepository.findActiveUserIdsByJourneyIdExcludingUser(journeyId, actorUserId))
                     .thenReturn(List.of(20L));
             when(userRepository.getReferenceById(20L)).thenReturn(createUser(20L));
 
             listener.handleScheduleCreated(
-                    new ScheduleCreatedEvent(scheduleId, journeyId, scheduleTitle, actorUserId)
+                    new ScheduleCreatedEvent(scheduleId, journeyId, "시부야 스크램블 집합", actorUserId)
             );
 
             @SuppressWarnings("unchecked")
@@ -257,7 +231,7 @@ class NotificationEventListenerTest {
             List<Notification> saved = captor.getValue();
             assertThat(saved).hasSize(1);
             assertThat(saved.get(0).getType()).isEqualTo(NotificationType.SCHEDULE_CREATED);
-            assertThat(saved.get(0).getBody()).isEqualTo("[시부야 스크램블 집합] 일정이 추가되었습니다.");
+            assertThat(saved.get(0).getBody()).isEqualTo("여행 일정이 생성되었습니다.");
             assertThat(saved.get(0).getResourceType()).isEqualTo(ResourceType.SCHEDULE);
             assertThat(saved.get(0).getResourceId()).isEqualTo(scheduleId);
         }
@@ -303,7 +277,7 @@ class NotificationEventListenerTest {
             verify(notificationRepository).saveAll(captor.capture());
 
             assertThat(captor.getValue().get(0).getType()).isEqualTo(NotificationType.SCHEDULE_UPDATED);
-            assertThat(captor.getValue().get(0).getBody()).isEqualTo("[시부야 스크램블 집합] 일정이 변경되었습니다.");
+            assertThat(captor.getValue().get(0).getBody()).isEqualTo("여행 일정이 변경되었습니다. 확인해주세요.");
         }
     }
 
@@ -325,7 +299,7 @@ class NotificationEventListenerTest {
             verify(notificationRepository).saveAll(captor.capture());
 
             assertThat(captor.getValue().get(0).getType()).isEqualTo(NotificationType.SCHEDULE_CANCELED);
-            assertThat(captor.getValue().get(0).getBody()).isEqualTo("[시부야 스크램블 집합] 일정이 취소되었습니다.");
+            assertThat(captor.getValue().get(0).getBody()).isEqualTo("여행 일정이 취소되었습니다.");
         }
     }
 

--- a/src/test/java/com/dduru/gildongmu/notification/listener/NotificationEventListenerTest.java
+++ b/src/test/java/com/dduru/gildongmu/notification/listener/NotificationEventListenerTest.java
@@ -8,7 +8,7 @@ import com.dduru.gildongmu.journey.repository.JourneyMemberRepository;
 import com.dduru.gildongmu.notification.domain.Notification;
 import com.dduru.gildongmu.notification.domain.enums.NotificationType;
 import com.dduru.gildongmu.notification.domain.enums.ResourceType;
-import com.dduru.gildongmu.notification.repository.NotificationRepository;
+import com.dduru.gildongmu.notification.service.NotificationPersistService;
 import com.dduru.gildongmu.participation.event.MatchAppliedEvent;
 import com.dduru.gildongmu.participation.event.MatchApprovedEvent;
 import com.dduru.gildongmu.user.domain.User;
@@ -38,7 +38,7 @@ import static org.mockito.Mockito.when;
 class NotificationEventListenerTest {
 
     @Mock
-    private NotificationRepository notificationRepository;
+    private NotificationPersistService notificationPersistService;
 
     @Mock
     private JourneyMemberRepository journeyMemberRepository;
@@ -50,7 +50,7 @@ class NotificationEventListenerTest {
 
     @BeforeEach
     void setUp() {
-        listener = new NotificationEventListener(notificationRepository, journeyMemberRepository, userRepository);
+        listener = new NotificationEventListener(notificationPersistService, journeyMemberRepository, userRepository);
     }
 
     // ── MATCH ─────────────────────────────────────────────────────────────────
@@ -74,7 +74,7 @@ class NotificationEventListenerTest {
             listener.handleMatchApplied(new MatchAppliedEvent(participationId, actorUserId, recipientUserId, postTitle, actorNickname));
 
             ArgumentCaptor<Notification> captor = ArgumentCaptor.forClass(Notification.class);
-            verify(notificationRepository).save(captor.capture());
+            verify(notificationPersistService).save(captor.capture());
 
             Notification saved = captor.getValue();
             assertThat(saved.getType()).isEqualTo(NotificationType.MATCH_APPLIED);
@@ -114,7 +114,7 @@ class NotificationEventListenerTest {
             listener.handleMatchApproved(new MatchApprovedEvent(participationId, applicantUserId, journeyId, journeyTitle, approverNickname));
 
             ArgumentCaptor<Notification> captor = ArgumentCaptor.forClass(Notification.class);
-            verify(notificationRepository).save(captor.capture());
+            verify(notificationPersistService).save(captor.capture());
 
             Notification saved = captor.getValue();
             assertThat(saved.getType()).isEqualTo(NotificationType.MATCH_APPROVED);
@@ -153,7 +153,7 @@ class NotificationEventListenerTest {
                     new JourneyNoticeCreatedEvent(5L, journeyId, "시부야 여정", actorUserId)
             );
 
-            verify(notificationRepository, never()).saveAll(any());
+            verify(notificationPersistService, never()).saveAll(any());
         }
 
         @Test
@@ -176,7 +176,7 @@ class NotificationEventListenerTest {
 
             @SuppressWarnings("unchecked")
             ArgumentCaptor<List<Notification>> captor = ArgumentCaptor.forClass(List.class);
-            verify(notificationRepository).saveAll(captor.capture());
+            verify(notificationPersistService).saveAll(captor.capture());
 
             List<Notification> saved = captor.getValue();
             assertThat(saved).hasSize(2);
@@ -226,7 +226,7 @@ class NotificationEventListenerTest {
 
             @SuppressWarnings("unchecked")
             ArgumentCaptor<List<Notification>> captor = ArgumentCaptor.forClass(List.class);
-            verify(notificationRepository).saveAll(captor.capture());
+            verify(notificationPersistService).saveAll(captor.capture());
 
             List<Notification> saved = captor.getValue();
             assertThat(saved).hasSize(1);
@@ -244,7 +244,7 @@ class NotificationEventListenerTest {
 
             listener.handleScheduleCreated(new ScheduleCreatedEvent(7L, 1L, "일정", 10L));
 
-            verify(notificationRepository, never()).saveAll(any());
+            verify(notificationPersistService, never()).saveAll(any());
         }
 
         @Test
@@ -274,7 +274,7 @@ class NotificationEventListenerTest {
 
             @SuppressWarnings("unchecked")
             ArgumentCaptor<List<Notification>> captor = ArgumentCaptor.forClass(List.class);
-            verify(notificationRepository).saveAll(captor.capture());
+            verify(notificationPersistService).saveAll(captor.capture());
 
             assertThat(captor.getValue().get(0).getType()).isEqualTo(NotificationType.SCHEDULE_UPDATED);
             assertThat(captor.getValue().get(0).getBody()).isEqualTo("여행 일정이 변경되었습니다. 확인해주세요.");
@@ -296,7 +296,7 @@ class NotificationEventListenerTest {
 
             @SuppressWarnings("unchecked")
             ArgumentCaptor<List<Notification>> captor = ArgumentCaptor.forClass(List.class);
-            verify(notificationRepository).saveAll(captor.capture());
+            verify(notificationPersistService).saveAll(captor.capture());
 
             assertThat(captor.getValue().get(0).getType()).isEqualTo(NotificationType.SCHEDULE_CANCELED);
             assertThat(captor.getValue().get(0).getBody()).isEqualTo("여행 일정이 취소되었습니다.");

--- a/src/test/java/com/dduru/gildongmu/notification/listener/NotificationEventListenerTest.java
+++ b/src/test/java/com/dduru/gildongmu/notification/listener/NotificationEventListenerTest.java
@@ -166,29 +166,11 @@ class NotificationEventListenerTest {
     class HandleJourneyNoticeCreated {
 
         @Test
-        @DisplayName("같은 게시글에 이미 공지 알림이 존재하면 저장하지 않는다 (dedup)")
-        void skipsWhenNotificationAlreadyExists() {
-            Long journeyPostId = 5L;
-            when(notificationRepository.existsByTypeAndResourceTypeAndResourceId(
-                    NotificationType.JOURNEY_NOTICE, ResourceType.JOURNEY_POST, journeyPostId
-            )).thenReturn(true);
-
-            listener.handleJourneyNoticeCreated(
-                    new JourneyNoticeCreatedEvent(journeyPostId, 1L, "시부야 여정", 10L)
-            );
-
-            verify(notificationRepository, never()).saveAll(any());
-            verify(journeyMemberRepository, never()).findActiveUserIdsByJourneyIdExcludingUser(any(), any());
-        }
-
-        @Test
         @DisplayName("행위자 제외 후 수신자가 없으면 저장하지 않는다")
         void skipsWhenNoRecipients() {
             Long journeyId = 1L;
             Long actorUserId = 10L;
 
-            when(notificationRepository.existsByTypeAndResourceTypeAndResourceId(any(), any(), any()))
-                    .thenReturn(false);
             when(journeyMemberRepository.findActiveUserIdsByJourneyIdExcludingUser(journeyId, actorUserId))
                     .thenReturn(List.of());
 
@@ -208,8 +190,6 @@ class NotificationEventListenerTest {
             String journeyTitle = "시부야 여정";
             List<Long> recipientIds = List.of(20L, 30L);
 
-            when(notificationRepository.existsByTypeAndResourceTypeAndResourceId(any(), any(), any()))
-                    .thenReturn(false);
             when(journeyMemberRepository.findActiveUserIdsByJourneyIdExcludingUser(journeyId, actorUserId))
                     .thenReturn(recipientIds);
             when(userRepository.getReferenceById(20L)).thenReturn(createUser(20L));
@@ -237,7 +217,7 @@ class NotificationEventListenerTest {
         @Test
         @DisplayName("알림 저장 중 예외가 발생해도 예외가 전파되지 않는다")
         void exceptionIsSwallowed() {
-            when(notificationRepository.existsByTypeAndResourceTypeAndResourceId(any(), any(), any()))
+            when(journeyMemberRepository.findActiveUserIdsByJourneyIdExcludingUser(any(), any()))
                     .thenThrow(new RuntimeException("DB 오류"));
 
             assertThatCode(() ->

--- a/src/test/java/com/dduru/gildongmu/notification/listener/NotificationEventListenerTest.java
+++ b/src/test/java/com/dduru/gildongmu/notification/listener/NotificationEventListenerTest.java
@@ -1,0 +1,364 @@
+package com.dduru.gildongmu.notification.listener;
+
+import com.dduru.gildongmu.journey.event.JourneyNoticeCreatedEvent;
+import com.dduru.gildongmu.journey.event.ScheduleCanceledEvent;
+import com.dduru.gildongmu.journey.event.ScheduleCreatedEvent;
+import com.dduru.gildongmu.journey.event.ScheduleUpdatedEvent;
+import com.dduru.gildongmu.journey.repository.JourneyMemberRepository;
+import com.dduru.gildongmu.notification.domain.Notification;
+import com.dduru.gildongmu.notification.domain.enums.NotificationType;
+import com.dduru.gildongmu.notification.domain.enums.ResourceType;
+import com.dduru.gildongmu.notification.repository.NotificationRepository;
+import com.dduru.gildongmu.participation.event.MatchAppliedEvent;
+import com.dduru.gildongmu.participation.event.MatchApprovedEvent;
+import com.dduru.gildongmu.participation.event.MatchRejectedEvent;
+import com.dduru.gildongmu.user.domain.User;
+import com.dduru.gildongmu.user.domain.enums.OauthType;
+import com.dduru.gildongmu.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("NotificationEventListener 테스트")
+class NotificationEventListenerTest {
+
+    @Mock
+    private NotificationRepository notificationRepository;
+
+    @Mock
+    private JourneyMemberRepository journeyMemberRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    private NotificationEventListener listener;
+
+    @BeforeEach
+    void setUp() {
+        listener = new NotificationEventListener(notificationRepository, journeyMemberRepository, userRepository);
+    }
+
+    // ── MATCH ─────────────────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("MATCH_APPLIED 이벤트")
+    class HandleMatchApplied {
+
+        @Test
+        @DisplayName("이벤트를 수신하면 모집글 작성자에게 알림 1건을 저장한다")
+        void savesNotificationForPostOwner() {
+            Long participationId = 1L;
+            Long actorUserId = 10L;
+            Long recipientUserId = 20L;
+            String postTitle = "일본 여행 모집";
+            User recipient = createUser(recipientUserId);
+
+            when(userRepository.getReferenceById(recipientUserId)).thenReturn(recipient);
+
+            listener.handleMatchApplied(new MatchAppliedEvent(participationId, actorUserId, recipientUserId, postTitle));
+
+            ArgumentCaptor<Notification> captor = ArgumentCaptor.forClass(Notification.class);
+            verify(notificationRepository).save(captor.capture());
+
+            Notification saved = captor.getValue();
+            assertThat(saved.getType()).isEqualTo(NotificationType.MATCH_APPLIED);
+            assertThat(saved.getBody()).isEqualTo("[일본 여행 모집]에 새로운 참여 신청이 도착했습니다.");
+            assertThat(saved.getResourceType()).isEqualTo(ResourceType.MATCH);
+            assertThat(saved.getResourceId()).isEqualTo(participationId);
+            assertThat(saved.isRead()).isFalse();
+        }
+
+        @Test
+        @DisplayName("알림 저장 중 예외가 발생해도 예외가 전파되지 않는다")
+        void exceptionIsSwallowed() {
+            when(userRepository.getReferenceById(any())).thenThrow(new RuntimeException("DB 오류"));
+
+            assertThatCode(() ->
+                    listener.handleMatchApplied(new MatchAppliedEvent(1L, 10L, 20L, "test"))
+            ).doesNotThrowAnyException();
+        }
+    }
+
+    @Nested
+    @DisplayName("MATCH_APPROVED 이벤트")
+    class HandleMatchApproved {
+
+        @Test
+        @DisplayName("이벤트를 수신하면 신청자에게 JOURNEY 타입 알림을 저장한다")
+        void savesNotificationForApplicantWithJourneyResource() {
+            Long participationId = 1L;
+            Long applicantUserId = 10L;
+            Long journeyId = 30L;
+            String journeyTitle = "도쿄 여정";
+            User applicant = createUser(applicantUserId);
+
+            when(userRepository.getReferenceById(applicantUserId)).thenReturn(applicant);
+
+            listener.handleMatchApproved(new MatchApprovedEvent(participationId, applicantUserId, journeyId, journeyTitle));
+
+            ArgumentCaptor<Notification> captor = ArgumentCaptor.forClass(Notification.class);
+            verify(notificationRepository).save(captor.capture());
+
+            Notification saved = captor.getValue();
+            assertThat(saved.getType()).isEqualTo(NotificationType.MATCH_APPROVED);
+            assertThat(saved.getBody()).isEqualTo("[도쿄 여정] 여행 참여가 승인되었습니다.");
+            assertThat(saved.getResourceType()).isEqualTo(ResourceType.JOURNEY);
+            assertThat(saved.getResourceId()).isEqualTo(journeyId);
+        }
+
+        @Test
+        @DisplayName("알림 저장 중 예외가 발생해도 예외가 전파되지 않는다")
+        void exceptionIsSwallowed() {
+            when(userRepository.getReferenceById(any())).thenThrow(new RuntimeException("DB 오류"));
+
+            assertThatCode(() ->
+                    listener.handleMatchApproved(new MatchApprovedEvent(1L, 10L, 30L, "여정"))
+            ).doesNotThrowAnyException();
+        }
+    }
+
+    @Nested
+    @DisplayName("MATCH_REJECTED 이벤트")
+    class HandleMatchRejected {
+
+        @Test
+        @DisplayName("이벤트를 수신하면 신청자에게 완곡한 문구의 알림을 저장한다")
+        void savesNotificationWithPoliteBody() {
+            Long participationId = 1L;
+            Long applicantUserId = 10L;
+            User applicant = createUser(applicantUserId);
+
+            when(userRepository.getReferenceById(applicantUserId)).thenReturn(applicant);
+
+            listener.handleMatchRejected(new MatchRejectedEvent(participationId, applicantUserId));
+
+            ArgumentCaptor<Notification> captor = ArgumentCaptor.forClass(Notification.class);
+            verify(notificationRepository).save(captor.capture());
+
+            Notification saved = captor.getValue();
+            assertThat(saved.getType()).isEqualTo(NotificationType.MATCH_REJECTED);
+            assertThat(saved.getBody()).isEqualTo("참여 신청이 검토되었으나 함께하기 어렵게 되었습니다.");
+            assertThat(saved.getResourceType()).isEqualTo(ResourceType.MATCH);
+            assertThat(saved.getResourceId()).isEqualTo(participationId);
+        }
+    }
+
+    // ── JOURNEY_NOTICE ────────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("JOURNEY_NOTICE 이벤트")
+    class HandleJourneyNoticeCreated {
+
+        @Test
+        @DisplayName("같은 게시글에 이미 공지 알림이 존재하면 저장하지 않는다 (dedup)")
+        void skipsWhenNotificationAlreadyExists() {
+            Long journeyPostId = 5L;
+            when(notificationRepository.existsByTypeAndResourceTypeAndResourceId(
+                    NotificationType.JOURNEY_NOTICE, ResourceType.JOURNEY_POST, journeyPostId
+            )).thenReturn(true);
+
+            listener.handleJourneyNoticeCreated(
+                    new JourneyNoticeCreatedEvent(journeyPostId, 1L, "시부야 여정", 10L)
+            );
+
+            verify(notificationRepository, never()).saveAll(any());
+            verify(journeyMemberRepository, never()).findActiveUserIdsByJourneyIdExcludingUser(any(), any());
+        }
+
+        @Test
+        @DisplayName("행위자 제외 후 수신자가 없으면 저장하지 않는다")
+        void skipsWhenNoRecipients() {
+            Long journeyId = 1L;
+            Long actorUserId = 10L;
+
+            when(notificationRepository.existsByTypeAndResourceTypeAndResourceId(any(), any(), any()))
+                    .thenReturn(false);
+            when(journeyMemberRepository.findActiveUserIdsByJourneyIdExcludingUser(journeyId, actorUserId))
+                    .thenReturn(List.of());
+
+            listener.handleJourneyNoticeCreated(
+                    new JourneyNoticeCreatedEvent(5L, journeyId, "시부야 여정", actorUserId)
+            );
+
+            verify(notificationRepository, never()).saveAll(any());
+        }
+
+        @Test
+        @DisplayName("ACTIVE 멤버 전원(행위자 제외)에게 알림을 저장한다")
+        void savesNotificationsForAllActiveMembers() {
+            Long journeyPostId = 5L;
+            Long journeyId = 1L;
+            Long actorUserId = 10L;
+            String journeyTitle = "시부야 여정";
+            List<Long> recipientIds = List.of(20L, 30L);
+
+            when(notificationRepository.existsByTypeAndResourceTypeAndResourceId(any(), any(), any()))
+                    .thenReturn(false);
+            when(journeyMemberRepository.findActiveUserIdsByJourneyIdExcludingUser(journeyId, actorUserId))
+                    .thenReturn(recipientIds);
+            when(userRepository.getReferenceById(20L)).thenReturn(createUser(20L));
+            when(userRepository.getReferenceById(30L)).thenReturn(createUser(30L));
+
+            listener.handleJourneyNoticeCreated(
+                    new JourneyNoticeCreatedEvent(journeyPostId, journeyId, journeyTitle, actorUserId)
+            );
+
+            @SuppressWarnings("unchecked")
+            ArgumentCaptor<List<Notification>> captor = ArgumentCaptor.forClass(List.class);
+            verify(notificationRepository).saveAll(captor.capture());
+
+            List<Notification> saved = captor.getValue();
+            assertThat(saved).hasSize(2);
+            assertThat(saved).allSatisfy(n -> {
+                assertThat(n.getType()).isEqualTo(NotificationType.JOURNEY_NOTICE);
+                assertThat(n.getBody()).isEqualTo("[시부야 여정] 새 공지가 등록되었습니다.");
+                assertThat(n.getResourceType()).isEqualTo(ResourceType.JOURNEY_POST);
+                assertThat(n.getResourceId()).isEqualTo(journeyPostId);
+                assertThat(n.isRead()).isFalse();
+            });
+        }
+
+        @Test
+        @DisplayName("알림 저장 중 예외가 발생해도 예외가 전파되지 않는다")
+        void exceptionIsSwallowed() {
+            when(notificationRepository.existsByTypeAndResourceTypeAndResourceId(any(), any(), any()))
+                    .thenThrow(new RuntimeException("DB 오류"));
+
+            assertThatCode(() ->
+                    listener.handleJourneyNoticeCreated(
+                            new JourneyNoticeCreatedEvent(5L, 1L, "여정", 10L)
+                    )
+            ).doesNotThrowAnyException();
+        }
+    }
+
+    // ── SCHEDULE ─────────────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("SCHEDULE_CREATED 이벤트")
+    class HandleScheduleCreated {
+
+        @Test
+        @DisplayName("ACTIVE 멤버 전원(행위자 제외)에게 일정 추가 알림을 저장한다")
+        void savesNotificationsForAllActiveMembers() {
+            Long scheduleId = 7L;
+            Long journeyId = 1L;
+            Long actorUserId = 10L;
+            String scheduleTitle = "시부야 스크램블 집합";
+
+            when(journeyMemberRepository.findActiveUserIdsByJourneyIdExcludingUser(journeyId, actorUserId))
+                    .thenReturn(List.of(20L));
+            when(userRepository.getReferenceById(20L)).thenReturn(createUser(20L));
+
+            listener.handleScheduleCreated(
+                    new ScheduleCreatedEvent(scheduleId, journeyId, scheduleTitle, actorUserId)
+            );
+
+            @SuppressWarnings("unchecked")
+            ArgumentCaptor<List<Notification>> captor = ArgumentCaptor.forClass(List.class);
+            verify(notificationRepository).saveAll(captor.capture());
+
+            List<Notification> saved = captor.getValue();
+            assertThat(saved).hasSize(1);
+            assertThat(saved.get(0).getType()).isEqualTo(NotificationType.SCHEDULE_CREATED);
+            assertThat(saved.get(0).getBody()).isEqualTo("[시부야 스크램블 집합] 일정이 추가되었습니다.");
+            assertThat(saved.get(0).getResourceType()).isEqualTo(ResourceType.SCHEDULE);
+            assertThat(saved.get(0).getResourceId()).isEqualTo(scheduleId);
+        }
+
+        @Test
+        @DisplayName("수신자가 없으면 저장하지 않는다")
+        void skipsWhenNoRecipients() {
+            when(journeyMemberRepository.findActiveUserIdsByJourneyIdExcludingUser(any(), any()))
+                    .thenReturn(List.of());
+
+            listener.handleScheduleCreated(new ScheduleCreatedEvent(7L, 1L, "일정", 10L));
+
+            verify(notificationRepository, never()).saveAll(any());
+        }
+
+        @Test
+        @DisplayName("알림 저장 중 예외가 발생해도 예외가 전파되지 않는다")
+        void exceptionIsSwallowed() {
+            when(journeyMemberRepository.findActiveUserIdsByJourneyIdExcludingUser(any(), any()))
+                    .thenThrow(new RuntimeException("DB 오류"));
+
+            assertThatCode(() ->
+                    listener.handleScheduleCreated(new ScheduleCreatedEvent(7L, 1L, "일정", 10L))
+            ).doesNotThrowAnyException();
+        }
+    }
+
+    @Nested
+    @DisplayName("SCHEDULE_UPDATED 이벤트")
+    class HandleScheduleUpdated {
+
+        @Test
+        @DisplayName("ACTIVE 멤버 전원(행위자 제외)에게 일정 변경 알림을 저장한다")
+        void savesNotificationsWithUpdatedBody() {
+            when(journeyMemberRepository.findActiveUserIdsByJourneyIdExcludingUser(1L, 10L))
+                    .thenReturn(List.of(20L));
+            when(userRepository.getReferenceById(20L)).thenReturn(createUser(20L));
+
+            listener.handleScheduleUpdated(new ScheduleUpdatedEvent(7L, 1L, "시부야 스크램블 집합", 10L));
+
+            @SuppressWarnings("unchecked")
+            ArgumentCaptor<List<Notification>> captor = ArgumentCaptor.forClass(List.class);
+            verify(notificationRepository).saveAll(captor.capture());
+
+            assertThat(captor.getValue().get(0).getType()).isEqualTo(NotificationType.SCHEDULE_UPDATED);
+            assertThat(captor.getValue().get(0).getBody()).isEqualTo("[시부야 스크램블 집합] 일정이 변경되었습니다.");
+        }
+    }
+
+    @Nested
+    @DisplayName("SCHEDULE_CANCELED 이벤트")
+    class HandleScheduleCanceled {
+
+        @Test
+        @DisplayName("ACTIVE 멤버 전원(행위자 제외)에게 일정 취소 알림을 저장한다")
+        void savesNotificationsWithCanceledBody() {
+            when(journeyMemberRepository.findActiveUserIdsByJourneyIdExcludingUser(1L, 10L))
+                    .thenReturn(List.of(20L));
+            when(userRepository.getReferenceById(20L)).thenReturn(createUser(20L));
+
+            listener.handleScheduleCanceled(new ScheduleCanceledEvent(7L, 1L, "시부야 스크램블 집합", 10L));
+
+            @SuppressWarnings("unchecked")
+            ArgumentCaptor<List<Notification>> captor = ArgumentCaptor.forClass(List.class);
+            verify(notificationRepository).saveAll(captor.capture());
+
+            assertThat(captor.getValue().get(0).getType()).isEqualTo(NotificationType.SCHEDULE_CANCELED);
+            assertThat(captor.getValue().get(0).getBody()).isEqualTo("[시부야 스크램블 집합] 일정이 취소되었습니다.");
+        }
+    }
+
+    // ── 헬퍼 메서드 ──────────────────────────────────────────────────────────
+
+    private User createUser(Long userId) {
+        User user = User.builder()
+                .email("user" + userId + "@example.com")
+                .name("user" + userId)
+                .oauthId("oauth-" + userId)
+                .oauthType(OauthType.KAKAO)
+                .build();
+        ReflectionTestUtils.setField(user, "id", userId);
+        return user;
+    }
+}

--- a/src/test/java/com/dduru/gildongmu/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/dduru/gildongmu/notification/service/NotificationServiceTest.java
@@ -1,0 +1,177 @@
+package com.dduru.gildongmu.notification.service;
+
+import com.dduru.gildongmu.common.time.TimeProvider;
+import com.dduru.gildongmu.notification.domain.Notification;
+import com.dduru.gildongmu.notification.domain.enums.NotificationType;
+import com.dduru.gildongmu.notification.domain.enums.ResourceType;
+import com.dduru.gildongmu.notification.dto.response.NotificationReadResponse;
+import com.dduru.gildongmu.notification.exception.NotificationAccessDeniedException;
+import com.dduru.gildongmu.notification.exception.NotificationNotFoundException;
+import com.dduru.gildongmu.notification.repository.NotificationRepository;
+import com.dduru.gildongmu.user.domain.User;
+import com.dduru.gildongmu.user.domain.enums.OauthType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("NotificationService 테스트")
+class NotificationServiceTest {
+
+    private static final LocalDateTime NOW = LocalDateTime.of(2026, 6, 22, 10, 0);
+
+    @Mock
+    private NotificationRepository notificationRepository;
+
+    @Mock
+    private TimeProvider timeProvider;
+
+    private NotificationService notificationService;
+
+    @BeforeEach
+    void setUp() {
+        lenient().when(timeProvider.now()).thenReturn(NOW);
+        notificationService = new NotificationService(notificationRepository, timeProvider);
+    }
+
+    @Nested
+    @DisplayName("단건 읽음 처리")
+    class MarkAsRead {
+
+        @Test
+        @DisplayName("미읽음 알림을 읽음 처리하면 read=true, readAt이 기록되고 success=true를 반환한다")
+        void unreadNotificationIsMarkedAsRead() {
+            Long userId = 1L;
+            Long notificationId = 10L;
+            Notification notification = createUnreadNotification(notificationId, createUser(userId));
+
+            when(notificationRepository.findById(notificationId)).thenReturn(Optional.of(notification));
+
+            NotificationReadResponse response = notificationService.markAsRead(userId, notificationId);
+
+            assertThat(response.success()).isTrue();
+            assertThat(notification.isRead()).isTrue();
+            assertThat(notification.getReadAt()).isEqualTo(NOW);
+        }
+
+        @Test
+        @DisplayName("이미 읽은 알림을 재요청해도 예외 없이 success=true를 반환한다 (멱등)")
+        void alreadyReadNotificationIsIdempotent() {
+            Long userId = 1L;
+            Long notificationId = 10L;
+            Notification notification = createReadNotification(notificationId, createUser(userId));
+            LocalDateTime originalReadAt = notification.getReadAt();
+
+            when(notificationRepository.findById(notificationId)).thenReturn(Optional.of(notification));
+
+            NotificationReadResponse response = notificationService.markAsRead(userId, notificationId);
+
+            assertThat(response.success()).isTrue();
+            assertThat(notification.getReadAt()).isEqualTo(originalReadAt); // readAt 변경 없음
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 알림 ID로 요청하면 NotificationNotFoundException이 발생한다")
+        void notFoundNotificationThrowsException() {
+            when(notificationRepository.findById(99L)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> notificationService.markAsRead(1L, 99L))
+                    .isInstanceOf(NotificationNotFoundException.class);
+        }
+
+        @Test
+        @DisplayName("타인의 알림을 읽음 처리하려 하면 NotificationAccessDeniedException이 발생한다")
+        void otherUsersNotificationThrowsAccessDeniedException() {
+            Long ownerId = 1L;
+            Long attackerId = 2L;
+            Long notificationId = 10L;
+            Notification notification = createUnreadNotification(notificationId, createUser(ownerId));
+
+            when(notificationRepository.findById(notificationId)).thenReturn(Optional.of(notification));
+
+            assertThatThrownBy(() -> notificationService.markAsRead(attackerId, notificationId))
+                    .isInstanceOf(NotificationAccessDeniedException.class);
+
+            assertThat(notification.isRead()).isFalse(); // 상태 변경 없음
+        }
+
+        @Test
+        @DisplayName("접근 권한이 없으면 알림 상태는 변경되지 않는다")
+        void accessDeniedDoesNotMutateNotificationState() {
+            Long ownerId = 1L;
+            Long notificationId = 10L;
+            Notification notification = createUnreadNotification(notificationId, createUser(ownerId));
+
+            when(notificationRepository.findById(notificationId)).thenReturn(Optional.of(notification));
+
+            try {
+                notificationService.markAsRead(99L, notificationId);
+            } catch (NotificationAccessDeniedException ignored) {
+            }
+
+            verify(timeProvider, never()).now();
+        }
+    }
+
+    @Nested
+    @DisplayName("전체 읽음 처리")
+    class MarkAllAsRead {
+
+        @Test
+        @DisplayName("전체 읽음 처리하면 벌크 업데이트 쿼리를 실행하고 success=true를 반환한다")
+        void bulkUpdateIsCalledAndReturnsSuccess() {
+            Long userId = 1L;
+
+            NotificationReadResponse response = notificationService.markAllAsRead(userId);
+
+            assertThat(response.success()).isTrue();
+            verify(notificationRepository).markAllAsReadByRecipientId(userId, NOW);
+        }
+    }
+
+    // ── 헬퍼 메서드 ──────────────────────────────────────────────────────────
+
+    private User createUser(Long userId) {
+        User user = User.builder()
+                .email("user" + userId + "@example.com")
+                .name("user" + userId)
+                .oauthId("oauth-" + userId)
+                .oauthType(OauthType.KAKAO)
+                .build();
+        ReflectionTestUtils.setField(user, "id", userId);
+        return user;
+    }
+
+    private Notification createUnreadNotification(Long notificationId, User recipient) {
+        Notification notification = Notification.create(
+                recipient,
+                NotificationType.MATCH_APPLIED,
+                "[테스트 게시글]에 새로운 참여 신청이 도착했습니다.",
+                ResourceType.MATCH,
+                1L
+        );
+        ReflectionTestUtils.setField(notification, "id", notificationId);
+        return notification;
+    }
+
+    private Notification createReadNotification(Long notificationId, User recipient) {
+        Notification notification = createUnreadNotification(notificationId, recipient);
+        notification.markAsRead(LocalDateTime.of(2026, 6, 1, 9, 0));
+        return notification;
+    }
+}

--- a/src/test/java/com/dduru/gildongmu/participation/service/ParticipationCommandServiceTest.java
+++ b/src/test/java/com/dduru/gildongmu/participation/service/ParticipationCommandServiceTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDate;
@@ -61,6 +62,9 @@ class ParticipationCommandServiceTest {
 
     @Mock
     private TimeProvider timeProvider;
+
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
 
     @InjectMocks
     private ParticipationCommandService participationCommandService;

--- a/src/test/java/com/dduru/gildongmu/participation/service/ParticipationCommandServiceTest.java
+++ b/src/test/java/com/dduru/gildongmu/participation/service/ParticipationCommandServiceTest.java
@@ -15,6 +15,8 @@ import com.dduru.gildongmu.participation.dto.response.ParticipationContactRespon
 import com.dduru.gildongmu.participation.repository.ParticipationRepository;
 import com.dduru.gildongmu.post.domain.Post;
 import com.dduru.gildongmu.post.repository.PostRepository;
+import com.dduru.gildongmu.profile.domain.Profile;
+import com.dduru.gildongmu.profile.repository.ProfileRepository;
 import com.dduru.gildongmu.profile.utils.ProfileImageResolver;
 import com.dduru.gildongmu.user.domain.User;
 import com.dduru.gildongmu.user.domain.enums.OauthType;
@@ -25,6 +27,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -32,6 +36,7 @@ import java.time.LocalDate;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -53,6 +58,9 @@ class ParticipationCommandServiceTest {
 
     @Mock
     private ProfileImageResolver profileImageResolver;
+
+    @Mock
+    private ProfileRepository profileRepository;
 
     @Mock
     private JourneyRepository journeyRepository;
@@ -117,9 +125,13 @@ class ParticipationCommandServiceTest {
             Participation participation = createParticipation(participationId, post, participantId);
             participation.contact();
 
+            Profile ownerProfile = mock(Profile.class);
+            when(ownerProfile.getNickname()).thenReturn("호스트닉네임");
+
             when(participationRepository.getByIdWithLockOrThrow(participationId)).thenReturn(participation);
             when(postRepository.getActiveByIdWithLockOrThrow(post.getId())).thenReturn(post);
             when(journeyRepository.getByPostIdOrThrow(post.getId())).thenReturn(journey);
+            when(profileRepository.findByUser_Id(ownerId)).thenReturn(Optional.of(ownerProfile));
             when(groupChatRoomService.inviteMemberOrGetRoom(ownerId, journey.getId(), participantId))
                     .thenReturn(new GroupChatInviteMemberResponse(roomId, true));
 


### PR DESCRIPTION
## 🔎 작업 내용
  - notifications 테이블 생성 및 Notification 엔티티 구현 (V24 마이그레이션)
  - 알림 도메인 전체 구현: NotificationType / ResourceType enum, Repository, QueryService, Service, Controller, EventListener, Exception
  - 도메인 이벤트 레코드 추가: MatchAppliedEvent, MatchApprovedEvent, JourneyNoticeCreatedEvent, ScheduleCreatedEvent, ScheduleUpdatedEvent, ScheduleCanceledEvent, PostUpdatedEvent
  - 기존 서비스에 이벤트 발행 연동: ParticipationApplicantService, ParticipationCommandService, JourneyPostService, JourneyScheduleService, PostService
  - JourneyMemberRepository에 여정 ACTIVE 멤버 조회 쿼리 추가
  - PostLikeRepository에 찜한 유저 ID 조회 쿼리 추가 (POST_UPDATED 수신자 결정용)
  - NotificationListRequest DTO 도입 — @Valid @ModelAttribute 방식으로 cursor/size 검증 일원화
  - NotificationService, NotificationEventListener 단위 테스트 작성
  
## ➕ 이슈 링크
* Closed #275

## 📸 스크린샷


## 😎 리뷰 요구사항
> * `NotificationEventListener`에서 `@TransactionalEventListener(AFTER_COMMIT)` + `@Transactional(REQUIRES_NEW)` 조합을 사용했습니다. 원본 트랜잭션 커밋 이후에 새 트랜잭션으로 알림을 저장하는 구조입니다.


## 📝 체크리스트
- [x] 브랜치 이름은 `feat/개발내용` 형식으로 작성했는가?
- [x] 커밋 메시지는 `feat(scope): 커밋 내용` 형식으로 작성했는가?
- [x] 작업 전 Issue를 작성했는가?
- [x] `dev` 브랜치로 병합을 요청했는가?
- [x] 불필요한 주석과 공백은 제거했는가?
- [x] 코드 리뷰어의 피드백을 반영했는가?
- [x] 테스트를 진행했는가?
- [x] 테스트 코드를 작성했는가?
