### PR TITLE
feat(notification): 알림 수신 전체 on/off 설정 기능 추가

### DIFF
--- a/docs/001-design/flows/005-notification-flow.md
+++ b/docs/001-design/flows/005-notification-flow.md
@@ -52,8 +52,9 @@ NotificationEventListener
   │
   ├── 수신자 결정
   ├── 알림 문구(body) 조립
-  ├── notificationPersistService.save() / saveAll()  ← REQUIRES_NEW 별도 트랜잭션
-  ├── fcmPushService.sendToUser() / sendToUsers()    ← 비동기 FCM 발송
+  ├── notificationPersistService.save() / saveAll()  ← REQUIRES_NEW 별도 트랜잭션 (전체 수신자)
+  ├── notificationEnabled = true 유저만 필터링       ← FCM 발송 대상 결정
+  ├── fcmPushService.sendToUser() / sendToUsers()    ← 비동기 FCM 발송 (필터링된 수신자)
   └── 예외 발생 시 log.error()만 남기고 무시
 ```
 
@@ -90,6 +91,11 @@ fcmPushService.sendToUser(userId, title, body)  [fcmExecutor 스레드풀, @Asyn
 ```
 
 FCM 발송은 인앱 알림 저장과 독립적이다. DB 저장 후 비동기로 실행되므로 FCM 실패가 알림 저장에 영향을 주지 않는다.
+
+> **알림 설정과 FCM 발송의 관계**
+> 인앱 알림(`notifications` 테이블)은 `notificationEnabled` 여부와 무관하게 항상 저장된다.
+> FCM 푸시만 `notificationEnabled = false` 유저를 발송 대상에서 제외한다.
+> 카카오톡 알림 끄기와 동일한 동작 — 앱 알림함에서는 확인 가능하고, 핸드폰 푸시만 차단.
 
 ### 이벤트 발행 지점 목록
 
@@ -207,9 +213,23 @@ PATCH /read-all
 
 ---
 
-## 7. 현재 범위 제외 항목 (3차)
+## 7. 알림 수신 설정 (on/off)
 
-- 알림 on/off 설정
+`PATCH /api/v1/notifications/settings` — 알림 수신 전체 on/off 설정
+
+```json
+{ "enabled": false }
+```
+
+- `users.notification_enabled` 컬럼으로 관리 (기본값 `true`)
+- off 시 FCM 푸시만 차단, 인앱 알림은 계속 저장됨
+- 1:1 알림(`MATCH_APPLIED`, `MATCH_APPROVED`): `existsByIdAndNotificationEnabled`로 발송 전 확인
+- 그룹 알림: `findEnabledUserIds(recipientIds)`로 발송 대상 필터링 후 FCM 호출
+
+---
+
+## 8. 현재 범위 제외 항목
+
 - `SCHEDULE_UPCOMING` — 시간 기반 스케줄러 + 푸시 연동 필요
 - 채팅 새 메시지 알림 — 디바운스/그룹핑 + 푸시 연동 필요
 - 시스템 공지/이벤트 (어드민 발송)

--- a/src/main/java/com/dduru/gildongmu/notification/controller/NotificationApiDocs.java
+++ b/src/main/java/com/dduru/gildongmu/notification/controller/NotificationApiDocs.java
@@ -4,6 +4,7 @@ import com.dduru.gildongmu.common.annotation.ApiErrorResponses;
 import com.dduru.gildongmu.common.dto.ApiResult;
 import com.dduru.gildongmu.common.exception.ErrorCode;
 import com.dduru.gildongmu.notification.dto.request.NotificationListRequest;
+import com.dduru.gildongmu.notification.dto.request.NotificationSettingsRequest;
 import com.dduru.gildongmu.notification.dto.response.NotificationListResponse;
 import com.dduru.gildongmu.notification.dto.response.NotificationReadResponse;
 import com.dduru.gildongmu.notification.dto.response.UnreadCountResponse;
@@ -16,6 +17,7 @@ import jakarta.validation.Valid;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "Notifications", description = "알림 API")
 @SecurityRequirement(name = "JWT")
@@ -56,5 +58,13 @@ public interface NotificationApiDocs {
     @ApiErrorResponses({ErrorCode.UNAUTHORIZED})
     ResponseEntity<ApiResult<NotificationReadResponse>> markAllAsRead(
             @Parameter(hidden = true) Long userId
+    );
+
+    @Operation(summary = "알림 설정 변경", description = "알림 수신 전체 on/off를 설정합니다.")
+    @ApiResponse(responseCode = "204", description = "설정 변경 성공")
+    @ApiErrorResponses({ErrorCode.UNAUTHORIZED, ErrorCode.INVALID_INPUT_VALUE})
+    ResponseEntity<ApiResult<Void>> updateNotificationSettings(
+            @Parameter(hidden = true) Long userId,
+            @Valid @RequestBody NotificationSettingsRequest request
     );
 }

--- a/src/main/java/com/dduru/gildongmu/notification/controller/NotificationController.java
+++ b/src/main/java/com/dduru/gildongmu/notification/controller/NotificationController.java
@@ -3,6 +3,7 @@ package com.dduru.gildongmu.notification.controller;
 import com.dduru.gildongmu.common.annotation.CurrentUser;
 import com.dduru.gildongmu.common.dto.ApiResult;
 import com.dduru.gildongmu.notification.dto.request.NotificationListRequest;
+import com.dduru.gildongmu.notification.dto.request.NotificationSettingsRequest;
 import com.dduru.gildongmu.notification.dto.response.NotificationListResponse;
 import com.dduru.gildongmu.notification.dto.response.NotificationReadResponse;
 import com.dduru.gildongmu.notification.dto.response.UnreadCountResponse;
@@ -10,6 +11,7 @@ import com.dduru.gildongmu.notification.service.NotificationQueryService;
 import com.dduru.gildongmu.notification.service.NotificationService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -53,5 +55,15 @@ public class NotificationController implements NotificationApiDocs {
             @CurrentUser Long userId
     ) {
         return ResponseEntity.ok(ApiResult.ok(notificationService.markAllAsRead(userId)));
+    }
+
+    @Override
+    @PatchMapping("/settings")
+    public ResponseEntity<ApiResult<Void>> updateNotificationSettings(
+            @CurrentUser Long userId,
+            @Valid @RequestBody NotificationSettingsRequest request
+    ) {
+        notificationService.updateNotificationSettings(userId, request.enabled());
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).body(ApiResult.noContent());
     }
 }

--- a/src/main/java/com/dduru/gildongmu/notification/dto/request/NotificationSettingsRequest.java
+++ b/src/main/java/com/dduru/gildongmu/notification/dto/request/NotificationSettingsRequest.java
@@ -1,0 +1,12 @@
+package com.dduru.gildongmu.notification.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "알림 설정 변경 요청")
+public record NotificationSettingsRequest(
+        @Schema(description = "알림 수신 여부", example = "true")
+        @NotNull(message = "enabled는 필수입니다.")
+        Boolean enabled
+) {
+}

--- a/src/main/java/com/dduru/gildongmu/notification/listener/NotificationEventListener.java
+++ b/src/main/java/com/dduru/gildongmu/notification/listener/NotificationEventListener.java
@@ -43,7 +43,9 @@ public class NotificationEventListener {
                     userRepository.getReferenceById(event.recipientUserId()),
                     NotificationType.MATCH_APPLIED, body, ResourceType.MATCH, event.participationId()
             ));
-            fcmPushService.sendToUser(event.recipientUserId(), "매칭 신청 도착", body);
+            if (userRepository.existsByIdAndNotificationEnabled(event.recipientUserId(), true)) {
+                fcmPushService.sendToUser(event.recipientUserId(), "매칭 신청 도착", body);
+            }
         } catch (Exception e) {
             log.error("MATCH_APPLIED 알림 저장 실패 - participationId={}", event.participationId(), e);
         }
@@ -57,7 +59,9 @@ public class NotificationEventListener {
                     userRepository.getReferenceById(event.applicantUserId()),
                     NotificationType.MATCH_APPROVED, body, ResourceType.JOURNEY, event.journeyId()
             ));
-            fcmPushService.sendToUser(event.applicantUserId(), "매칭 승인", body);
+            if (userRepository.existsByIdAndNotificationEnabled(event.applicantUserId(), true)) {
+                fcmPushService.sendToUser(event.applicantUserId(), "매칭 승인", body);
+            }
         } catch (Exception e) {
             log.error("MATCH_APPROVED 알림 저장 실패 - journeyId={}", event.journeyId(), e);
         }
@@ -152,6 +156,8 @@ public class NotificationEventListener {
                 ))
                 .toList();
         notificationPersistService.saveAll(notifications);
-        fcmPushService.sendToUsers(recipientIds, pushTitle, body);
+        List<Long> fcmTargetIds = userRepository.findEnabledUserIds(recipientIds);
+        if (fcmTargetIds.isEmpty()) return;
+        fcmPushService.sendToUsers(fcmTargetIds, pushTitle, body);
     }
 }

--- a/src/main/java/com/dduru/gildongmu/notification/service/NotificationService.java
+++ b/src/main/java/com/dduru/gildongmu/notification/service/NotificationService.java
@@ -5,6 +5,8 @@ import com.dduru.gildongmu.notification.domain.Notification;
 import com.dduru.gildongmu.notification.dto.response.NotificationReadResponse;
 import com.dduru.gildongmu.notification.exception.NotificationAccessDeniedException;
 import com.dduru.gildongmu.notification.repository.NotificationRepository;
+import com.dduru.gildongmu.user.domain.User;
+import com.dduru.gildongmu.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class NotificationService {
 
     private final NotificationRepository notificationRepository;
+    private final UserRepository userRepository;
     private final TimeProvider timeProvider;
 
     public NotificationReadResponse markAsRead(Long userId, Long notificationId) {
@@ -34,5 +37,10 @@ public class NotificationService {
     public NotificationReadResponse markAllAsRead(Long userId) {
         notificationRepository.markAllAsReadByRecipientId(userId, timeProvider.now());
         return NotificationReadResponse.ok();
+    }
+
+    public void updateNotificationSettings(Long userId, boolean enabled) {
+        User user = userRepository.getByIdOrThrow(userId);
+        user.updateNotificationEnabled(enabled);
     }
 }

--- a/src/main/java/com/dduru/gildongmu/user/domain/User.java
+++ b/src/main/java/com/dduru/gildongmu/user/domain/User.java
@@ -39,6 +39,9 @@ public class User extends BaseTimeEntity {
     @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     private Profile profile;
 
+    @Column(name = "notification_enabled", nullable = false)
+    private boolean notificationEnabled = true;
+
     @Builder
     public User(String email, String name, String oauthId, OauthType oauthType, Role role) {
         this.email = email;
@@ -46,5 +49,10 @@ public class User extends BaseTimeEntity {
         this.oauthId = oauthId;
         this.oauthType = oauthType;
         this.role = role != null ? role : Role.USER;
+        this.notificationEnabled = true;
+    }
+
+    public void updateNotificationEnabled(boolean enabled) {
+        this.notificationEnabled = enabled;
     }
 }

--- a/src/main/java/com/dduru/gildongmu/user/repository/UserRepository.java
+++ b/src/main/java/com/dduru/gildongmu/user/repository/UserRepository.java
@@ -41,4 +41,9 @@ public interface UserRepository extends JpaRepository<User, Long> {
         return findById(id)
                 .orElseThrow(UserNotFoundException::new);
     }
+
+    @Query("SELECT u.id FROM User u WHERE u.id IN :ids AND u.notificationEnabled = true")
+    List<Long> findEnabledUserIds(@Param("ids") List<Long> ids);
+
+    boolean existsByIdAndNotificationEnabled(Long id, boolean notificationEnabled);
 }

--- a/src/main/resources/db/migration/V26__user_notification_enabled.sql
+++ b/src/main/resources/db/migration/V26__user_notification_enabled.sql
@@ -1,0 +1,2 @@
+ALTER TABLE users
+    ADD COLUMN notification_enabled TINYINT(1) NOT NULL DEFAULT 1;

--- a/src/test/java/com/dduru/gildongmu/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/dduru/gildongmu/notification/service/NotificationServiceTest.java
@@ -10,6 +10,7 @@ import com.dduru.gildongmu.notification.exception.NotificationNotFoundException;
 import com.dduru.gildongmu.notification.repository.NotificationRepository;
 import com.dduru.gildongmu.user.domain.User;
 import com.dduru.gildongmu.user.domain.enums.OauthType;
+import com.dduru.gildongmu.user.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -39,6 +40,9 @@ class NotificationServiceTest {
     private NotificationRepository notificationRepository;
 
     @Mock
+    private UserRepository userRepository;
+
+    @Mock
     private TimeProvider timeProvider;
 
     private NotificationService notificationService;
@@ -46,7 +50,7 @@ class NotificationServiceTest {
     @BeforeEach
     void setUp() {
         lenient().when(timeProvider.now()).thenReturn(NOW);
-        notificationService = new NotificationService(notificationRepository, timeProvider);
+        notificationService = new NotificationService(notificationRepository, userRepository, timeProvider);
     }
 
     @Nested


### PR DESCRIPTION
## 🔎 작업 내용
  * `users.notification_enabled` 컬럼 추가 (Flyway V26 마이그레이션)
  * `User` 엔티티에 `notificationEnabled` 필드 및 `updateNotificationEnabled()` 도메인 메서드 추가
  * `PATCH /api/v1/notifications/settings` 엔드포인트 추가
  * `NotificationSettingsRequest` DTO 추가
  * `UserRepository`에 `findEnabledUserIds()`, `existsByIdAndNotificationEnabled()` 추가
  * `NotificationEventListener`에서 인앱 알림 저장은 전체 수신자 유지, FCM 발송 직전 `notificationEnabled = true` 유저만 필터링


## ➕ 이슈 링크
* CLOSED #301 

## 📸 스크린샷


## 😎 리뷰 요구사항
 > * 알림 off 시 FCM만 차단하고 인앱 알림은 계속 저장하는 방식으로 구현했습니다.
 > * 알림 수신 설정을 별도 테이블로 분리하지 않고 `users` 테이블에 `notification_enabled` 컬럼으로 구현했습니다. 설정 항목이 현재 1개이고 유저와 1:1 관계가 명확해 조인 없이 단순하게 처리할 수 있다고 판단했습니다

## 🧑‍💻 예정 작업
- 없음

## 📝 체크리스트
- [x] 브랜치 이름은 `feat/#이슈번호-개발내용` 형식으로 작성했는가?
- [x] 커밋 메시지는 `[#이슈번호] feat(scope): 커밋 내용` 형식으로 작성했는가?
- [x] PR 제목은 `feat(scope): PR 제목` 형식으로 작성했는가?
- [x] 작업 전 Issue를 작성했는가?
- [x] `dev` 브랜치로 병합을 요청했는가?
- [x] 불필요한 주석과 공백은 제거했는가?
- [ ] 코드 리뷰어의 피드백을 반영했는가?
- [x] 테스트를 진행했는가?
- [ ] 테스트 코드를 작성했는가? 