### PR TITLE
feat: FCM 푸시 알림 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ out/
 
 ### Blue-Green runtime state ###
 deployment/nginx/conf.d/upstreams/active-upstream.inc
+
+### Firebase ###
+src/main/resources/firebase/

--- a/build.gradle
+++ b/build.gradle
@@ -69,6 +69,8 @@ dependencies {
 	implementation 'software.amazon.awssdk:auth:2.20.26'
 	//CoolSMS
 	implementation 'net.nurigo:sdk:4.3.0'
+	//Firebase Admin SDK
+	implementation 'com.google.firebase:firebase-admin:9.4.2'
 }
 
 tasks.named('test') {

--- a/docs/001-design/001-domain.md
+++ b/docs/001-design/001-domain.md
@@ -32,6 +32,8 @@
 | `verification` | 휴대폰 인증번호 발송/검증 | Redis 또는 인증 데이터 |
 | `admin` | 관리자 사용자/게시글/신고 조회 및 처리 | admin controller/service |
 | `home` | 홈 화면 데이터 조합 | `HomeResponse` |
+| `notification` | 도메인 이벤트 기반 인앱 알림 생성·저장, 알림함 조회/읽음 처리 | `Notification`, `NotificationType`, `ResourceType` |
+| `fcm` | FCM 디바이스 토큰 등록/삭제, 이벤트 기반 FCM 푸시 발송 | `UserFcmToken`, `DeviceType` |
 | `common` | 공통 응답, 예외, 설정, JWT, WebSocket, validation | `ApiResult`, `ErrorCode`, `BaseTimeEntity` |
 
 ---

--- a/docs/001-design/002-data.md
+++ b/docs/001-design/002-data.md
@@ -62,6 +62,8 @@
 | `reports` | report | 게시글 신고 |
 | `super_host_tickets` | superhost | 슈퍼호스트 티켓 |
 | `super_host_exposures` | superhost | 슈퍼호스트 노출 |
+| `notifications` | notification | 인앱 알림 (이벤트 기반 생성, 커서 페이지네이션 조회) |
+| `user_fcm_tokens` | fcm | FCM 푸시 토큰 (사용자·디바이스별 upsert, 만료 시 자동 삭제) |
 
 ---
 
@@ -99,3 +101,5 @@
 - `chat_rooms`: 그룹 채팅방은 `journey_id` unique.
 - `chat_messages`: `(room_id, id)` 조회 인덱스가 메시지 커서 조회에 사용됩니다.
 - `journey_posts`: `(journey_id, is_deleted, is_notice, created_at, id)` 인덱스가 여정 게시판 조회에 사용됩니다.
+- `notifications`: `(recipient_user_id, id)` 인덱스가 커서 페이지네이션 조회에 사용됩니다.
+- `user_fcm_tokens`: `uk_token (token)` — 동일 토큰 중복 등록 방지. `uk_user_device (user_id, device_type)` — 사용자+디바이스 타입 기준 upsert 키.

--- a/docs/001-design/flows/005-notification-flow.md
+++ b/docs/001-design/flows/005-notification-flow.md
@@ -1,11 +1,12 @@
 # 005. Notification Flow
 
 > 알림 서비스는 도메인 이벤트를 수신해 수신자에게 인앱 알림을 생성·저장하고,
-> 사용자가 알림함에서 조회·읽음 처리하는 흐름이다.
+> FCM 푸시 알림을 비동기로 발송하며, 사용자가 알림함에서 조회·읽음 처리하는 흐름이다.
 
 이 문서는 `알림` 기능을 처음 보는 사람이 아래를 한 번에 이해할 수 있도록 정리한 제품 흐름 문서다.
 
 - 알림이 어떤 경로로 생성되는지 (도메인 이벤트 → 리스너)
+- FCM 푸시 발송 흐름 및 토큰 관리
 - 알림 타입별 수신자 결정 규칙
 - 조회 API의 커서 페이지네이션 방식
 - 예외 처리 및 격리 정책
@@ -52,8 +53,24 @@ NotificationEventListener (REQUIRES_NEW transaction)
   ├── 수신자 결정
   ├── 알림 문구(body) 조립
   ├── notificationRepository.save() / saveAll()
+  ├── fcmPushService.sendToUser() / sendToUsers()  ← 비동기 FCM 발송
   └── 예외 발생 시 log.error()만 남기고 무시
 ```
+
+### FCM 푸시 발송 흐름
+
+```
+fcmPushService.sendToUser(userId, title, body)  [fcmExecutor 스레드풀, @Async]
+  │
+  ├── Firebase 미초기화 → return (graceful skip)
+  ├── user_fcm_tokens 에서 토큰 조회 → 없으면 return
+  ├── 500개 단위 청크 분할
+  └── FirebaseMessaging.sendEachForMulticast()
+        ├── 성공 → 완료
+        └── UNREGISTERED / INVALID_ARGUMENT → 해당 토큰 즉시 삭제
+```
+
+FCM 발송은 인앱 알림 저장과 독립적이다. DB 저장 후 비동기로 실행되므로 FCM 실패가 알림 저장에 영향을 주지 않는다.
 
 ### 이벤트 발행 지점 목록
 
@@ -168,9 +185,8 @@ PATCH /read-all
 
 ---
 
-## 7. 현재 범위 제외 항목 (2차)
+## 7. 현재 범위 제외 항목 (3차)
 
-- FCM 푸시 발송
 - 알림 on/off 설정
 - `SCHEDULE_UPCOMING` — 시간 기반 스케줄러 + 푸시 연동 필요
 - 채팅 새 메시지 알림 — 디바운스/그룹핑 + 푸시 연동 필요

--- a/docs/002-architecture/001-package-structure.md
+++ b/docs/002-architecture/001-package-structure.md
@@ -28,6 +28,8 @@ src/main/java/com/dduru/gildongmu/
 ├── s3/
 ├── verification/
 ├── admin/
+├── notification/
+├── fcm/
 └── common/
 ```
 

--- a/docs/004-operations/001-infrastructure.md
+++ b/docs/004-operations/001-infrastructure.md
@@ -60,6 +60,7 @@
 - `AWS_REGION`, `AWS_S3_BUCKET`, `AWS_S3_ACCESS_KEY`, `AWS_S3_SECRET_KEY`
 - `COOLSMS_API_KEY`, `COOLSMS_API_SECRET`, `COOLSMS_FROM_NUMBER`
 - `KAKAO_*`, `GOOGLE_*`
+- `FCM_SERVICE_ACCOUNT_PATH` — Firebase 서비스 계정 JSON 경로 (`fcm.service-account-path`, 기본값 `firebase/service-account.json`)
 - `ECR_REGISTRY`, `ECR_REPOSITORY`, `IMAGE_TAG`
 
 ---

--- a/src/main/java/com/dduru/gildongmu/common/config/AsyncConfig.java
+++ b/src/main/java/com/dduru/gildongmu/common/config/AsyncConfig.java
@@ -1,0 +1,26 @@
+package com.dduru.gildongmu.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.ThreadPoolExecutor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+
+    @Bean(name = "fcmExecutor")
+    public Executor fcmExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(5);
+        executor.setMaxPoolSize(20);
+        executor.setQueueCapacity(100);
+        executor.setThreadNamePrefix("fcm-");
+        executor.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());
+        executor.initialize();
+        return executor;
+    }
+}

--- a/src/main/java/com/dduru/gildongmu/fcm/config/FirebaseConfig.java
+++ b/src/main/java/com/dduru/gildongmu/fcm/config/FirebaseConfig.java
@@ -1,0 +1,37 @@
+package com.dduru.gildongmu.fcm.config;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+@Slf4j
+@Configuration
+public class FirebaseConfig {
+
+    @Value("${fcm.service-account-path}")
+    private String serviceAccountPath;
+
+    @PostConstruct
+    public void initialize() {
+        if (!FirebaseApp.getApps().isEmpty()) {
+            return;
+        }
+        try {
+            InputStream serviceAccount = new ClassPathResource(serviceAccountPath).getInputStream();
+            FirebaseOptions options = FirebaseOptions.builder()
+                    .setCredentials(GoogleCredentials.fromStream(serviceAccount))
+                    .build();
+            FirebaseApp.initializeApp(options);
+        } catch (IOException e) {
+            log.warn("Firebase 초기화 실패 — FCM 푸시 비활성화됩니다. ({})", e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/dduru/gildongmu/fcm/controller/FcmTokenApiDocs.java
+++ b/src/main/java/com/dduru/gildongmu/fcm/controller/FcmTokenApiDocs.java
@@ -1,0 +1,42 @@
+package com.dduru.gildongmu.fcm.controller;
+
+import com.dduru.gildongmu.common.annotation.ApiErrorResponses;
+import com.dduru.gildongmu.common.dto.ApiResult;
+import com.dduru.gildongmu.common.exception.ErrorCode;
+import com.dduru.gildongmu.fcm.dto.request.FcmTokenDeleteRequest;
+import com.dduru.gildongmu.fcm.dto.request.FcmTokenRegisterRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "FCM Token", description = "FCM 토큰 관리 API")
+@SecurityRequirement(name = "JWT")
+public interface FcmTokenApiDocs {
+
+    @Operation(
+            summary = "FCM 토큰 등록/갱신",
+            description = "기기의 FCM 토큰을 등록합니다. 동일 기기 타입으로 이미 토큰이 있으면 갱신합니다."
+    )
+    @ApiResponse(responseCode = "204", description = "등록/갱신 성공")
+    @ApiErrorResponses({ErrorCode.UNAUTHORIZED, ErrorCode.INVALID_INPUT_VALUE})
+    ResponseEntity<ApiResult<Void>> register(
+            @Parameter(hidden = true) Long userId,
+            @Valid @RequestBody FcmTokenRegisterRequest request
+    );
+
+    @Operation(
+            summary = "FCM 토큰 삭제",
+            description = "로그아웃 시 해당 기기의 FCM 토큰을 삭제합니다."
+    )
+    @ApiResponse(responseCode = "204", description = "삭제 성공")
+    @ApiErrorResponses({ErrorCode.UNAUTHORIZED, ErrorCode.INVALID_INPUT_VALUE})
+    ResponseEntity<ApiResult<Void>> delete(
+            @Parameter(hidden = true) Long userId,
+            @Valid @RequestBody FcmTokenDeleteRequest request
+    );
+}

--- a/src/main/java/com/dduru/gildongmu/fcm/controller/FcmTokenController.java
+++ b/src/main/java/com/dduru/gildongmu/fcm/controller/FcmTokenController.java
@@ -1,0 +1,40 @@
+package com.dduru.gildongmu.fcm.controller;
+
+import com.dduru.gildongmu.common.annotation.CurrentUser;
+import com.dduru.gildongmu.common.dto.ApiResult;
+import com.dduru.gildongmu.fcm.dto.request.FcmTokenDeleteRequest;
+import com.dduru.gildongmu.fcm.dto.request.FcmTokenRegisterRequest;
+import com.dduru.gildongmu.fcm.service.FcmTokenService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/fcm/token")
+public class FcmTokenController implements FcmTokenApiDocs {
+
+    private final FcmTokenService fcmTokenService;
+
+    @Override
+    @PostMapping
+    public ResponseEntity<ApiResult<Void>> register(
+            @CurrentUser Long userId,
+            @Valid @RequestBody FcmTokenRegisterRequest request
+    ) {
+        fcmTokenService.register(userId, request);
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).body(ApiResult.noContent());
+    }
+
+    @Override
+    @DeleteMapping
+    public ResponseEntity<ApiResult<Void>> delete(
+            @CurrentUser Long userId,
+            @Valid @RequestBody FcmTokenDeleteRequest request
+    ) {
+        fcmTokenService.delete(userId, request);
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).body(ApiResult.noContent());
+    }
+}

--- a/src/main/java/com/dduru/gildongmu/fcm/domain/UserFcmToken.java
+++ b/src/main/java/com/dduru/gildongmu/fcm/domain/UserFcmToken.java
@@ -1,0 +1,39 @@
+package com.dduru.gildongmu.fcm.domain;
+
+import com.dduru.gildongmu.common.entity.BaseTimeEntity;
+import com.dduru.gildongmu.fcm.domain.enums.DeviceType;
+import com.dduru.gildongmu.user.domain.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "user_fcm_tokens")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserFcmToken extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(nullable = false, length = 500)
+    private String token;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "device_type", nullable = false, length = 10)
+    private DeviceType deviceType;
+
+    public static UserFcmToken create(User user, String token, DeviceType deviceType) {
+        UserFcmToken fcmToken = new UserFcmToken();
+        fcmToken.user = user;
+        fcmToken.token = token;
+        fcmToken.deviceType = deviceType;
+        return fcmToken;
+    }
+}

--- a/src/main/java/com/dduru/gildongmu/fcm/domain/enums/DeviceType.java
+++ b/src/main/java/com/dduru/gildongmu/fcm/domain/enums/DeviceType.java
@@ -1,0 +1,5 @@
+package com.dduru.gildongmu.fcm.domain.enums;
+
+public enum DeviceType {
+    AOS
+}

--- a/src/main/java/com/dduru/gildongmu/fcm/dto/request/FcmTokenDeleteRequest.java
+++ b/src/main/java/com/dduru/gildongmu/fcm/dto/request/FcmTokenDeleteRequest.java
@@ -1,0 +1,12 @@
+package com.dduru.gildongmu.fcm.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(description = "FCM 토큰 삭제 요청")
+public record FcmTokenDeleteRequest(
+        @Schema(description = "삭제할 FCM 디바이스 토큰", example = "eKxy3z1...")
+        @NotBlank(message = "token은 필수입니다.")
+        String token
+) {
+}

--- a/src/main/java/com/dduru/gildongmu/fcm/dto/request/FcmTokenRegisterRequest.java
+++ b/src/main/java/com/dduru/gildongmu/fcm/dto/request/FcmTokenRegisterRequest.java
@@ -1,0 +1,17 @@
+package com.dduru.gildongmu.fcm.dto.request;
+
+import com.dduru.gildongmu.fcm.domain.enums.DeviceType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "FCM 토큰 등록/갱신 요청")
+public record FcmTokenRegisterRequest(
+        @Schema(description = "FCM 디바이스 토큰", example = "eKxy3z1...")
+        @NotBlank(message = "token은 필수입니다.")
+        String token,
+        @Schema(description = "기기 타입", example = "AOS")
+        @NotNull(message = "deviceType은 필수입니다.")
+        DeviceType deviceType
+) {
+}

--- a/src/main/java/com/dduru/gildongmu/fcm/repository/UserFcmTokenRepository.java
+++ b/src/main/java/com/dduru/gildongmu/fcm/repository/UserFcmTokenRepository.java
@@ -1,0 +1,30 @@
+package com.dduru.gildongmu.fcm.repository;
+
+import com.dduru.gildongmu.fcm.domain.UserFcmToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface UserFcmTokenRepository extends JpaRepository<UserFcmToken, Long> {
+
+    @Modifying(clearAutomatically = true)
+    @Query(value = """
+            INSERT INTO user_fcm_tokens (user_id, token, device_type, created_at, modified_at)
+            VALUES (:userId, :token, :deviceType, NOW(6), NOW(6))
+            ON DUPLICATE KEY UPDATE token = VALUES(token), modified_at = NOW(6)
+            """, nativeQuery = true)
+    void upsert(@Param("userId") Long userId,
+                @Param("token") String token,
+                @Param("deviceType") String deviceType);
+
+    void deleteByToken(String token);
+
+    List<UserFcmToken> findAllByUser_Id(Long userId);
+
+    List<UserFcmToken> findAllByUser_IdIn(List<Long> userIds);
+
+    void deleteByUser_IdAndToken(Long userId, String token);
+}

--- a/src/main/java/com/dduru/gildongmu/fcm/service/FcmPushService.java
+++ b/src/main/java/com/dduru/gildongmu/fcm/service/FcmPushService.java
@@ -1,0 +1,98 @@
+package com.dduru.gildongmu.fcm.service;
+
+import com.dduru.gildongmu.fcm.domain.UserFcmToken;
+import com.dduru.gildongmu.fcm.repository.UserFcmTokenRepository;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.messaging.*;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class FcmPushService {
+
+    private static final int FCM_MAX_TOKENS = 500;
+
+    private final UserFcmTokenRepository userFcmTokenRepository;
+
+    @Async("fcmExecutor")
+    @Transactional
+    public void sendToUser(Long userId, String title, String body) {
+        if (!isFirebaseInitialized()) return;
+
+        List<String> tokens = userFcmTokenRepository.findAllByUser_Id(userId)
+                .stream()
+                .map(UserFcmToken::getToken)
+                .toList();
+
+        if (tokens.isEmpty()) return;
+
+        sendMulticast(tokens, title, body);
+    }
+
+    @Async("fcmExecutor")
+    @Transactional
+    public void sendToUsers(List<Long> userIds, String title, String body) {
+        if (!isFirebaseInitialized()) return;
+        if (userIds.isEmpty()) return;
+
+        List<String> tokens = userFcmTokenRepository.findAllByUser_IdIn(userIds)
+                .stream()
+                .map(UserFcmToken::getToken)
+                .toList();
+
+        if (tokens.isEmpty()) return;
+
+        sendMulticast(tokens, title, body);
+    }
+
+    private void sendMulticast(List<String> tokens, String title, String body) {
+        for (int i = 0; i < tokens.size(); i += FCM_MAX_TOKENS) {
+            List<String> chunk = tokens.subList(i, Math.min(i + FCM_MAX_TOKENS, tokens.size()));
+            sendBatch(chunk, title, body);
+        }
+    }
+
+    private void sendBatch(List<String> tokens, String title, String body) {
+        MulticastMessage message = MulticastMessage.builder()
+                .setNotification(Notification.builder()
+                        .setTitle(title)
+                        .setBody(body)
+                        .build())
+                .addAllTokens(tokens)
+                .build();
+
+        try {
+            BatchResponse response = FirebaseMessaging.getInstance().sendEachForMulticast(message);
+            handleFailedTokens(tokens, response);
+        } catch (FirebaseMessagingException e) {
+            log.error("FCM 멀티캐스트 발송 실패 - tokens={}", tokens.size(), e);
+        }
+    }
+
+    private void handleFailedTokens(List<String> tokens, BatchResponse response) {
+        List<SendResponse> responses = response.getResponses();
+        for (int i = 0; i < responses.size(); i++) {
+            SendResponse sendResponse = responses.get(i);
+            if (!sendResponse.isSuccessful()) {
+                MessagingErrorCode errorCode = sendResponse.getException().getMessagingErrorCode();
+                if (errorCode == MessagingErrorCode.UNREGISTERED
+                        || errorCode == MessagingErrorCode.INVALID_ARGUMENT) {
+                    String expiredToken = tokens.get(i);
+                    userFcmTokenRepository.deleteByToken(expiredToken);
+                    log.info("만료된 FCM 토큰 삭제 - token={}", expiredToken);
+                }
+            }
+        }
+    }
+
+    private boolean isFirebaseInitialized() {
+        return !FirebaseApp.getApps().isEmpty();
+    }
+}

--- a/src/main/java/com/dduru/gildongmu/fcm/service/FcmTokenService.java
+++ b/src/main/java/com/dduru/gildongmu/fcm/service/FcmTokenService.java
@@ -1,0 +1,24 @@
+package com.dduru.gildongmu.fcm.service;
+
+import com.dduru.gildongmu.fcm.dto.request.FcmTokenDeleteRequest;
+import com.dduru.gildongmu.fcm.dto.request.FcmTokenRegisterRequest;
+import com.dduru.gildongmu.fcm.repository.UserFcmTokenRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class FcmTokenService {
+
+    private final UserFcmTokenRepository userFcmTokenRepository;
+
+    public void register(Long userId, FcmTokenRegisterRequest request) {
+        userFcmTokenRepository.upsert(userId, request.token(), request.deviceType().name());
+    }
+
+    public void delete(Long userId, FcmTokenDeleteRequest request) {
+        userFcmTokenRepository.deleteByUser_IdAndToken(userId, request.token());
+    }
+}

--- a/src/main/java/com/dduru/gildongmu/notification/listener/NotificationEventListener.java
+++ b/src/main/java/com/dduru/gildongmu/notification/listener/NotificationEventListener.java
@@ -1,5 +1,6 @@
 package com.dduru.gildongmu.notification.listener;
 
+import com.dduru.gildongmu.fcm.service.FcmPushService;
 import com.dduru.gildongmu.journey.event.JourneyNoticeCreatedEvent;
 import com.dduru.gildongmu.journey.event.ScheduleCanceledEvent;
 import com.dduru.gildongmu.journey.event.ScheduleCreatedEvent;
@@ -32,20 +33,18 @@ public class NotificationEventListener {
     private final NotificationRepository notificationRepository;
     private final JourneyMemberRepository journeyMemberRepository;
     private final UserRepository userRepository;
+    private final FcmPushService fcmPushService;
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void handleMatchApplied(MatchAppliedEvent event) {
         try {
+            String body = "[" + event.postTitle() + "]에 새로운 참여 신청이 도착했습니다.";
             User recipient = userRepository.getReferenceById(event.recipientUserId());
-            Notification notification = Notification.create(
-                    recipient,
-                    NotificationType.MATCH_APPLIED,
-                    "[" + event.postTitle() + "]에 새로운 참여 신청이 도착했습니다.",
-                    ResourceType.MATCH,
-                    event.participationId()
-            );
-            notificationRepository.save(notification);
+            notificationRepository.save(Notification.create(
+                    recipient, NotificationType.MATCH_APPLIED, body, ResourceType.MATCH, event.participationId()
+            ));
+            fcmPushService.sendToUser(event.recipientUserId(), "새로운 참여 신청", body);
         } catch (Exception e) {
             log.error("MATCH_APPLIED 알림 저장 실패 - participationId={}", event.participationId(), e);
         }
@@ -55,17 +54,14 @@ public class NotificationEventListener {
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void handleMatchApproved(MatchApprovedEvent event) {
         try {
+            String body = "[" + event.journeyTitle() + "] 여행 참여가 승인되었습니다.";
             User recipient = userRepository.getReferenceById(event.applicantUserId());
-            Notification notification = Notification.create(
-                    recipient,
-                    NotificationType.MATCH_APPROVED,
-                    "[" + event.journeyTitle() + "] 여행 참여가 승인되었습니다.",
-                    ResourceType.JOURNEY,
-                    event.journeyId()
-            );
-            notificationRepository.save(notification);
+            notificationRepository.save(Notification.create(
+                    recipient, NotificationType.MATCH_APPROVED, body, ResourceType.JOURNEY, event.journeyId()
+            ));
+            fcmPushService.sendToUser(event.applicantUserId(), "참여 승인", body);
         } catch (Exception e) {
-            log.error("MATCH_APPROVED 알림 저장 실패 - participationId={}", event.participationId(), e);
+            log.error("MATCH_APPROVED 알림 저장 실패 - journeyId={}", event.journeyId(), e);
         }
     }
 
@@ -73,15 +69,12 @@ public class NotificationEventListener {
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void handleMatchRejected(MatchRejectedEvent event) {
         try {
+            String body = "참여 신청이 검토되었으나 함께하기 어렵게 되었습니다.";
             User recipient = userRepository.getReferenceById(event.applicantUserId());
-            Notification notification = Notification.create(
-                    recipient,
-                    NotificationType.MATCH_REJECTED,
-                    "참여 신청이 검토되었으나 함께하기 어렵게 되었습니다.",
-                    ResourceType.MATCH,
-                    event.participationId()
-            );
-            notificationRepository.save(notification);
+            notificationRepository.save(Notification.create(
+                    recipient, NotificationType.MATCH_REJECTED, body, ResourceType.MATCH, event.participationId()
+            ));
+            fcmPushService.sendToUser(event.applicantUserId(), "참여 신청 결과", body);
         } catch (Exception e) {
             log.error("MATCH_REJECTED 알림 저장 실패 - participationId={}", event.participationId(), e);
         }
@@ -93,21 +86,18 @@ public class NotificationEventListener {
         try {
             List<Long> recipientIds = journeyMemberRepository
                     .findActiveUserIdsByJourneyIdExcludingUser(event.journeyId(), event.actorUserId());
-            if (recipientIds.isEmpty()) {
-                return;
-            }
+            if (recipientIds.isEmpty()) return;
 
             String body = "[" + event.journeyTitle() + "] 새 공지가 등록되었습니다.";
             List<Notification> notifications = recipientIds.stream()
                     .map(id -> Notification.create(
                             userRepository.getReferenceById(id),
-                            NotificationType.JOURNEY_NOTICE,
-                            body,
-                            ResourceType.JOURNEY_POST,
-                            event.journeyPostId()
+                            NotificationType.JOURNEY_NOTICE, body,
+                            ResourceType.JOURNEY_POST, event.journeyPostId()
                     ))
                     .toList();
             notificationRepository.saveAll(notifications);
+            fcmPushService.sendToUsers(recipientIds, "새 공지", body);
         } catch (Exception e) {
             log.error("JOURNEY_NOTICE 알림 저장 실패 - journeyPostId={}", event.journeyPostId(), e);
         }
@@ -117,11 +107,11 @@ public class NotificationEventListener {
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void handleScheduleCreated(ScheduleCreatedEvent event) {
         try {
-            saveScheduleNotifications(
+            saveScheduleNotificationsAndPush(
                     event.journeyId(), event.actorUserId(),
                     NotificationType.SCHEDULE_CREATED,
                     "[" + event.scheduleTitle() + "] 일정이 추가되었습니다.",
-                    event.scheduleId()
+                    "새 일정", event.scheduleId()
             );
         } catch (Exception e) {
             log.error("SCHEDULE_CREATED 알림 저장 실패 - scheduleId={}", event.scheduleId(), e);
@@ -132,11 +122,11 @@ public class NotificationEventListener {
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void handleScheduleUpdated(ScheduleUpdatedEvent event) {
         try {
-            saveScheduleNotifications(
+            saveScheduleNotificationsAndPush(
                     event.journeyId(), event.actorUserId(),
                     NotificationType.SCHEDULE_UPDATED,
                     "[" + event.scheduleTitle() + "] 일정이 변경되었습니다.",
-                    event.scheduleId()
+                    "일정 변경", event.scheduleId()
             );
         } catch (Exception e) {
             log.error("SCHEDULE_UPDATED 알림 저장 실패 - scheduleId={}", event.scheduleId(), e);
@@ -147,39 +137,32 @@ public class NotificationEventListener {
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void handleScheduleCanceled(ScheduleCanceledEvent event) {
         try {
-            saveScheduleNotifications(
+            saveScheduleNotificationsAndPush(
                     event.journeyId(), event.actorUserId(),
                     NotificationType.SCHEDULE_CANCELED,
                     "[" + event.scheduleTitle() + "] 일정이 취소되었습니다.",
-                    event.scheduleId()
+                    "일정 취소", event.scheduleId()
             );
         } catch (Exception e) {
             log.error("SCHEDULE_CANCELED 알림 저장 실패 - scheduleId={}", event.scheduleId(), e);
         }
     }
 
-    private void saveScheduleNotifications(
-            Long journeyId,
-            Long actorUserId,
-            NotificationType type,
-            String body,
-            Long scheduleId
+    private void saveScheduleNotificationsAndPush(
+            Long journeyId, Long actorUserId,
+            NotificationType type, String body, String pushTitle, Long scheduleId
     ) {
         List<Long> recipientIds = journeyMemberRepository
                 .findActiveUserIdsByJourneyIdExcludingUser(journeyId, actorUserId);
-        if (recipientIds.isEmpty()) {
-            return;
-        }
+        if (recipientIds.isEmpty()) return;
 
         List<Notification> notifications = recipientIds.stream()
                 .map(id -> Notification.create(
                         userRepository.getReferenceById(id),
-                        type,
-                        body,
-                        ResourceType.SCHEDULE,
-                        scheduleId
+                        type, body, ResourceType.SCHEDULE, scheduleId
                 ))
                 .toList();
         notificationRepository.saveAll(notifications);
+        fcmPushService.sendToUsers(recipientIds, pushTitle, body);
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -70,6 +70,9 @@ springdoc:
   default-consumes-media-type: application/json;charset=UTF-8
   default-produces-media-type: application/json;charset=UTF-8
 
+fcm:
+  service-account-path: firebase/service-account.json
+
 logging:
   pattern:
     console: "%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - [reqId=%X{requestId:-} ip=%X{clientIp:-} method=%X{method:-} uri=%X{uri:-} userId=%X{userId:-} ua=%X{userAgent:-}] %msg%n"

--- a/src/main/resources/db/migration/V25__user_fcm_tokens.sql
+++ b/src/main/resources/db/migration/V25__user_fcm_tokens.sql
@@ -1,0 +1,13 @@
+CREATE TABLE user_fcm_tokens
+(
+    id          BIGINT       NOT NULL AUTO_INCREMENT,
+    user_id     BIGINT       NOT NULL,
+    token       VARCHAR(500) NOT NULL,
+    device_type VARCHAR(10)  NOT NULL,
+    created_at  DATETIME(6)  NOT NULL,
+    modified_at DATETIME(6)  NOT NULL,
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_token (token),
+    UNIQUE KEY uk_user_device (user_id, device_type),
+    CONSTRAINT fk_fcm_token_user FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE
+);

--- a/src/test/java/com/dduru/gildongmu/fcm/service/FcmPushServiceTest.java
+++ b/src/test/java/com/dduru/gildongmu/fcm/service/FcmPushServiceTest.java
@@ -1,0 +1,142 @@
+package com.dduru.gildongmu.fcm.service;
+
+import com.dduru.gildongmu.fcm.domain.UserFcmToken;
+import com.dduru.gildongmu.fcm.domain.enums.DeviceType;
+import com.dduru.gildongmu.fcm.repository.UserFcmTokenRepository;
+import com.dduru.gildongmu.user.domain.User;
+import com.dduru.gildongmu.user.domain.enums.OauthType;
+import com.google.firebase.FirebaseApp;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("FcmPushService 테스트")
+class FcmPushServiceTest {
+
+    @Mock
+    private UserFcmTokenRepository userFcmTokenRepository;
+
+    private FcmPushService fcmPushService;
+
+    @BeforeEach
+    void setUp() {
+        fcmPushService = new FcmPushService(userFcmTokenRepository);
+    }
+
+    @Nested
+    @DisplayName("단일 사용자 푸시 발송")
+    class SendToUser {
+
+        @Test
+        @DisplayName("Firebase가 초기화되지 않으면 토큰 조회 없이 종료한다")
+        void skipsWhenFirebaseNotInitialized() {
+            try (MockedStatic<FirebaseApp> firebaseAppMock = mockStatic(FirebaseApp.class)) {
+                firebaseAppMock.when(FirebaseApp::getApps).thenReturn(List.of());
+
+                fcmPushService.sendToUser(1L, "제목", "내용");
+
+                verify(userFcmTokenRepository, never()).findAllByUser_Id(any());
+            }
+        }
+
+        @Test
+        @DisplayName("Firebase가 초기화됐으나 등록된 토큰이 없으면 발송하지 않는다")
+        void skipsWhenNoTokensRegistered() {
+            try (MockedStatic<FirebaseApp> firebaseAppMock = mockStatic(FirebaseApp.class)) {
+                firebaseAppMock.when(FirebaseApp::getApps).thenReturn(List.of(mock(FirebaseApp.class)));
+                when(userFcmTokenRepository.findAllByUser_Id(1L)).thenReturn(List.of());
+
+                fcmPushService.sendToUser(1L, "제목", "내용");
+
+                verify(userFcmTokenRepository).findAllByUser_Id(1L);
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("다수 사용자 푸시 발송")
+    class SendToUsers {
+
+        @Test
+        @DisplayName("Firebase가 초기화되지 않으면 토큰 조회 없이 종료한다")
+        void skipsWhenFirebaseNotInitialized() {
+            try (MockedStatic<FirebaseApp> firebaseAppMock = mockStatic(FirebaseApp.class)) {
+                firebaseAppMock.when(FirebaseApp::getApps).thenReturn(List.of());
+
+                fcmPushService.sendToUsers(List.of(1L, 2L), "제목", "내용");
+
+                verify(userFcmTokenRepository, never()).findAllByUser_Id(any());
+            }
+        }
+
+        @Test
+        @DisplayName("userIds가 비어 있으면 토큰 조회 없이 종료한다")
+        void skipsWhenUserIdsIsEmpty() {
+            fcmPushService.sendToUsers(List.of(), "제목", "내용");
+
+            verify(userFcmTokenRepository, never()).findAllByUser_Id(any());
+        }
+
+        @Test
+        @DisplayName("Firebase가 초기화됐으나 모든 사용자의 토큰이 없으면 발송하지 않는다")
+        void skipsWhenNoTokensForAnyUser() {
+            try (MockedStatic<FirebaseApp> firebaseAppMock = mockStatic(FirebaseApp.class)) {
+                firebaseAppMock.when(FirebaseApp::getApps).thenReturn(List.of(mock(FirebaseApp.class)));
+                when(userFcmTokenRepository.findAllByUser_Id(1L)).thenReturn(List.of());
+                when(userFcmTokenRepository.findAllByUser_Id(2L)).thenReturn(List.of());
+
+                fcmPushService.sendToUsers(List.of(1L, 2L), "제목", "내용");
+
+                verify(userFcmTokenRepository).findAllByUser_Id(1L);
+                verify(userFcmTokenRepository).findAllByUser_Id(2L);
+            }
+        }
+
+        @Test
+        @DisplayName("Firebase가 초기화되면 모든 사용자의 토큰을 수집한다")
+        void collectsTokensFromAllUsers() {
+            try (MockedStatic<FirebaseApp> firebaseAppMock = mockStatic(FirebaseApp.class)) {
+                firebaseAppMock.when(FirebaseApp::getApps).thenReturn(List.of(mock(FirebaseApp.class)));
+
+                UserFcmToken token1 = createFcmToken(1L, "token-user1");
+                UserFcmToken token2 = createFcmToken(2L, "token-user2");
+                when(userFcmTokenRepository.findAllByUser_Id(1L)).thenReturn(List.of(token1));
+                when(userFcmTokenRepository.findAllByUser_Id(2L)).thenReturn(List.of(token2));
+
+                // Firebase 실제 발송은 하지 않으므로 토큰 조회까지만 검증
+                // (FirebaseMessaging.getInstance()는 실제 Firebase 없이 호출 불가)
+                try {
+                    fcmPushService.sendToUsers(List.of(1L, 2L), "제목", "내용");
+                } catch (Exception ignored) {
+                    // Firebase 미초기화 환경에서 sendEachForMulticast 호출 시 발생하는 예외 무시
+                }
+
+                verify(userFcmTokenRepository).findAllByUser_Id(1L);
+                verify(userFcmTokenRepository).findAllByUser_Id(2L);
+            }
+        }
+    }
+
+    private UserFcmToken createFcmToken(Long userId, String token) {
+        User user = User.builder()
+                .email("user" + userId + "@example.com")
+                .name("user" + userId)
+                .oauthId("oauth-" + userId)
+                .oauthType(OauthType.KAKAO)
+                .build();
+        ReflectionTestUtils.setField(user, "id", userId);
+        return UserFcmToken.create(user, token, DeviceType.AOS);
+    }
+}

--- a/src/test/java/com/dduru/gildongmu/fcm/service/FcmTokenServiceTest.java
+++ b/src/test/java/com/dduru/gildongmu/fcm/service/FcmTokenServiceTest.java
@@ -1,0 +1,62 @@
+package com.dduru.gildongmu.fcm.service;
+
+import com.dduru.gildongmu.fcm.domain.enums.DeviceType;
+import com.dduru.gildongmu.fcm.dto.request.FcmTokenDeleteRequest;
+import com.dduru.gildongmu.fcm.dto.request.FcmTokenRegisterRequest;
+import com.dduru.gildongmu.fcm.repository.UserFcmTokenRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("FcmTokenService 테스트")
+class FcmTokenServiceTest {
+
+    @Mock
+    private UserFcmTokenRepository userFcmTokenRepository;
+
+    private FcmTokenService fcmTokenService;
+
+    @BeforeEach
+    void setUp() {
+        fcmTokenService = new FcmTokenService(userFcmTokenRepository);
+    }
+
+    @Nested
+    @DisplayName("토큰 등록/갱신")
+    class Register {
+
+        @Test
+        @DisplayName("userId, token, deviceType을 upsert 쿼리에 전달한다")
+        void callsUpsertWithCorrectArguments() {
+            Long userId = 1L;
+            FcmTokenRegisterRequest request = new FcmTokenRegisterRequest("fcm-token-abc", DeviceType.AOS);
+
+            fcmTokenService.register(userId, request);
+
+            verify(userFcmTokenRepository).upsert(userId, "fcm-token-abc", "AOS");
+        }
+    }
+
+    @Nested
+    @DisplayName("토큰 삭제 (로그아웃)")
+    class Delete {
+
+        @Test
+        @DisplayName("userId와 token으로 해당 기기 토큰을 삭제한다")
+        void callsDeleteWithCorrectArguments() {
+            Long userId = 1L;
+            FcmTokenDeleteRequest request = new FcmTokenDeleteRequest("fcm-token-abc");
+
+            fcmTokenService.delete(userId, request);
+
+            verify(userFcmTokenRepository).deleteByUser_IdAndToken(userId, "fcm-token-abc");
+        }
+    }
+}

--- a/src/test/java/com/dduru/gildongmu/notification/listener/NotificationEventListenerTest.java
+++ b/src/test/java/com/dduru/gildongmu/notification/listener/NotificationEventListenerTest.java
@@ -14,6 +14,7 @@ import com.dduru.gildongmu.participation.event.MatchApprovedEvent;
 import com.dduru.gildongmu.participation.event.MatchRejectedEvent;
 import com.dduru.gildongmu.user.domain.User;
 import com.dduru.gildongmu.user.domain.enums.OauthType;
+import com.dduru.gildongmu.fcm.service.FcmPushService;
 import com.dduru.gildongmu.user.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -47,11 +48,14 @@ class NotificationEventListenerTest {
     @Mock
     private UserRepository userRepository;
 
+    @Mock
+    private FcmPushService fcmPushService;
+
     private NotificationEventListener listener;
 
     @BeforeEach
     void setUp() {
-        listener = new NotificationEventListener(notificationRepository, journeyMemberRepository, userRepository);
+        listener = new NotificationEventListener(notificationRepository, journeyMemberRepository, userRepository, fcmPushService);
     }
 
     // ── MATCH ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## 🔎 작업 내용
  * FCM 디바이스 토큰 관리 및 푸시 알림 발송 구현
  * 토큰 등록(`POST /api/v1/fcm/token`) / 삭제(`DELETE /api/v1/fcm/token`) API 구현
  * `ON DUPLICATE KEY UPDATE` upsert로 사용자+디바이스 기준 토큰 단일 유지
  * 알림 저장 후 `@Async("fcmExecutor")`로 FCM 푸시를 비동기 발송 (인앱 알림 저장과 독립)
  * Firebase 500개 토큰 제한 대응: 청크 단위 분할 발송
  * UNREGISTERED / INVALID_ARGUMENT 응답 수신 시 만료 토큰 즉시 삭제
  * Firebase 미초기화 환경(local 등)에서 graceful skip
  
## ➕ 이슈 링크
* CLOSED #288 

## 😎 리뷰 요구사항
* google-services.json 프론트에 공유 필요
* firebase 패키지의 service-account.json은 git ignore에 추가

## 📝 체크리스트
- [x] 브랜치 이름은 `feat/개발내용` 형식으로 작성했는가?
- [x] 커밋 메시지는 `feat(scope): 커밋 내용` 형식으로 작성했는가?
- [x] 작업 전 Issue를 작성했는가?
- [x] `dev` 브랜치로 병합을 요청했는가?
- [x] 불필요한 주석과 공백은 제거했는가?
- [ ] 코드 리뷰어의 피드백을 반영했는가?
- [x] 테스트를 진행했는가?
- [x] 테스트 코드를 작성했는가?
