### PR TITLE
feat(notification): 여행 임박 알림 자동 발송 기능

### DIFF
--- a/docs/001-design/flows/005-notification-flow.md
+++ b/docs/001-design/flows/005-notification-flow.md
@@ -109,7 +109,7 @@ FCM 발송은 인앱 알림 저장과 독립적이다. DB 저장 후 비동기�
 | `JourneyScheduleService` | `deleteSchedule()` | `ScheduleCanceledEvent` |
 | `PostService` | `update()` | `PostUpdatedEvent` |
 
-> `TRIP_UPCOMING`은 이벤트 기반이 아닌 스케줄러 기반으로 발송한다. 아래 9절 참고.
+> `TRIP_UPCOMING`은 이벤트 기반이 아닌 스케줄러 기반으로 발송한다. 아래 7절 참고.
 
 ---
 
@@ -227,12 +227,12 @@ TripUpcomingScheduler (@Scheduled — 매일 오전 9시)
   └── TripUpcomingNotificationService.notifyUpcomingTrips()
         ├── startDate = 오늘 + 3일인 여정의 ACTIVE 멤버 전체 조회
         ├── 여정별 그룹핑
-        ├── 오늘 이미 발송된 여정은 스킵 (중복 발송 방지)
-        ├── Notification 인앱 저장 (전체 멤버)
+        ├── 오늘 이미 발송된 멤버 제외 (멤버 단위 중복 방지)
+        ├── Notification 인앱 저장 (미발송 멤버)
         └── FCM 발송 (notificationEnabled = true 멤버만)
 ```
 
-**중복 발송 방지**: `notifications` 테이블에 해당 `journeyId`로 `TRIP_UPCOMING` 알림이 오늘 이미 생성돼 있으면 스킵한다.
+**중복 발송 방지**: `notifications` 테이블에서 오늘 생성된 `TRIP_UPCOMING` 알림의 recipient_id를 조회해, 이미 수신한 멤버는 제외하고 미수신 멤버에게만 발송한다.
 
 ---
 

--- a/docs/001-design/flows/005-notification-flow.md
+++ b/docs/001-design/flows/005-notification-flow.md
@@ -109,6 +109,8 @@ FCM 발송은 인앱 알림 저장과 독립적이다. DB 저장 후 비동기�
 | `JourneyScheduleService` | `deleteSchedule()` | `ScheduleCanceledEvent` |
 | `PostService` | `update()` | `PostUpdatedEvent` |
 
+> `TRIP_UPCOMING`은 이벤트 기반이 아닌 스케줄러 기반으로 발송한다. 아래 9절 참고.
+
 ---
 
 ## 3. 알림 타입별 규칙
@@ -122,8 +124,9 @@ FCM 발송은 인앱 알림 저장과 독립적이다. DB 저장 후 비동기�
 | `JOURNEY_NOTICE` | 여정 ACTIVE 멤버 전원 (행위자 제외) | `JourneyMemberRepository`로 조회 |
 | `SCHEDULE_CREATED / UPDATED / CANCELED` | 여정 ACTIVE 멤버 전원 (행위자 제외) | `JourneyMemberRepository`로 조회 |
 | `POST_UPDATED` | 해당 모집글을 찜한 유저 전원 | `PostLikeRepository`로 조회 |
+| `TRIP_UPCOMING` | 여정 ACTIVE 멤버 전원 | 스케줄러에서 `JourneyMemberRepository`로 조회 |
 
-> 행위자 본인은 항상 수신자에서 제외된다.
+> 행위자 본인은 항상 수신자에서 제외된다. (`TRIP_UPCOMING` 제외)
 
 ### 알림 문구(body)
 
@@ -136,6 +139,7 @@ FCM 발송은 인앱 알림 저장과 독립적이다. DB 저장 후 비동기�
 | `SCHEDULE_UPDATED` | `{일정 이름} 일정이 변경되었습니다.` |
 | `SCHEDULE_CANCELED` | `{일정 이름} 일정이 취소되었습니다.` |
 | `POST_UPDATED` | `관심 있는 모집글에 변경이 있습니다.` |
+| `TRIP_UPCOMING` | `곧 여행이 시작됩니다. 준비물은 다 챙기셨나요?` |
 
 > `MATCH_APPLIED`의 닉네임은 신청자, `MATCH_APPROVED`의 닉네임은 승인자(모집글 작성자)이다.
 > 닉네임은 이벤트 발행 시점에 `ProfileRepository`로 조회해 이벤트에 포함한다.
@@ -149,6 +153,7 @@ FCM 발송은 인앱 알림 저장과 독립적이다. DB 저장 후 비동기�
 | `JOURNEY_NOTICE` | `JOURNEY_POST` | `journeyPostId` |
 | `SCHEDULE_*` | `SCHEDULE` | `scheduleId` |
 | `POST_UPDATED` | `JOURNEY_POST` | `postId` (모집글 상세로 이동) |
+| `TRIP_UPCOMING` | `JOURNEY` | `journeyId` |
 
 ---
 
@@ -213,7 +218,25 @@ PATCH /read-all
 
 ---
 
-## 7. 알림 수신 설정 (on/off)
+## 7. 여행 임박 알림 (TRIP_UPCOMING)
+
+이벤트 기반이 아닌 **스케줄러 기반**으로 동작한다.
+
+```
+TripUpcomingScheduler (@Scheduled — 매일 오전 9시)
+  └── TripUpcomingNotificationService.notifyUpcomingTrips()
+        ├── startDate = 오늘 + 3일인 여정의 ACTIVE 멤버 전체 조회
+        ├── 여정별 그룹핑
+        ├── 오늘 이미 발송된 여정은 스킵 (중복 발송 방지)
+        ├── Notification 인앱 저장 (전체 멤버)
+        └── FCM 발송 (notificationEnabled = true 멤버만)
+```
+
+**중복 발송 방지**: `notifications` 테이블에 해당 `journeyId`로 `TRIP_UPCOMING` 알림이 오늘 이미 생성돼 있으면 스킵한다.
+
+---
+
+## 8. 알림 수신 설정 (on/off)
 
 `PATCH /api/v1/notifications/settings` — 알림 수신 전체 on/off 설정
 
@@ -228,7 +251,7 @@ PATCH /read-all
 
 ---
 
-## 8. 현재 범위 제외 항목
+## 9. 현재 범위 제외 항목
 
 - `SCHEDULE_UPCOMING` — 시간 기반 스케줄러 + 푸시 연동 필요
 - 채팅 새 메시지 알림 — 디바운스/그룹핑 + 푸시 연동 필요

--- a/src/main/java/com/dduru/gildongmu/journey/dto/query/UpcomingTripMemberQueryResult.java
+++ b/src/main/java/com/dduru/gildongmu/journey/dto/query/UpcomingTripMemberQueryResult.java
@@ -1,0 +1,8 @@
+package com.dduru.gildongmu.journey.dto.query;
+
+public record UpcomingTripMemberQueryResult(
+        Long journeyId,
+        String journeyTitle,
+        Long userId
+) {
+}

--- a/src/main/java/com/dduru/gildongmu/journey/repository/JourneyMemberRepository.java
+++ b/src/main/java/com/dduru/gildongmu/journey/repository/JourneyMemberRepository.java
@@ -3,6 +3,7 @@ package com.dduru.gildongmu.journey.repository;
 import com.dduru.gildongmu.journey.domain.JourneyMember;
 import com.dduru.gildongmu.journey.domain.enums.JourneyMemberStatus;
 import com.dduru.gildongmu.journey.dto.query.JourneyMemberStatusQueryResult;
+import com.dduru.gildongmu.journey.dto.query.UpcomingTripMemberQueryResult;
 import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
@@ -147,4 +148,15 @@ public interface JourneyMemberRepository extends JpaRepository<JourneyMember, Lo
             @Param("journeyId") Long journeyId,
             @Param("excludeUserId") Long excludeUserId
     );
+
+    // JPQL new — 엔티티 전체 로딩 없이 필요한 필드만 DTO 생성자로 직접 매핑 (FQCN 필수)
+    @Query("""
+            SELECT new com.dduru.gildongmu.journey.dto.query.UpcomingTripMemberQueryResult(
+                jm.journey.id, jm.journey.title, jm.user.id
+            )
+            FROM JourneyMember jm
+            WHERE jm.journey.post.startDate = :targetDate
+              AND jm.status = 'ACTIVE'
+            """)
+    List<UpcomingTripMemberQueryResult> findUpcomingTripMembers(@Param("targetDate") LocalDate targetDate);
 }

--- a/src/main/java/com/dduru/gildongmu/notification/domain/enums/NotificationType.java
+++ b/src/main/java/com/dduru/gildongmu/notification/domain/enums/NotificationType.java
@@ -7,5 +7,6 @@ public enum NotificationType {
     SCHEDULE_CREATED,
     SCHEDULE_UPDATED,
     SCHEDULE_CANCELED,
-    POST_UPDATED
+    POST_UPDATED,
+    TRIP_UPCOMING
 }

--- a/src/main/java/com/dduru/gildongmu/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/dduru/gildongmu/notification/repository/NotificationRepository.java
@@ -1,6 +1,7 @@
 package com.dduru.gildongmu.notification.repository;
 
 import com.dduru.gildongmu.notification.domain.Notification;
+import com.dduru.gildongmu.notification.domain.enums.NotificationType;
 import com.dduru.gildongmu.notification.exception.NotificationNotFoundException;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -40,4 +41,16 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
             WHERE n.recipient.id = :userId AND n.read = false
             """)
     int markAllAsReadByRecipientId(@Param("userId") Long userId, @Param("now") LocalDateTime now);
+
+    // cutoff(오늘 자정) 조건: 출발일 변경 시 재발송을 허용하기 위해 과거 기록을 중복으로 보지 않음
+    @Query("""
+            SELECT n.recipient.id FROM Notification n
+            WHERE n.type = :type
+              AND n.resourceId = :resourceId
+              AND n.createdAt >= :cutoff
+            """)
+    List<Long> findNotifiedRecipientIds(
+            @Param("type") NotificationType type,
+            @Param("resourceId") Long resourceId,
+            @Param("cutoff") LocalDateTime cutoff);
 }

--- a/src/main/java/com/dduru/gildongmu/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/dduru/gildongmu/notification/repository/NotificationRepository.java
@@ -2,6 +2,7 @@ package com.dduru.gildongmu.notification.repository;
 
 import com.dduru.gildongmu.notification.domain.Notification;
 import com.dduru.gildongmu.notification.domain.enums.NotificationType;
+import com.dduru.gildongmu.notification.domain.enums.ResourceType;
 import com.dduru.gildongmu.notification.exception.NotificationNotFoundException;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -44,13 +45,15 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
 
     // cutoff(오늘 자정) 조건: 출발일 변경 시 재발송을 허용하기 위해 과거 기록을 중복으로 보지 않음
     @Query("""
-            SELECT n.recipient.id FROM Notification n
+            SELECT DISTINCT n.recipient.id FROM Notification n
             WHERE n.type = :type
+              AND n.resourceType = :resourceType
               AND n.resourceId = :resourceId
               AND n.createdAt >= :cutoff
             """)
     List<Long> findNotifiedRecipientIds(
             @Param("type") NotificationType type,
+            @Param("resourceType") ResourceType resourceType,
             @Param("resourceId") Long resourceId,
             @Param("cutoff") LocalDateTime cutoff);
 }

--- a/src/main/java/com/dduru/gildongmu/notification/scheduler/TripUpcomingScheduler.java
+++ b/src/main/java/com/dduru/gildongmu/notification/scheduler/TripUpcomingScheduler.java
@@ -1,0 +1,25 @@
+package com.dduru.gildongmu.notification.scheduler;
+
+import com.dduru.gildongmu.notification.service.TripUpcomingNotificationService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class TripUpcomingScheduler {
+
+    private final TripUpcomingNotificationService tripUpcomingNotificationService;
+
+    @Scheduled(cron = "0 0 9 * * *") // 매일 오전 9시 실행
+    public void notifyUpcomingTrips() {
+        try {
+            tripUpcomingNotificationService.notifyUpcomingTrips();
+            log.info("여행 임박 알림 발송 완료");
+        } catch (Exception e) {
+            log.error("여행 임박 알림 스케줄러 실패", e);
+        }
+    }
+}

--- a/src/main/java/com/dduru/gildongmu/notification/service/TripUpcomingNotificationService.java
+++ b/src/main/java/com/dduru/gildongmu/notification/service/TripUpcomingNotificationService.java
@@ -1,0 +1,93 @@
+package com.dduru.gildongmu.notification.service;
+
+import com.dduru.gildongmu.common.time.TimeProvider;
+import com.dduru.gildongmu.fcm.service.FcmPushService;
+import com.dduru.gildongmu.journey.dto.query.UpcomingTripMemberQueryResult;
+import com.dduru.gildongmu.journey.repository.JourneyMemberRepository;
+import com.dduru.gildongmu.notification.domain.Notification;
+import com.dduru.gildongmu.notification.domain.enums.NotificationType;
+import com.dduru.gildongmu.notification.domain.enums.ResourceType;
+import com.dduru.gildongmu.notification.repository.NotificationRepository;
+import com.dduru.gildongmu.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TripUpcomingNotificationService {
+
+    private static final int UPCOMING_DAYS_BEFORE = 3;
+    private static final String PUSH_TITLE = "일정 임박";
+    private static final String PUSH_BODY = "곧 여행이 시작됩니다. 준비물은 다 챙기셨나요?";
+
+    private final JourneyMemberRepository journeyMemberRepository;
+    private final NotificationRepository notificationRepository;
+    private final NotificationPersistService notificationPersistService;
+    private final UserRepository userRepository;
+    private final FcmPushService fcmPushService;
+    private final TimeProvider timeProvider;
+
+    @Transactional(readOnly = true)
+    public void notifyUpcomingTrips() {
+        LocalDate targetDate = timeProvider.today().plusDays(UPCOMING_DAYS_BEFORE);
+        LocalDateTime startOfToday = timeProvider.today().atStartOfDay();
+
+        List<UpcomingTripMemberQueryResult> upcomingTripMembers =
+                journeyMemberRepository.findUpcomingTripMembers(targetDate);
+
+        if (upcomingTripMembers.isEmpty()) return;
+
+        upcomingTripMembers.stream()
+                .collect(Collectors.groupingBy(UpcomingTripMemberQueryResult::journeyId))
+                .forEach((journeyId, members) -> notifyMembers(journeyId, members, startOfToday));
+    }
+
+    private void notifyMembers(Long journeyId, List<UpcomingTripMemberQueryResult> members, LocalDateTime startOfToday) {
+        List<Long> allUserIds = members.stream()
+                .map(UpcomingTripMemberQueryResult::userId)
+                .toList();
+
+        List<Long> pendingUserIds = findPendingUserIds(allUserIds, journeyId, startOfToday);
+
+        if (pendingUserIds.isEmpty()) {
+            log.info("TRIP_UPCOMING 전원 발송 완료 상태 - journeyId={}", journeyId);
+            return;
+        }
+
+        List<Notification> notifications = pendingUserIds.stream()
+                .map(userId -> Notification.create(
+                        userRepository.getReferenceById(userId), // 실제 User를 로딩하지 않고 FK용 프록시만 생성
+                        NotificationType.TRIP_UPCOMING,
+                        PUSH_BODY,
+                        ResourceType.JOURNEY,
+                        journeyId
+                ))
+                .toList();
+
+        notificationPersistService.saveAll(notifications);
+
+        List<Long> fcmTargetIds = userRepository.findEnabledUserIds(pendingUserIds);
+        if (fcmTargetIds.isEmpty()) return;
+        fcmPushService.sendToUsers(fcmTargetIds, PUSH_TITLE, PUSH_BODY);
+    }
+
+    private List<Long> findPendingUserIds(List<Long> allUserIds, Long journeyId, LocalDateTime startOfToday) {
+        // contains() 조회를 O(1)로 처리하기 위해 Set으로 변환
+        Set<Long> alreadyNotified = new HashSet<>(
+                notificationRepository.findNotifiedRecipientIds(
+                        NotificationType.TRIP_UPCOMING, journeyId, startOfToday));
+        return allUserIds.stream()
+                .filter(id -> !alreadyNotified.contains(id))
+                .toList();
+    }
+}

--- a/src/main/java/com/dduru/gildongmu/notification/service/TripUpcomingNotificationService.java
+++ b/src/main/java/com/dduru/gildongmu/notification/service/TripUpcomingNotificationService.java
@@ -39,8 +39,9 @@ public class TripUpcomingNotificationService {
 
     @Transactional(readOnly = true)
     public void notifyUpcomingTrips() {
-        LocalDate targetDate = timeProvider.today().plusDays(UPCOMING_DAYS_BEFORE);
-        LocalDateTime startOfToday = timeProvider.today().atStartOfDay();
+        LocalDate today = timeProvider.today();
+        LocalDate targetDate = today.plusDays(UPCOMING_DAYS_BEFORE);
+        LocalDateTime startOfToday = today.atStartOfDay();
 
         List<UpcomingTripMemberQueryResult> upcomingTripMembers =
                 journeyMemberRepository.findUpcomingTripMembers(targetDate);

--- a/src/main/java/com/dduru/gildongmu/notification/service/TripUpcomingNotificationService.java
+++ b/src/main/java/com/dduru/gildongmu/notification/service/TripUpcomingNotificationService.java
@@ -86,7 +86,7 @@ public class TripUpcomingNotificationService {
         // contains() 조회를 O(1)로 처리하기 위해 Set으로 변환
         Set<Long> alreadyNotified = new HashSet<>(
                 notificationRepository.findNotifiedRecipientIds(
-                        NotificationType.TRIP_UPCOMING, journeyId, startOfToday));
+                        NotificationType.TRIP_UPCOMING, ResourceType.JOURNEY, journeyId, startOfToday));
         return allUserIds.stream()
                 .filter(id -> !alreadyNotified.contains(id))
                 .toList();

--- a/src/main/java/com/dduru/gildongmu/post/scheduler/PostStatusScheduler.java
+++ b/src/main/java/com/dduru/gildongmu/post/scheduler/PostStatusScheduler.java
@@ -15,8 +15,6 @@ public class PostStatusScheduler {
 
     @Scheduled(cron = "0 0 0 * * *") // 매일 자정 실행
     public void updateExpiredPostStatus() {
-        log.debug("만료 게시글 상태 업데이트 스케줄러 - 실행");
-        
         try {
             int updatedCount = postService.closeExpiredPosts();
             log.info("만료 게시글 상태 업데이트됨 - count={}", updatedCount);

--- a/src/test/java/com/dduru/gildongmu/notification/service/TripUpcomingNotificationServiceTest.java
+++ b/src/test/java/com/dduru/gildongmu/notification/service/TripUpcomingNotificationServiceTest.java
@@ -87,7 +87,7 @@ class TripUpcomingNotificationServiceTest {
 
             when(journeyMemberRepository.findUpcomingTripMembers(TARGET_DATE)).thenReturn(rows);
             when(notificationRepository.findNotifiedRecipientIds(
-                    eq(NotificationType.TRIP_UPCOMING), eq(journeyId), any())).thenReturn(List.of());
+                    eq(NotificationType.TRIP_UPCOMING), eq(ResourceType.JOURNEY), eq(journeyId), any())).thenReturn(List.of());
             when(userRepository.getReferenceById(10L)).thenReturn(createUser(10L));
             when(userRepository.getReferenceById(20L)).thenReturn(createUser(20L));
             when(userRepository.findEnabledUserIds(List.of(10L, 20L))).thenReturn(List.of(10L, 20L));
@@ -119,7 +119,7 @@ class TripUpcomingNotificationServiceTest {
 
             when(journeyMemberRepository.findUpcomingTripMembers(TARGET_DATE)).thenReturn(rows);
             when(notificationRepository.findNotifiedRecipientIds(
-                    eq(NotificationType.TRIP_UPCOMING), eq(journeyId), any())).thenReturn(List.of());
+                    eq(NotificationType.TRIP_UPCOMING), eq(ResourceType.JOURNEY), eq(journeyId), any())).thenReturn(List.of());
             when(userRepository.getReferenceById(10L)).thenReturn(createUser(10L));
             when(userRepository.getReferenceById(20L)).thenReturn(createUser(20L));
             when(userRepository.findEnabledUserIds(List.of(10L, 20L))).thenReturn(List.of(10L));
@@ -139,7 +139,7 @@ class TripUpcomingNotificationServiceTest {
 
             when(journeyMemberRepository.findUpcomingTripMembers(TARGET_DATE)).thenReturn(rows);
             when(notificationRepository.findNotifiedRecipientIds(
-                    eq(NotificationType.TRIP_UPCOMING), eq(journeyId), any())).thenReturn(List.of());
+                    eq(NotificationType.TRIP_UPCOMING), eq(ResourceType.JOURNEY), eq(journeyId), any())).thenReturn(List.of());
             when(userRepository.getReferenceById(10L)).thenReturn(createUser(10L));
             when(userRepository.findEnabledUserIds(List.of(10L))).thenReturn(List.of());
 
@@ -164,7 +164,7 @@ class TripUpcomingNotificationServiceTest {
 
             when(journeyMemberRepository.findUpcomingTripMembers(TARGET_DATE)).thenReturn(rows);
             when(notificationRepository.findNotifiedRecipientIds(
-                    eq(NotificationType.TRIP_UPCOMING), eq(journeyId), any())).thenReturn(List.of(10L));
+                    eq(NotificationType.TRIP_UPCOMING), eq(ResourceType.JOURNEY), eq(journeyId), any())).thenReturn(List.of(10L));
 
             service.notifyUpcomingTrips();
 
@@ -184,7 +184,7 @@ class TripUpcomingNotificationServiceTest {
             when(journeyMemberRepository.findUpcomingTripMembers(TARGET_DATE)).thenReturn(rows);
             // 10L은 이미 받음, 20L은 아직 미수신
             when(notificationRepository.findNotifiedRecipientIds(
-                    eq(NotificationType.TRIP_UPCOMING), eq(journeyId), any())).thenReturn(List.of(10L));
+                    eq(NotificationType.TRIP_UPCOMING), eq(ResourceType.JOURNEY), eq(journeyId), any())).thenReturn(List.of(10L));
             when(userRepository.getReferenceById(20L)).thenReturn(createUser(20L));
             when(userRepository.findEnabledUserIds(List.of(20L))).thenReturn(List.of(20L));
 
@@ -209,9 +209,9 @@ class TripUpcomingNotificationServiceTest {
 
             when(journeyMemberRepository.findUpcomingTripMembers(TARGET_DATE)).thenReturn(rows);
             when(notificationRepository.findNotifiedRecipientIds(
-                    eq(NotificationType.TRIP_UPCOMING), eq(journeyId1), any())).thenReturn(List.of(10L));
+                    eq(NotificationType.TRIP_UPCOMING), eq(ResourceType.JOURNEY), eq(journeyId1), any())).thenReturn(List.of(10L));
             when(notificationRepository.findNotifiedRecipientIds(
-                    eq(NotificationType.TRIP_UPCOMING), eq(journeyId2), any())).thenReturn(List.of());
+                    eq(NotificationType.TRIP_UPCOMING), eq(ResourceType.JOURNEY), eq(journeyId2), any())).thenReturn(List.of());
             when(userRepository.getReferenceById(20L)).thenReturn(createUser(20L));
             when(userRepository.findEnabledUserIds(List.of(20L))).thenReturn(List.of(20L));
 

--- a/src/test/java/com/dduru/gildongmu/notification/service/TripUpcomingNotificationServiceTest.java
+++ b/src/test/java/com/dduru/gildongmu/notification/service/TripUpcomingNotificationServiceTest.java
@@ -1,0 +1,240 @@
+package com.dduru.gildongmu.notification.service;
+
+import com.dduru.gildongmu.common.time.TimeProvider;
+import com.dduru.gildongmu.fcm.service.FcmPushService;
+import com.dduru.gildongmu.journey.dto.query.UpcomingTripMemberQueryResult;
+import com.dduru.gildongmu.journey.repository.JourneyMemberRepository;
+import com.dduru.gildongmu.notification.domain.Notification;
+import com.dduru.gildongmu.notification.domain.enums.NotificationType;
+import com.dduru.gildongmu.notification.domain.enums.ResourceType;
+import com.dduru.gildongmu.notification.repository.NotificationRepository;
+import com.dduru.gildongmu.user.domain.User;
+import com.dduru.gildongmu.user.domain.enums.OauthType;
+import com.dduru.gildongmu.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("TripUpcomingNotificationService 테스트")
+class TripUpcomingNotificationServiceTest {
+
+    private static final LocalDate TODAY = LocalDate.of(2026, 6, 30);
+    private static final LocalDate TARGET_DATE = TODAY.plusDays(3);
+
+    @Mock private JourneyMemberRepository journeyMemberRepository;
+    @Mock private NotificationRepository notificationRepository;
+    @Mock private NotificationPersistService notificationPersistService;
+    @Mock private UserRepository userRepository;
+    @Mock private FcmPushService fcmPushService;
+    @Mock private TimeProvider timeProvider;
+
+    private TripUpcomingNotificationService service;
+
+    @BeforeEach
+    void setUp() {
+        when(timeProvider.today()).thenReturn(TODAY);
+        service = new TripUpcomingNotificationService(
+                journeyMemberRepository, notificationRepository, notificationPersistService,
+                userRepository, fcmPushService, timeProvider
+        );
+    }
+
+    @Nested
+    @DisplayName("대상 여정이 없는 경우")
+    class NoUpcomingTrips {
+
+        @Test
+        @DisplayName("3일 후 출발 여정이 없으면 알림을 저장하지 않는다")
+        void skipsWhenNoUpcomingTrips() {
+            when(journeyMemberRepository.findUpcomingTripMembers(TARGET_DATE)).thenReturn(List.of());
+
+            service.notifyUpcomingTrips();
+
+            verify(notificationPersistService, never()).saveAll(any());
+            verify(fcmPushService, never()).sendToUsers(any(), any(), any());
+        }
+    }
+
+    @Nested
+    @DisplayName("정상 발송")
+    class NormalNotification {
+
+        @Test
+        @DisplayName("3일 후 출발 여정의 ACTIVE 멤버 전원에게 TRIP_UPCOMING 알림을 저장한다")
+        void savesNotificationsForAllActiveMembers() {
+            Long journeyId = 1L;
+            List<UpcomingTripMemberQueryResult> rows = List.of(
+                    new UpcomingTripMemberQueryResult(journeyId, "도쿄 여행", 10L),
+                    new UpcomingTripMemberQueryResult(journeyId, "도쿄 여행", 20L)
+            );
+
+            when(journeyMemberRepository.findUpcomingTripMembers(TARGET_DATE)).thenReturn(rows);
+            when(notificationRepository.findNotifiedRecipientIds(
+                    eq(NotificationType.TRIP_UPCOMING), eq(journeyId), any())).thenReturn(List.of());
+            when(userRepository.getReferenceById(10L)).thenReturn(createUser(10L));
+            when(userRepository.getReferenceById(20L)).thenReturn(createUser(20L));
+            when(userRepository.findEnabledUserIds(List.of(10L, 20L))).thenReturn(List.of(10L, 20L));
+
+            service.notifyUpcomingTrips();
+
+            @SuppressWarnings("unchecked")
+            ArgumentCaptor<List<Notification>> captor = ArgumentCaptor.forClass(List.class);
+            verify(notificationPersistService).saveAll(captor.capture());
+
+            List<Notification> saved = captor.getValue();
+            assertThat(saved).hasSize(2);
+            assertThat(saved).allSatisfy(n -> {
+                assertThat(n.getType()).isEqualTo(NotificationType.TRIP_UPCOMING);
+                assertThat(n.getResourceType()).isEqualTo(ResourceType.JOURNEY);
+                assertThat(n.getResourceId()).isEqualTo(journeyId);
+                assertThat(n.isRead()).isFalse();
+            });
+        }
+
+        @Test
+        @DisplayName("알림 off 유저는 FCM 발송 대상에서 제외된다")
+        void fcmIsFilteredByNotificationEnabled() {
+            Long journeyId = 1L;
+            List<UpcomingTripMemberQueryResult> rows = List.of(
+                    new UpcomingTripMemberQueryResult(journeyId, "도쿄 여행", 10L),
+                    new UpcomingTripMemberQueryResult(journeyId, "도쿄 여행", 20L)
+            );
+
+            when(journeyMemberRepository.findUpcomingTripMembers(TARGET_DATE)).thenReturn(rows);
+            when(notificationRepository.findNotifiedRecipientIds(
+                    eq(NotificationType.TRIP_UPCOMING), eq(journeyId), any())).thenReturn(List.of());
+            when(userRepository.getReferenceById(10L)).thenReturn(createUser(10L));
+            when(userRepository.getReferenceById(20L)).thenReturn(createUser(20L));
+            when(userRepository.findEnabledUserIds(List.of(10L, 20L))).thenReturn(List.of(10L));
+
+            service.notifyUpcomingTrips();
+
+            verify(fcmPushService).sendToUsers(eq(List.of(10L)), any(), any());
+        }
+
+        @Test
+        @DisplayName("전원 알림 off이면 FCM을 발송하지 않는다")
+        void skipsFcmWhenAllUsersDisabled() {
+            Long journeyId = 1L;
+            List<UpcomingTripMemberQueryResult> rows = List.of(
+                    new UpcomingTripMemberQueryResult(journeyId, "도쿄 여행", 10L)
+            );
+
+            when(journeyMemberRepository.findUpcomingTripMembers(TARGET_DATE)).thenReturn(rows);
+            when(notificationRepository.findNotifiedRecipientIds(
+                    eq(NotificationType.TRIP_UPCOMING), eq(journeyId), any())).thenReturn(List.of());
+            when(userRepository.getReferenceById(10L)).thenReturn(createUser(10L));
+            when(userRepository.findEnabledUserIds(List.of(10L))).thenReturn(List.of());
+
+            service.notifyUpcomingTrips();
+
+            verify(notificationPersistService).saveAll(any());
+            verify(fcmPushService, never()).sendToUsers(any(), any(), any());
+        }
+    }
+
+    @Nested
+    @DisplayName("중복 발송 방지")
+    class DuplicatePrevention {
+
+        @Test
+        @DisplayName("오늘 이미 전원 발송 완료된 여정은 스킵한다")
+        void skipsJourneyAlreadySentToday() {
+            Long journeyId = 1L;
+            List<UpcomingTripMemberQueryResult> rows = List.of(
+                    new UpcomingTripMemberQueryResult(journeyId, "도쿄 여행", 10L)
+            );
+
+            when(journeyMemberRepository.findUpcomingTripMembers(TARGET_DATE)).thenReturn(rows);
+            when(notificationRepository.findNotifiedRecipientIds(
+                    eq(NotificationType.TRIP_UPCOMING), eq(journeyId), any())).thenReturn(List.of(10L));
+
+            service.notifyUpcomingTrips();
+
+            verify(notificationPersistService, never()).saveAll(any());
+            verify(fcmPushService, never()).sendToUsers(any(), any(), any());
+        }
+
+        @Test
+        @DisplayName("배치 실패로 일부만 발송된 경우 미발송 멤버에게만 재발송한다")
+        void resendsOnlyToMembersWhoDidNotReceive() {
+            Long journeyId = 1L;
+            List<UpcomingTripMemberQueryResult> rows = List.of(
+                    new UpcomingTripMemberQueryResult(journeyId, "도쿄 여행", 10L),
+                    new UpcomingTripMemberQueryResult(journeyId, "도쿄 여행", 20L)
+            );
+
+            when(journeyMemberRepository.findUpcomingTripMembers(TARGET_DATE)).thenReturn(rows);
+            // 10L은 이미 받음, 20L은 아직 미수신
+            when(notificationRepository.findNotifiedRecipientIds(
+                    eq(NotificationType.TRIP_UPCOMING), eq(journeyId), any())).thenReturn(List.of(10L));
+            when(userRepository.getReferenceById(20L)).thenReturn(createUser(20L));
+            when(userRepository.findEnabledUserIds(List.of(20L))).thenReturn(List.of(20L));
+
+            service.notifyUpcomingTrips();
+
+            @SuppressWarnings("unchecked")
+            ArgumentCaptor<List<Notification>> captor = ArgumentCaptor.forClass(List.class);
+            verify(notificationPersistService).saveAll(captor.capture());
+            assertThat(captor.getValue()).hasSize(1);
+            assertThat(captor.getValue().get(0).getResourceId()).isEqualTo(journeyId);
+        }
+
+        @Test
+        @DisplayName("여러 여정 중 일부만 중복이면 미발송 여정만 정상 발송한다")
+        void sendsOnlyToNonDuplicateJourneys() {
+            Long journeyId1 = 1L;
+            Long journeyId2 = 2L;
+            List<UpcomingTripMemberQueryResult> rows = List.of(
+                    new UpcomingTripMemberQueryResult(journeyId1, "도쿄 여행", 10L),
+                    new UpcomingTripMemberQueryResult(journeyId2, "오사카 여행", 20L)
+            );
+
+            when(journeyMemberRepository.findUpcomingTripMembers(TARGET_DATE)).thenReturn(rows);
+            when(notificationRepository.findNotifiedRecipientIds(
+                    eq(NotificationType.TRIP_UPCOMING), eq(journeyId1), any())).thenReturn(List.of(10L));
+            when(notificationRepository.findNotifiedRecipientIds(
+                    eq(NotificationType.TRIP_UPCOMING), eq(journeyId2), any())).thenReturn(List.of());
+            when(userRepository.getReferenceById(20L)).thenReturn(createUser(20L));
+            when(userRepository.findEnabledUserIds(List.of(20L))).thenReturn(List.of(20L));
+
+            service.notifyUpcomingTrips();
+
+            @SuppressWarnings("unchecked")
+            ArgumentCaptor<List<Notification>> captor = ArgumentCaptor.forClass(List.class);
+            verify(notificationPersistService).saveAll(captor.capture());
+            assertThat(captor.getValue()).hasSize(1);
+            assertThat(captor.getValue().get(0).getResourceId()).isEqualTo(journeyId2);
+        }
+    }
+
+    // ── 헬퍼 메서드 ──────────────────────────────────────────────────────────
+
+    private User createUser(Long userId) {
+        User user = User.builder()
+                .email("user" + userId + "@example.com")
+                .name("user" + userId)
+                .oauthId("oauth-" + userId)
+                .oauthType(OauthType.KAKAO)
+                .build();
+        ReflectionTestUtils.setField(user, "id", userId);
+        return user;
+    }
+}


### PR DESCRIPTION
## 🔎 작업 내용
  * `NotificationType.TRIP_UPCOMING` 알림 타입 추가
  * `UpcomingTripMemberQueryResult` DTO 추가 (JPQL new 프로젝션, FQCN 방식)
  * `JourneyMemberRepository.findUpcomingTripMembers()` — 출발일 = 오늘+3일인 여정의 ACTIVE 멤버 전체 조회 쿼리 추가
  * `NotificationRepository.findNotifiedRecipientIds()` — 오늘 자정 이후 발송 이력 조회 쿼리 추가 (멤버 단위 중복 방지)
  * `TripUpcomingNotificationService` — 여정별 그룹핑, 멤버 단위 중복 방지, 인앱 저장 + FCM 발송 로직 구현
  * `TripUpcomingScheduler` — 매일 오전 9시 실행 스케줄러 추가
  * `TripUpcomingNotificationServiceTest` — 7개 테스트 케이스 작성


## ➕ 이슈 링크
* CLOSED #293 

## 😎 리뷰 요구사항
  > 출발일이 변경되면 동일 journeyId라도 재발송이 필요한 케이스가 있어, "오늘 발송 이력이 없으면 중복으로 보지 않는" 방식으로 구현했습니다.


## 🧑‍💻 예정 작업
- 없음

## 📝 체크리스트
- [x] 브랜치 이름은 `feat/#이슈번호-개발내용` 형식으로 작성했는가?
- [x] 커밋 메시지는 `[#이슈번호] feat(scope): 커밋 내용` 형식으로 작성했는가?
- [x] PR 제목은 `feat(scope): PR 제목` 형식으로 작성했는가?
- [x] 작업 전 Issue를 작성했는가?
- [x] `dev` 브랜치로 병합을 요청했는가?
- [x] 불필요한 주석과 공백은 제거했는가?
- [ ] 코드 리뷰어의 피드백을 반영했는가?
- [x] 테스트를 진행했는가?
- [x] 테스트 코드를 작성했는가?
