### PR TITLE
feat(notification): 채팅 새 메시지 FCM 푸시 알림 구현  

### DIFF
--- a/docs/001-design/flows/005-notification-flow.md
+++ b/docs/001-design/flows/005-notification-flow.md
@@ -109,7 +109,8 @@ FCM 발송은 인앱 알림 저장과 독립적이다. DB 저장 후 비동기�
 | `JourneyScheduleService` | `deleteSchedule()` | `ScheduleCanceledEvent` |
 | `PostService` | `update()` | `PostUpdatedEvent` |
 
-> `TRIP_UPCOMING`은 이벤트 기반이 아닌 스케줄러 기반으로 발송한다. 아래 9절 참고.
+> `TRIP_UPCOMING`은 이벤트 기반이 아닌 스케줄러 기반으로 발송한다. 아래 7절 참고.
+> 채팅 메시지 푸시는 `ChatMessageCreatedEvent`를 `ChatMessagePushEventListener`가 수신한다. 인앱 저장 없이 FCM만 발송한다. 아래 9절 참고.
 
 ---
 
@@ -251,9 +252,78 @@ TripUpcomingScheduler (@Scheduled — 매일 오전 9시)
 
 ---
 
-## 9. 현재 범위 제외 항목
+## 9. 채팅 메시지 FCM 푸시
+
+채팅 메시지는 `notifications` 테이블에 저장하지 않는다. **FCM 푸시만 발송**한다.
+채팅 메시지 자체가 `chat_messages` 테이블에 저장되므로 인앱 저장은 중복이다.
+
+### 발송 흐름
+
+```
+ChatMessageSendService (메시지 저장 트랜잭션)
+  └── ChatMessageCreatedEvent 발행
+
+                    ↓ AFTER_COMMIT
+
+ChatMessagePushEventListener
+  ├── [1] messageType == SYSTEM → return         (입장/퇴장 시스템 메시지 제외)
+  ├── [2] 수신자 = 채팅방 멤버 전체 - 발신자
+  │         수신자 없으면 → return
+  ├── [3] Redis presence 조회 → 접속 중인 유저 제외
+  │         (WebSocket으로 실시간 메시지 수신 중이므로 푸시 불필요)
+  │         전원 접속 중이면 → return
+  ├── [4] SET chat:push:lastsent:{roomId} NX EX 30
+  │         실패 (쿨다운 중) → return
+  ├── [5] findEnabledUserIds() → notificationEnabled = false 제외
+  │         없으면 → return
+  └── [6] FCM 발송
+```
+
+### Leading Edge Debounce (30초 쿨다운)
+
+같은 채팅방에서 연속 메시지가 올 때 첫 메시지에만 즉시 푸시하고, 이후 30초간 억제한다.
+
+```
+t=0초   메시지 1 → SET NX 성공 → 푸시 발송 ✅  (키 TTL 30초 시작)
+t=10초  메시지 2 → SET NX 실패 (키 있음)  → 스킵 ❌
+t=32초  메시지 3 → SET NX 성공 (키 만료됨) → 푸시 발송 ✅
+```
+
+30초 타이머는 첫 메시지 기준으로 고정된다. 이후 메시지가 와도 리셋되지 않는다.
+
+### 접속 상태 추적 (Redis)
+
+```
+chat:online:{roomId}     → Set<userId>        (TTL 2h, 좀비 세션 자동 정리)
+chat:session:{sessionId} → {userId}:{roomId}  (TTL 2h, DISCONNECT 시 cleanup용)
+```
+
+| STOMP 이벤트 | 처리 |
+|---|---|
+| SUBSCRIBE `/topic/chat/rooms/{roomId}` | `SADD chat:online:{roomId} {userId}` |
+| UNSUBSCRIBE | `SREM chat:online:{roomId} {userId}` |
+| SessionDisconnectEvent (앱 종료/네트워크 끊김) | session 키 조회 → SREM → DEL |
+
+### 알림 포맷
+
+| 채팅방 타입 | title | body |
+|---|---|---|
+| GROUP (동행 여행방) | 여정 제목 | `{닉네임}: {메시지 내용}` (30자 초과 시 `...`) |
+| GROUP IMAGE | 여정 제목 | `{닉네임}: 사진을 보냈습니다.` |
+| PRIVATE (1:1) | 발신자 닉네임 | `{메시지 내용}` (닉네임 미포함, title에 이미 표시) |
+| PRIVATE IMAGE | 발신자 닉네임 | `사진을 보냈습니다.` |
+
+> SYSTEM 메시지(입장·퇴장 등)는 푸시 대상이 아니다.
+
+### collapseKey
+
+`collapseKey = "chat:{roomId}"` 를 Android/APNS 모두에 적용한다.
+디바이스가 오프라인 상태일 때 같은 채팅방 알림이 여러 개 FCM 큐에 쌓이면, 기기가 온라인 복귀 시 최신 1개만 수신한다.
+
+---
+
+## 10. 현재 범위 제외 항목
 
 - `SCHEDULE_UPCOMING` — 시간 기반 스케줄러 + 푸시 연동 필요
-- 채팅 새 메시지 알림 — 디바운스/그룹핑 + 푸시 연동 필요
 - 시스템 공지/이벤트 (어드민 발송)
 - 90일 경과 알림 자동 삭제 배치

--- a/docs/001-design/flows/005-notification-flow.md
+++ b/docs/001-design/flows/005-notification-flow.md
@@ -294,15 +294,19 @@ t=32초  메시지 3 → SET NX 성공 (키 만료됨) → 푸시 발송 ✅
 ### 접속 상태 추적 (Redis)
 
 ```
-chat:online:{roomId}     → Set<userId>        (TTL 2h, 좀비 세션 자동 정리)
-chat:session:{sessionId} → {userId}:{roomId}  (TTL 2h, DISCONNECT 시 cleanup용)
+chat:online:{roomId}                      → Set<userId>        (TTL 2h, 좀비 세션 자동 정리)
+chat:session:{sessionId}                  → {userId}:{roomId}  (TTL 2h, DISCONNECT 시 roomId 역추적용)
+chat:subscription:{sessionId}:{subId}     → {roomId}           (TTL 2h, UNSUBSCRIBE 시 roomId 역추적용)
 ```
+
+> STOMP UNSUBSCRIBE 프레임은 `destination` 없이 `subscriptionId`만 전달하므로,
+> SUBSCRIBE 시 subscription 키를 저장해두고 UNSUBSCRIBE 시 roomId를 역추적한다.
 
 | STOMP 이벤트 | 처리 |
 |---|---|
-| SUBSCRIBE `/topic/chat/rooms/{roomId}` | `SADD chat:online:{roomId} {userId}` |
-| UNSUBSCRIBE | `SREM chat:online:{roomId} {userId}` |
-| SessionDisconnectEvent (앱 종료/네트워크 끊김) | session 키 조회 → SREM → DEL |
+| SUBSCRIBE `/topic/chat/rooms/{roomId}` | `SADD chat:online:{roomId} {userId}` + subscription 키 저장 |
+| UNSUBSCRIBE | subscription 키 조회 → `SREM chat:online:{roomId} {userId}` → subscription 키 삭제 |
+| SessionDisconnectEvent (앱 종료/네트워크 끊김) | session 키 조회 → `SREM` → session 키 삭제 |
 
 ### 알림 포맷
 

--- a/docs/001-design/flows/005-notification-flow.md
+++ b/docs/001-design/flows/005-notification-flow.md
@@ -272,10 +272,10 @@ ChatMessagePushEventListener
   ├── [3] Redis presence 조회 → 접속 중인 유저 제외
   │         (WebSocket으로 실시간 메시지 수신 중이므로 푸시 불필요)
   │         전원 접속 중이면 → return
-  ├── [4] SET chat:push:lastsent:{roomId} NX EX 30
-  │         실패 (쿨다운 중) → return
-  ├── [5] findEnabledUserIds() → notificationEnabled = false 제외
+  ├── [4] findEnabledUserIds() → notificationEnabled = false 제외
   │         없으면 → return
+  ├── [5] SET chat:push:lastsent:{roomId} NX EX 30
+  │         실패 (쿨다운 중) → return
   └── [6] FCM 발송
 ```
 

--- a/src/main/java/com/dduru/gildongmu/chat/event/ChatMessagePushEventListener.java
+++ b/src/main/java/com/dduru/gildongmu/chat/event/ChatMessagePushEventListener.java
@@ -51,10 +51,10 @@ public class ChatMessagePushEventListener {
                 .toList();
         if (offlineRecipients.isEmpty()) return;
 
-        if (!chatPushNotificationService.canSendPush(roomId)) return;
-
         List<Long> fcmTargetIds = userRepository.findEnabledUserIds(offlineRecipients);
         if (fcmTargetIds.isEmpty()) return;
+
+        if (!chatPushNotificationService.canSendPush(roomId)) return;
 
         String roomTitle = resolveRoomTitle(message);
         String senderNickname = message.getSender().getProfile().getNickname();

--- a/src/main/java/com/dduru/gildongmu/chat/event/ChatMessagePushEventListener.java
+++ b/src/main/java/com/dduru/gildongmu/chat/event/ChatMessagePushEventListener.java
@@ -1,0 +1,76 @@
+package com.dduru.gildongmu.chat.event;
+
+import com.dduru.gildongmu.chat.domain.ChatMessage;
+import com.dduru.gildongmu.chat.domain.ChatRoom;
+import com.dduru.gildongmu.chat.domain.enums.ChatMessageType;
+import com.dduru.gildongmu.chat.domain.enums.ChatRoomType;
+import com.dduru.gildongmu.chat.repository.ChatMessageRepository;
+import com.dduru.gildongmu.chat.repository.ChatRoomMemberRepository;
+import com.dduru.gildongmu.chat.service.ChatOnlineStatusService;
+import com.dduru.gildongmu.chat.service.ChatPushNotificationService;
+import com.dduru.gildongmu.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import java.util.List;
+import java.util.Set;
+
+@Component
+@RequiredArgsConstructor
+public class ChatMessagePushEventListener {
+
+    private final ChatMessageRepository chatMessageRepository;
+    private final ChatRoomMemberRepository chatRoomMemberRepository;
+    private final ChatOnlineStatusService chatOnlineStatusService;
+    private final ChatPushNotificationService chatPushNotificationService;
+    private final UserRepository userRepository;
+
+    // Spring 6: @TransactionalEventListener + @Transactional 동시 사용 금지 (RestrictedTransactionalEventListenerFactory)
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handle(ChatMessageCreatedEvent event) {
+        ChatMessage message = chatMessageRepository.findByIdWithSenderAndRoom(event.messageId())
+                .orElse(null);
+        if (message == null) return;
+
+        if (message.getMessageType() == ChatMessageType.SYSTEM) return;
+
+        Long senderId = message.getSender().getId();
+        Long roomId = event.roomId();
+
+        List<Long> recipientIds = chatRoomMemberRepository.findUserIdsByRoomId(roomId)
+                .stream()
+                .filter(id -> !id.equals(senderId))
+                .toList();
+        if (recipientIds.isEmpty()) return;
+
+        Set<Long> onlineIds = chatOnlineStatusService.getOnlineUserIds(roomId);
+        List<Long> offlineRecipients = recipientIds.stream()
+                .filter(id -> !onlineIds.contains(id))
+                .toList();
+        if (offlineRecipients.isEmpty()) return;
+
+        if (!chatPushNotificationService.canSendPush(roomId)) return;
+
+        List<Long> fcmTargetIds = userRepository.findEnabledUserIds(offlineRecipients);
+        if (fcmTargetIds.isEmpty()) return;
+
+        String roomTitle = resolveRoomTitle(message);
+        String senderNickname = message.getSender().getProfile().getNickname();
+
+        chatPushNotificationService.sendPush(
+                fcmTargetIds, roomTitle, senderNickname,
+                message.getContent(), message.getMessageType(), message.getRoom().getRoomType(), roomId
+        );
+    }
+
+    private String resolveRoomTitle(ChatMessage message) {
+        ChatRoom room = message.getRoom();
+        if (room.getRoomType() == ChatRoomType.GROUP) {
+            return room.getJourney().getTitle();
+        }
+        // PRIVATE: 수신자 입장에서 상대방 = 발신자
+        return message.getSender().getProfile().getNickname();
+    }
+}

--- a/src/main/java/com/dduru/gildongmu/chat/event/ChatStompDisconnectListener.java
+++ b/src/main/java/com/dduru/gildongmu/chat/event/ChatStompDisconnectListener.java
@@ -1,0 +1,19 @@
+package com.dduru.gildongmu.chat.event;
+
+import com.dduru.gildongmu.chat.service.ChatOnlineStatusService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+
+@Component
+@RequiredArgsConstructor
+public class ChatStompDisconnectListener {
+
+    private final ChatOnlineStatusService chatOnlineStatusService;
+
+    @EventListener
+    public void handle(SessionDisconnectEvent event) {
+        chatOnlineStatusService.disconnect(event.getSessionId());
+    }
+}

--- a/src/main/java/com/dduru/gildongmu/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/dduru/gildongmu/chat/repository/ChatMessageRepository.java
@@ -40,4 +40,15 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
     );
 
     boolean existsByIdAndRoom_IdAndCreatedAtGreaterThanEqual(Long messageId, Long roomId, LocalDateTime visibleFrom);
+
+    @Query("""
+            SELECT m
+            FROM ChatMessage m
+            JOIN FETCH m.sender s
+            JOIN FETCH s.profile p
+            JOIN FETCH m.room r
+            LEFT JOIN FETCH r.journey j
+            WHERE m.id = :messageId
+            """)
+    Optional<ChatMessage> findByIdWithSenderAndRoom(@Param("messageId") Long messageId);
 }

--- a/src/main/java/com/dduru/gildongmu/chat/repository/ChatRoomMemberRepository.java
+++ b/src/main/java/com/dduru/gildongmu/chat/repository/ChatRoomMemberRepository.java
@@ -84,5 +84,5 @@ public interface ChatRoomMemberRepository extends JpaRepository<ChatRoomMember, 
               AND m.user.id = :participantUserId
               AND m.room.status = 'ACTIVE'
             """)
-    boolean existsByChatRoom_IdAndUser_Id(@Param("roomId") Long roomId, @Param("participantUserId") Long participantUserId);
+    boolean isMember(@Param("roomId") Long roomId, @Param("participantUserId") Long participantUserId);
 }

--- a/src/main/java/com/dduru/gildongmu/chat/service/ChatOnlineStatusService.java
+++ b/src/main/java/com/dduru/gildongmu/chat/service/ChatOnlineStatusService.java
@@ -49,12 +49,9 @@ public class ChatOnlineStatusService {
         if (sessionValue == null) return;
 
         String[] parts = sessionValue.split(":");
-        if (parts.length != 2) return;
-
-        String userId = parts[0];
-        String roomId = parts[1];
         try {
-            redisTemplate.opsForSet().remove(onlineKey(Long.parseLong(roomId)), userId);
+            if (parts.length != 2) return;
+            redisTemplate.opsForSet().remove(onlineKey(Long.parseLong(parts[1])), parts[0]);
         } catch (NumberFormatException e) {
             // 데이터 손상 시에도 세션 키는 반드시 삭제
         } finally {

--- a/src/main/java/com/dduru/gildongmu/chat/service/ChatOnlineStatusService.java
+++ b/src/main/java/com/dduru/gildongmu/chat/service/ChatOnlineStatusService.java
@@ -1,0 +1,61 @@
+package com.dduru.gildongmu.chat.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class ChatOnlineStatusService {
+
+    private static final String ONLINE_KEY_PREFIX = "chat:online:";
+    private static final String SESSION_KEY_PREFIX = "chat:session:";
+    private static final Duration PRESENCE_TTL = Duration.ofHours(2);
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public void enter(Long roomId, Long userId, String sessionId) {
+        String onlineKey = onlineKey(roomId);
+        redisTemplate.opsForSet().add(onlineKey, userId.toString());
+        redisTemplate.expire(onlineKey, PRESENCE_TTL); // add()는 TTL을 갱신하지 않아 매번 명시적으로 설정
+        redisTemplate.opsForValue().set(sessionKey(sessionId), userId + ":" + roomId, PRESENCE_TTL);
+    }
+
+    public void leave(Long roomId, Long userId, String sessionId) {
+        redisTemplate.opsForSet().remove(onlineKey(roomId), userId.toString());
+        redisTemplate.delete(sessionKey(sessionId));
+    }
+
+    // 앱 강제 종료 시 UNSUBSCRIBE 없이 연결이 끊김 → sessionId만 알 수 있어 세션 키로 roomId 역추적
+    public void disconnect(String sessionId) {
+        String sessionValue = redisTemplate.opsForValue().get(sessionKey(sessionId));
+        if (sessionValue == null) return;
+
+        String[] parts = sessionValue.split(":");
+        if (parts.length != 2) return;
+
+        String userId = parts[0];
+        String roomId = parts[1];
+        redisTemplate.opsForSet().remove(onlineKey(Long.parseLong(roomId)), userId);
+        redisTemplate.delete(sessionKey(sessionId));
+    }
+
+    public Set<Long> getOnlineUserIds(Long roomId) {
+        Set<String> members = redisTemplate.opsForSet().members(onlineKey(roomId));
+        if (members == null || members.isEmpty()) return Collections.emptySet();
+        return members.stream().map(Long::parseLong).collect(Collectors.toSet());
+    }
+
+    private String onlineKey(Long roomId) {
+        return ONLINE_KEY_PREFIX + roomId;
+    }
+
+    private String sessionKey(String sessionId) {
+        return SESSION_KEY_PREFIX + sessionId;
+    }
+}

--- a/src/main/java/com/dduru/gildongmu/chat/service/ChatOnlineStatusService.java
+++ b/src/main/java/com/dduru/gildongmu/chat/service/ChatOnlineStatusService.java
@@ -15,20 +15,32 @@ public class ChatOnlineStatusService {
 
     private static final String ONLINE_KEY_PREFIX = "chat:online:";
     private static final String SESSION_KEY_PREFIX = "chat:session:";
+    private static final String SUBSCRIPTION_KEY_PREFIX = "chat:subscription:";
     private static final Duration PRESENCE_TTL = Duration.ofHours(2);
 
     private final RedisTemplate<String, String> redisTemplate;
 
-    public void enter(Long roomId, Long userId, String sessionId) {
+    public void enter(Long roomId, Long userId, String sessionId, String subscriptionId) {
         String onlineKey = onlineKey(roomId);
         redisTemplate.opsForSet().add(onlineKey, userId.toString());
         redisTemplate.expire(onlineKey, PRESENCE_TTL); // add()는 TTL을 갱신하지 않아 매번 명시적으로 설정
         redisTemplate.opsForValue().set(sessionKey(sessionId), userId + ":" + roomId, PRESENCE_TTL);
+        redisTemplate.opsForValue().set(subscriptionKey(sessionId, subscriptionId), roomId.toString(), PRESENCE_TTL);
     }
 
-    public void leave(Long roomId, Long userId, String sessionId) {
-        redisTemplate.opsForSet().remove(onlineKey(roomId), userId.toString());
-        redisTemplate.delete(sessionKey(sessionId));
+    // STOMP UNSUBSCRIBE 프레임은 destination 없이 subscriptionId만 전달 → subscription 키로 roomId 역추적
+    public void leave(String sessionId, String subscriptionId, Long userId) {
+        String subscriptionKey = subscriptionKey(sessionId, subscriptionId);
+        String roomIdValue = redisTemplate.opsForValue().get(subscriptionKey);
+        if (roomIdValue == null) return;
+        try {
+            Long roomId = Long.parseLong(roomIdValue);
+            redisTemplate.opsForSet().remove(onlineKey(roomId), userId.toString());
+        } catch (NumberFormatException e) {
+            // 데이터 손상 시에도 subscription 키는 반드시 삭제
+        } finally {
+            redisTemplate.delete(subscriptionKey);
+        }
     }
 
     // 앱 강제 종료 시 UNSUBSCRIBE 없이 연결이 끊김 → sessionId만 알 수 있어 세션 키로 roomId 역추적
@@ -41,8 +53,13 @@ public class ChatOnlineStatusService {
 
         String userId = parts[0];
         String roomId = parts[1];
-        redisTemplate.opsForSet().remove(onlineKey(Long.parseLong(roomId)), userId);
-        redisTemplate.delete(sessionKey(sessionId));
+        try {
+            redisTemplate.opsForSet().remove(onlineKey(Long.parseLong(roomId)), userId);
+        } catch (NumberFormatException e) {
+            // 데이터 손상 시에도 세션 키는 반드시 삭제
+        } finally {
+            redisTemplate.delete(sessionKey(sessionId));
+        }
     }
 
     public Set<Long> getOnlineUserIds(Long roomId) {
@@ -57,5 +74,9 @@ public class ChatOnlineStatusService {
 
     private String sessionKey(String sessionId) {
         return SESSION_KEY_PREFIX + sessionId;
+    }
+
+    private String subscriptionKey(String sessionId, String subscriptionId) {
+        return SUBSCRIPTION_KEY_PREFIX + sessionId + ":" + subscriptionId;
     }
 }

--- a/src/main/java/com/dduru/gildongmu/chat/service/ChatPushNotificationService.java
+++ b/src/main/java/com/dduru/gildongmu/chat/service/ChatPushNotificationService.java
@@ -1,0 +1,61 @@
+package com.dduru.gildongmu.chat.service;
+
+import com.dduru.gildongmu.chat.domain.enums.ChatMessageType;
+import com.dduru.gildongmu.chat.domain.enums.ChatRoomType;
+import com.dduru.gildongmu.fcm.service.FcmPushService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ChatPushNotificationService {
+
+    private static final String COOLDOWN_KEY_PREFIX = "chat:push:lastsent:";
+    private static final Duration COOLDOWN_DURATION = Duration.ofSeconds(30);
+    private static final int CONTENT_MAX_LENGTH = 30;
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private final FcmPushService fcmPushService;
+
+    // SET NX EX 30 — 원자적 연산으로 leading edge debounce 구현
+    // 키 없음(30초 경과 or 최초): SET 성공 → true (발송 가능, 쿨다운 시작)
+    // 키 있음(30초 이내): SET 생략 → false (쿨다운 중, 스킵)
+    public boolean canSendPush(Long roomId) {
+        Boolean keySet = redisTemplate.opsForValue()
+                .setIfAbsent(COOLDOWN_KEY_PREFIX + roomId, "1", COOLDOWN_DURATION);
+        return Boolean.TRUE.equals(keySet); // Redis 오류 시 null 반환시 false로 처리 → 언박싱 NPE 방지
+    }
+
+    public void sendPush(List<Long> userIds, String roomTitle, String senderNickname,
+                         String content, ChatMessageType messageType, ChatRoomType roomType, Long roomId) {
+        String body = buildBody(senderNickname, content, messageType, roomType);
+        fcmPushService.sendToUsers(userIds, roomTitle, body, "chat:" + roomId);
+    }
+
+    private String buildBody(String senderNickname, String content, ChatMessageType messageType, ChatRoomType roomType) {
+        if (roomType == ChatRoomType.PRIVATE) {
+            return switch (messageType) {
+                case TEXT -> truncate(content);
+                case IMAGE -> "사진을 보냈습니다.";
+                default -> "메시지를 보냈습니다.";
+            };
+        }
+        return switch (messageType) {
+            case TEXT -> senderNickname + ": " + truncate(content);
+            case IMAGE -> senderNickname + ": 사진을 보냈습니다.";
+            default -> senderNickname + ": 메시지를 보냈습니다.";
+        };
+    }
+
+    // length() 대신 codePointCount 사용 — 이모지 등 유니코드 보조 문자가 length()에서 2로 카운트되는 문제 방지
+    private String truncate(String content) {
+        int codePointLength = content.codePointCount(0, content.length());
+        if (codePointLength <= CONTENT_MAX_LENGTH) return content;
+        int endIndex = content.offsetByCodePoints(0, CONTENT_MAX_LENGTH);
+        return content.substring(0, endIndex) + "...";
+    }
+}

--- a/src/main/java/com/dduru/gildongmu/chat/service/GroupChatRoomService.java
+++ b/src/main/java/com/dduru/gildongmu/chat/service/GroupChatRoomService.java
@@ -77,7 +77,7 @@ public class GroupChatRoomService {
     }
 
     private boolean isAlreadyMember(ChatRoom chatRoom, Long inviteeUserId) {
-        return chatRoomMemberRepository.existsByChatRoom_IdAndUser_Id(chatRoom.getId(), inviteeUserId);
+        return chatRoomMemberRepository.isMember(chatRoom.getId(), inviteeUserId);
     }
 
     /**

--- a/src/main/java/com/dduru/gildongmu/chat/websocket/ChatStompPresenceInterceptor.java
+++ b/src/main/java/com/dduru/gildongmu/chat/websocket/ChatStompPresenceInterceptor.java
@@ -1,0 +1,73 @@
+package com.dduru.gildongmu.chat.websocket;
+
+import com.dduru.gildongmu.chat.constants.ChatDestinationPaths;
+import com.dduru.gildongmu.chat.service.ChatOnlineStatusService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageHeaderAccessor;
+import org.springframework.stereotype.Component;
+
+import java.security.Principal;
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class ChatStompPresenceInterceptor implements ChannelInterceptor {
+
+    private final ChatOnlineStatusService chatOnlineStatusService;
+
+    @Override
+    public Message<?> preSend(Message<?> message, MessageChannel channel) {
+        StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+        if (accessor == null || accessor.getCommand() == null) return message;
+
+        switch (accessor.getCommand()) {
+            case SUBSCRIBE -> handleSubscribe(accessor);
+            case UNSUBSCRIBE -> handleUnsubscribe(accessor);
+            default -> { }
+        }
+
+        return message;
+    }
+
+    private void handleSubscribe(StompHeaderAccessor accessor) {
+        extractRoomId(accessor.getDestination()).ifPresent(roomId -> {
+            Long userId = extractUserId(accessor);
+            if (userId == null) return;
+            chatOnlineStatusService.enter(roomId, userId, accessor.getSessionId());
+        });
+    }
+
+    private void handleUnsubscribe(StompHeaderAccessor accessor) {
+        extractRoomId(accessor.getDestination()).ifPresent(roomId -> {
+            Long userId = extractUserId(accessor);
+            if (userId == null) return;
+            chatOnlineStatusService.leave(roomId, userId, accessor.getSessionId());
+        });
+    }
+
+    private Optional<Long> extractRoomId(String destination) {
+        if (destination == null || !destination.startsWith(ChatDestinationPaths.TOPIC_ROOM_PREFIX)) {
+            return Optional.empty();
+        }
+        try {
+            String suffix = destination.substring(ChatDestinationPaths.TOPIC_ROOM_PREFIX.length());
+            return Optional.of(Long.parseLong(suffix));
+        } catch (NumberFormatException e) {
+            return Optional.empty();
+        }
+    }
+
+    private Long extractUserId(StompHeaderAccessor accessor) {
+        Principal user = accessor.getUser();
+        if (user == null) return null;
+        try {
+            return Long.parseLong(user.getName()); // JWT 인증 시 Principal.name = userId
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/dduru/gildongmu/chat/websocket/ChatStompPresenceInterceptor.java
+++ b/src/main/java/com/dduru/gildongmu/chat/websocket/ChatStompPresenceInterceptor.java
@@ -1,6 +1,7 @@
 package com.dduru.gildongmu.chat.websocket;
 
 import com.dduru.gildongmu.chat.constants.ChatDestinationPaths;
+import com.dduru.gildongmu.chat.repository.ChatRoomMemberRepository;
 import com.dduru.gildongmu.chat.service.ChatOnlineStatusService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.Message;
@@ -18,6 +19,7 @@ import java.util.Optional;
 public class ChatStompPresenceInterceptor implements ChannelInterceptor {
 
     private final ChatOnlineStatusService chatOnlineStatusService;
+    private final ChatRoomMemberRepository chatRoomMemberRepository;
 
     @Override
     public Message<?> preSend(Message<?> message, MessageChannel channel) {
@@ -25,20 +27,25 @@ public class ChatStompPresenceInterceptor implements ChannelInterceptor {
         if (accessor == null || accessor.getCommand() == null) return message;
 
         switch (accessor.getCommand()) {
-            case SUBSCRIBE -> handleSubscribe(accessor);
+            case SUBSCRIBE -> { if (!handleSubscribe(accessor)) return null; } // null 반환 → STOMP 프레임 드롭
             case UNSUBSCRIBE -> handleUnsubscribe(accessor);
-            default -> { }
         }
 
         return message;
     }
 
-    private void handleSubscribe(StompHeaderAccessor accessor) {
-        extractRoomId(accessor.getDestination()).ifPresent(roomId -> {
-            Long userId = extractUserId(accessor);
-            if (userId == null) return;
-            chatOnlineStatusService.enter(roomId, userId, accessor.getSessionId(), accessor.getSubscriptionId());
-        });
+    private boolean handleSubscribe(StompHeaderAccessor accessor) {
+        Optional<Long> roomIdOpt = extractRoomId(accessor.getDestination());
+        if (roomIdOpt.isEmpty()) return true;
+
+        Long roomId = roomIdOpt.get();
+        Long userId = extractUserId(accessor);
+        if (userId == null) return false;
+
+        if (!chatRoomMemberRepository.isMember(roomId, userId)) return false;
+
+        chatOnlineStatusService.enter(roomId, userId, accessor.getSessionId(), accessor.getSubscriptionId());
+        return true;
     }
 
     // UNSUBSCRIBE 프레임은 destination 없이 subscriptionId만 전달 → subscriptionId로 roomId 역추적

--- a/src/main/java/com/dduru/gildongmu/chat/websocket/ChatStompPresenceInterceptor.java
+++ b/src/main/java/com/dduru/gildongmu/chat/websocket/ChatStompPresenceInterceptor.java
@@ -37,16 +37,17 @@ public class ChatStompPresenceInterceptor implements ChannelInterceptor {
         extractRoomId(accessor.getDestination()).ifPresent(roomId -> {
             Long userId = extractUserId(accessor);
             if (userId == null) return;
-            chatOnlineStatusService.enter(roomId, userId, accessor.getSessionId());
+            chatOnlineStatusService.enter(roomId, userId, accessor.getSessionId(), accessor.getSubscriptionId());
         });
     }
 
+    // UNSUBSCRIBE 프레임은 destination 없이 subscriptionId만 전달 → subscriptionId로 roomId 역추적
     private void handleUnsubscribe(StompHeaderAccessor accessor) {
-        extractRoomId(accessor.getDestination()).ifPresent(roomId -> {
-            Long userId = extractUserId(accessor);
-            if (userId == null) return;
-            chatOnlineStatusService.leave(roomId, userId, accessor.getSessionId());
-        });
+        Long userId = extractUserId(accessor);
+        if (userId == null) return;
+        String subscriptionId = accessor.getSubscriptionId();
+        if (subscriptionId == null) return;
+        chatOnlineStatusService.leave(accessor.getSessionId(), subscriptionId, userId);
     }
 
     private Optional<Long> extractRoomId(String destination) {

--- a/src/main/java/com/dduru/gildongmu/common/config/WebSocketStompConfig.java
+++ b/src/main/java/com/dduru/gildongmu/common/config/WebSocketStompConfig.java
@@ -1,5 +1,6 @@
 package com.dduru.gildongmu.common.config;
 
+import com.dduru.gildongmu.chat.websocket.ChatStompPresenceInterceptor;
 import com.dduru.gildongmu.common.websocket.JwtStompChannelInterceptor;
 import com.dduru.gildongmu.common.websocket.StompErrorHandler;
 import lombok.RequiredArgsConstructor;
@@ -16,6 +17,7 @@ import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerCo
 public class WebSocketStompConfig implements WebSocketMessageBrokerConfigurer {
 
     private final JwtStompChannelInterceptor jwtStompChannelInterceptor;
+    private final ChatStompPresenceInterceptor chatStompPresenceInterceptor;
     private final StompErrorHandler stompErrorHandler;
 
     @Override
@@ -36,6 +38,7 @@ public class WebSocketStompConfig implements WebSocketMessageBrokerConfigurer {
 
     @Override
     public void configureClientInboundChannel(ChannelRegistration registration) {
-        registration.interceptors(jwtStompChannelInterceptor);
+        // JWT 인증 후 presence 추적 순서 보장
+        registration.interceptors(jwtStompChannelInterceptor, chatStompPresenceInterceptor);
     }
 }

--- a/src/main/java/com/dduru/gildongmu/fcm/service/FcmPushService.java
+++ b/src/main/java/com/dduru/gildongmu/fcm/service/FcmPushService.java
@@ -31,11 +31,20 @@ public class FcmPushService {
 
         if (tokens.isEmpty()) return;
 
-        sendMulticast(tokens, title, body);
+        sendMulticast(tokens, title, body, null);
     }
 
     @Async("fcmExecutor")
     public void sendToUsers(List<Long> userIds, String title, String body) {
+        doSendToUsers(userIds, title, body, null);
+    }
+
+    @Async("fcmExecutor")
+    public void sendToUsers(List<Long> userIds, String title, String body, String collapseKey) {
+        doSendToUsers(userIds, title, body, collapseKey);
+    }
+
+    private void doSendToUsers(List<Long> userIds, String title, String body, String collapseKey) {
         if (isFirebaseNotInitialized()) return;
         if (userIds.isEmpty()) return;
 
@@ -46,24 +55,31 @@ public class FcmPushService {
 
         if (tokens.isEmpty()) return;
 
-        sendMulticast(tokens, title, body);
+        sendMulticast(tokens, title, body, collapseKey);
     }
 
-    private void sendMulticast(List<String> tokens, String title, String body) {
+    // FCM 단일 요청 토큰 수 제한(500개)으로 인해 청크 단위로 분할 발송
+    private void sendMulticast(List<String> tokens, String title, String body, String collapseKey) {
         for (int i = 0; i < tokens.size(); i += FCM_MAX_TOKENS) {
             List<String> chunk = tokens.subList(i, Math.min(i + FCM_MAX_TOKENS, tokens.size()));
-            sendBatch(chunk, title, body);
+            sendBatch(chunk, title, body, collapseKey);
         }
     }
 
-    private void sendBatch(List<String> tokens, String title, String body) {
-        MulticastMessage message = MulticastMessage.builder()
+    private void sendBatch(List<String> tokens, String title, String body, String collapseKey) {
+        MulticastMessage.Builder builder = MulticastMessage.builder()
                 .setNotification(Notification.builder()
                         .setTitle(title)
                         .setBody(body)
                         .build())
-                .addAllTokens(tokens)
-                .build();
+                .addAllTokens(tokens);
+
+        if (collapseKey != null) {
+            builder.setAndroidConfig(AndroidConfig.builder().setCollapseKey(collapseKey).build());
+            builder.setApnsConfig(ApnsConfig.builder().putHeader("apns-collapse-id", collapseKey).build());
+        }
+
+        MulticastMessage message = builder.build();
 
         try {
             BatchResponse response = FirebaseMessaging.getInstance().sendEachForMulticast(message);
@@ -96,6 +112,7 @@ public class FcmPushService {
         return !sendResponse.isSuccessful();
     }
 
+    // Firebase 설정 없는 로컬 환경에서 예외 방지
     private boolean isFirebaseNotInitialized() {
         return FirebaseApp.getApps().isEmpty();
     }

--- a/src/test/java/com/dduru/gildongmu/chat/event/ChatMessagePushEventListenerTest.java
+++ b/src/test/java/com/dduru/gildongmu/chat/event/ChatMessagePushEventListenerTest.java
@@ -1,0 +1,262 @@
+package com.dduru.gildongmu.chat.event;
+
+import com.dduru.gildongmu.chat.domain.ChatMessage;
+import com.dduru.gildongmu.chat.domain.ChatRoom;
+import com.dduru.gildongmu.chat.domain.enums.ChatMessageType;
+import com.dduru.gildongmu.chat.domain.enums.ChatRoomType;
+import com.dduru.gildongmu.chat.repository.ChatMessageRepository;
+import com.dduru.gildongmu.chat.repository.ChatRoomMemberRepository;
+import com.dduru.gildongmu.chat.service.ChatOnlineStatusService;
+import com.dduru.gildongmu.chat.service.ChatPushNotificationService;
+import com.dduru.gildongmu.journey.domain.Journey;
+import com.dduru.gildongmu.profile.domain.Profile;
+import com.dduru.gildongmu.user.domain.User;
+import com.dduru.gildongmu.user.domain.enums.OauthType;
+import com.dduru.gildongmu.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ChatMessagePushEventListener 테스트")
+class ChatMessagePushEventListenerTest {
+
+    private static final Long ROOM_ID = 10L;
+    private static final Long SENDER_ID = 1L;
+    private static final Long MESSAGE_ID = 100L;
+
+    @Mock private ChatMessageRepository chatMessageRepository;
+    @Mock private ChatRoomMemberRepository chatRoomMemberRepository;
+    @Mock private ChatOnlineStatusService chatOnlineStatusService;
+    @Mock private ChatPushNotificationService chatPushNotificationService;
+    @Mock private UserRepository userRepository;
+
+    private ChatMessagePushEventListener listener;
+
+    @BeforeEach
+    void setUp() {
+        listener = new ChatMessagePushEventListener(
+                chatMessageRepository, chatRoomMemberRepository,
+                chatOnlineStatusService, chatPushNotificationService, userRepository
+        );
+    }
+
+    @Nested
+    @DisplayName("필터 — 조기 종료 케이스")
+    class EarlyReturnCases {
+
+        @Test
+        @DisplayName("메시지를 찾을 수 없으면 푸시를 발송하지 않는다")
+        void skipsWhenMessageNotFound() {
+            when(chatMessageRepository.findByIdWithSenderAndRoom(MESSAGE_ID)).thenReturn(Optional.empty());
+
+            listener.handle(new ChatMessageCreatedEvent(ROOM_ID, MESSAGE_ID));
+
+            verify(chatPushNotificationService, never()).sendPush(any(), any(), any(), any(), any(), any(), any());
+        }
+
+        @Test
+        @DisplayName("SYSTEM 메시지는 푸시를 발송하지 않는다")
+        void skipsSystemMessage() {
+            ChatMessage message = createMessage(ChatMessageType.SYSTEM, "홍길동 님이 입장하였습니다.");
+            when(chatMessageRepository.findByIdWithSenderAndRoom(MESSAGE_ID)).thenReturn(Optional.of(message));
+
+            listener.handle(new ChatMessageCreatedEvent(ROOM_ID, MESSAGE_ID));
+
+            verify(chatRoomMemberRepository, never()).findUserIdsByRoomId(any());
+        }
+
+        @Test
+        @DisplayName("발신자 외 수신자가 없으면 푸시를 발송하지 않는다")
+        void skipsWhenNoRecipients() {
+            ChatMessage message = createGroupMessage(ChatMessageType.TEXT, "안녕");
+            when(chatMessageRepository.findByIdWithSenderAndRoom(MESSAGE_ID)).thenReturn(Optional.of(message));
+            when(chatRoomMemberRepository.findUserIdsByRoomId(ROOM_ID)).thenReturn(List.of(SENDER_ID));
+
+            listener.handle(new ChatMessageCreatedEvent(ROOM_ID, MESSAGE_ID));
+
+            verify(chatOnlineStatusService, never()).getOnlineUserIds(any());
+        }
+
+        @Test
+        @DisplayName("수신자 전원이 채팅방에 접속 중이면 푸시를 발송하지 않는다")
+        void skipsWhenAllRecipientsOnline() {
+            Long recipientId = 2L;
+            ChatMessage message = createGroupMessage(ChatMessageType.TEXT, "안녕");
+            when(chatMessageRepository.findByIdWithSenderAndRoom(MESSAGE_ID)).thenReturn(Optional.of(message));
+            when(chatRoomMemberRepository.findUserIdsByRoomId(ROOM_ID)).thenReturn(List.of(SENDER_ID, recipientId));
+            when(chatOnlineStatusService.getOnlineUserIds(ROOM_ID)).thenReturn(Set.of(recipientId));
+
+            listener.handle(new ChatMessageCreatedEvent(ROOM_ID, MESSAGE_ID));
+
+            verify(chatPushNotificationService, never()).canSendPush(any());
+        }
+
+        @Test
+        @DisplayName("30초 쿨다운 중이면 푸시를 발송하지 않는다")
+        void skipsWhenCooldownActive() {
+            Long recipientId = 2L;
+            ChatMessage message = createGroupMessage(ChatMessageType.TEXT, "안녕");
+            when(chatMessageRepository.findByIdWithSenderAndRoom(MESSAGE_ID)).thenReturn(Optional.of(message));
+            when(chatRoomMemberRepository.findUserIdsByRoomId(ROOM_ID)).thenReturn(List.of(SENDER_ID, recipientId));
+            when(chatOnlineStatusService.getOnlineUserIds(ROOM_ID)).thenReturn(Set.of());
+            when(chatPushNotificationService.canSendPush(ROOM_ID)).thenReturn(false);
+
+            listener.handle(new ChatMessageCreatedEvent(ROOM_ID, MESSAGE_ID));
+
+            verify(userRepository, never()).findEnabledUserIds(any());
+        }
+
+        @Test
+        @DisplayName("알림 수신 off 유저만 남으면 FCM을 발송하지 않는다")
+        void skipsWhenAllNotificationDisabled() {
+            Long recipientId = 2L;
+            ChatMessage message = createGroupMessage(ChatMessageType.TEXT, "안녕");
+            when(chatMessageRepository.findByIdWithSenderAndRoom(MESSAGE_ID)).thenReturn(Optional.of(message));
+            when(chatRoomMemberRepository.findUserIdsByRoomId(ROOM_ID)).thenReturn(List.of(SENDER_ID, recipientId));
+            when(chatOnlineStatusService.getOnlineUserIds(ROOM_ID)).thenReturn(Set.of());
+            when(chatPushNotificationService.canSendPush(ROOM_ID)).thenReturn(true);
+            when(userRepository.findEnabledUserIds(List.of(recipientId))).thenReturn(List.of());
+
+            listener.handle(new ChatMessageCreatedEvent(ROOM_ID, MESSAGE_ID));
+
+            verify(chatPushNotificationService, never()).sendPush(any(), any(), any(), any(), any(), any(), any());
+        }
+    }
+
+    @Nested
+    @DisplayName("정상 발송")
+    class NormalSend {
+
+        @Test
+        @DisplayName("GROUP 방은 여정 제목을 title로 FCM을 발송한다")
+        void sendsGroupPushWithJourneyTitle() {
+            Long recipientId = 2L;
+            ChatMessage message = createGroupMessage(ChatMessageType.TEXT, "오늘 저녁 7시 어때?");
+            setupNormalSendMocks(message, recipientId);
+
+            listener.handle(new ChatMessageCreatedEvent(ROOM_ID, MESSAGE_ID));
+
+            verify(chatPushNotificationService).sendPush(
+                    eq(List.of(recipientId)), eq("도쿄 여행"), eq("홍길동"),
+                    eq("오늘 저녁 7시 어때?"), eq(ChatMessageType.TEXT), eq(ChatRoomType.GROUP), eq(ROOM_ID)
+            );
+        }
+
+        @Test
+        @DisplayName("PRIVATE 방은 발신자 닉네임을 title로 FCM을 발송한다")
+        void sendsPrivatePushWithSenderNickname() {
+            Long recipientId = 2L;
+            ChatMessage message = createPrivateMessage(ChatMessageType.TEXT, "안녕하세요");
+            setupNormalSendMocks(message, recipientId);
+
+            listener.handle(new ChatMessageCreatedEvent(ROOM_ID, MESSAGE_ID));
+
+            verify(chatPushNotificationService).sendPush(
+                    eq(List.of(recipientId)), eq("홍길동"), eq("홍길동"),
+                    eq("안녕하세요"), eq(ChatMessageType.TEXT), eq(ChatRoomType.PRIVATE), eq(ROOM_ID)
+            );
+        }
+
+        @Test
+        @DisplayName("이미지 메시지도 정상 발송한다")
+        void sendsImagePush() {
+            Long recipientId = 2L;
+            ChatMessage message = createGroupMessage(ChatMessageType.IMAGE, "https://s3.example.com/img.jpg");
+            setupNormalSendMocks(message, recipientId);
+
+            listener.handle(new ChatMessageCreatedEvent(ROOM_ID, MESSAGE_ID));
+
+            verify(chatPushNotificationService).sendPush(
+                    any(), any(), any(), any(), eq(ChatMessageType.IMAGE), eq(ChatRoomType.GROUP), eq(ROOM_ID)
+            );
+        }
+
+        @Test
+        @DisplayName("접속 중인 유저를 제외한 미접속 수신자에게만 발송한다")
+        void sendsOnlyToOfflineRecipients() {
+            Long onlineId = 2L;
+            Long offlineId = 3L;
+            ChatMessage message = createGroupMessage(ChatMessageType.TEXT, "ㅎㅇ");
+            when(chatMessageRepository.findByIdWithSenderAndRoom(MESSAGE_ID)).thenReturn(Optional.of(message));
+            when(chatRoomMemberRepository.findUserIdsByRoomId(ROOM_ID))
+                    .thenReturn(List.of(SENDER_ID, onlineId, offlineId));
+            when(chatOnlineStatusService.getOnlineUserIds(ROOM_ID)).thenReturn(Set.of(onlineId));
+            when(chatPushNotificationService.canSendPush(ROOM_ID)).thenReturn(true);
+            when(userRepository.findEnabledUserIds(List.of(offlineId))).thenReturn(List.of(offlineId));
+
+            listener.handle(new ChatMessageCreatedEvent(ROOM_ID, MESSAGE_ID));
+
+            verify(chatPushNotificationService).sendPush(
+                    eq(List.of(offlineId)), any(), any(), any(), any(), any(), any()
+            );
+        }
+
+        private void setupNormalSendMocks(ChatMessage message, Long recipientId) {
+            when(chatMessageRepository.findByIdWithSenderAndRoom(MESSAGE_ID)).thenReturn(Optional.of(message));
+            when(chatRoomMemberRepository.findUserIdsByRoomId(ROOM_ID))
+                    .thenReturn(List.of(SENDER_ID, recipientId));
+            when(chatOnlineStatusService.getOnlineUserIds(ROOM_ID)).thenReturn(Set.of());
+            when(chatPushNotificationService.canSendPush(ROOM_ID)).thenReturn(true);
+            when(userRepository.findEnabledUserIds(List.of(recipientId))).thenReturn(List.of(recipientId));
+        }
+    }
+
+    // ── 헬퍼 메서드 ──────────────────────────────────────────────────────────
+
+    private ChatMessage createGroupMessage(ChatMessageType type, String content) {
+        User sender = createSender();
+        ChatRoom room = mock(ChatRoom.class);
+        Journey journey = mock(Journey.class);
+        lenient().when(room.getRoomType()).thenReturn(ChatRoomType.GROUP);
+        lenient().when(room.getJourney()).thenReturn(journey);
+        lenient().when(journey.getTitle()).thenReturn("도쿄 여행");
+        return buildMessage(room, sender, type, content);
+    }
+
+    private ChatMessage createPrivateMessage(ChatMessageType type, String content) {
+        User sender = createSender();
+        ChatRoom room = mock(ChatRoom.class);
+        lenient().when(room.getRoomType()).thenReturn(ChatRoomType.PRIVATE);
+        return buildMessage(room, sender, type, content);
+    }
+
+    private ChatMessage createMessage(ChatMessageType type, String content) {
+        User sender = createSender();
+        ChatRoom room = mock(ChatRoom.class);
+        return buildMessage(room, sender, type, content);
+    }
+
+    private ChatMessage buildMessage(ChatRoom room, User sender, ChatMessageType type, String content) {
+        ChatMessage message = ChatMessage.create(room, sender, type, content);
+        ReflectionTestUtils.setField(message, "id", MESSAGE_ID);
+        return message;
+    }
+
+    private User createSender() {
+        User user = User.builder()
+                .email("hong@example.com")
+                .name("홍길동")
+                .oauthId("oauth-1")
+                .oauthType(OauthType.KAKAO)
+                .build();
+        ReflectionTestUtils.setField(user, "id", SENDER_ID);
+        Profile profile = new Profile(user);
+        ReflectionTestUtils.setField(profile, "nickname", "홍길동");
+        ReflectionTestUtils.setField(user, "profile", profile);
+        return user;
+    }
+}

--- a/src/test/java/com/dduru/gildongmu/chat/event/ChatMessagePushEventListenerTest.java
+++ b/src/test/java/com/dduru/gildongmu/chat/event/ChatMessagePushEventListenerTest.java
@@ -113,11 +113,12 @@ class ChatMessagePushEventListenerTest {
             when(chatMessageRepository.findByIdWithSenderAndRoom(MESSAGE_ID)).thenReturn(Optional.of(message));
             when(chatRoomMemberRepository.findUserIdsByRoomId(ROOM_ID)).thenReturn(List.of(SENDER_ID, recipientId));
             when(chatOnlineStatusService.getOnlineUserIds(ROOM_ID)).thenReturn(Set.of());
+            when(userRepository.findEnabledUserIds(List.of(recipientId))).thenReturn(List.of(recipientId));
             when(chatPushNotificationService.canSendPush(ROOM_ID)).thenReturn(false);
 
             listener.handle(new ChatMessageCreatedEvent(ROOM_ID, MESSAGE_ID));
 
-            verify(userRepository, never()).findEnabledUserIds(any());
+            verify(chatPushNotificationService, never()).sendPush(any(), any(), any(), any(), any(), any(), any());
         }
 
         @Test
@@ -128,7 +129,6 @@ class ChatMessagePushEventListenerTest {
             when(chatMessageRepository.findByIdWithSenderAndRoom(MESSAGE_ID)).thenReturn(Optional.of(message));
             when(chatRoomMemberRepository.findUserIdsByRoomId(ROOM_ID)).thenReturn(List.of(SENDER_ID, recipientId));
             when(chatOnlineStatusService.getOnlineUserIds(ROOM_ID)).thenReturn(Set.of());
-            when(chatPushNotificationService.canSendPush(ROOM_ID)).thenReturn(true);
             when(userRepository.findEnabledUserIds(List.of(recipientId))).thenReturn(List.of());
 
             listener.handle(new ChatMessageCreatedEvent(ROOM_ID, MESSAGE_ID));

--- a/src/test/java/com/dduru/gildongmu/chat/service/ChatOnlineStatusServiceTest.java
+++ b/src/test/java/com/dduru/gildongmu/chat/service/ChatOnlineStatusServiceTest.java
@@ -43,27 +43,50 @@ class ChatOnlineStatusServiceTest {
     class Enter {
 
         @Test
-        @DisplayName("유저를 online 셋에 추가하고 세션 매핑을 저장한다")
-        void addsUserToOnlineSetAndStoresSession() {
-            service.enter(5L, 10L, "session-1");
+        @DisplayName("유저를 online 셋에 추가하고 세션·구독 매핑을 저장한다")
+        void addsUserToOnlineSetAndStoresSessionAndSubscription() {
+            service.enter(5L, 10L, "session-1", "sub-1");
 
             verify(setOps).add("chat:online:5", "10");
             verify(redisTemplate).expire(eq("chat:online:5"), eq(Duration.ofHours(2)));
             verify(valueOps).set("chat:session:session-1", "10:5", Duration.ofHours(2));
+            verify(valueOps).set("chat:subscription:session-1:sub-1", "5", Duration.ofHours(2));
         }
     }
 
     @Nested
-    @DisplayName("leave — 채팅방 퇴장")
-    class Leave {
+    @DisplayName("leave — 구독 해제")
+    class LeaveBySubscription {
 
         @Test
-        @DisplayName("유저를 online 셋에서 제거하고 세션 매핑을 삭제한다")
-        void removesUserFromOnlineSetAndDeletesSession() {
-            service.leave(5L, 10L, "session-1");
+        @DisplayName("subscription 키로 roomId를 조회해 online 셋에서 제거하고 subscription 키를 삭제한다")
+        void removesUserFromOnlineSetAndDeletesSubscriptionKey() {
+            when(valueOps.get("chat:subscription:session-1:sub-1")).thenReturn("5");
+
+            service.leave("session-1", "sub-1", 10L);
 
             verify(setOps).remove("chat:online:5", "10");
-            verify(redisTemplate).delete("chat:session:session-1");
+            verify(redisTemplate).delete("chat:subscription:session-1:sub-1");
+        }
+
+        @Test
+        @DisplayName("subscription 키가 없으면 아무 작업도 하지 않는다")
+        void doesNothingWhenSubscriptionNotFound() {
+            when(valueOps.get("chat:subscription:session-1:sub-1")).thenReturn(null);
+
+            service.leave("session-1", "sub-1", 10L);
+
+            verify(setOps, never()).remove(any(), any());
+        }
+
+        @Test
+        @DisplayName("roomId 파싱 실패 시에도 subscription 키는 삭제한다")
+        void deletesSubscriptionKeyEvenOnParseFailure() {
+            when(valueOps.get("chat:subscription:session-1:sub-1")).thenReturn("invalid");
+
+            service.leave("session-1", "sub-1", 10L);
+
+            verify(redisTemplate).delete("chat:subscription:session-1:sub-1");
         }
     }
 
@@ -90,6 +113,16 @@ class ChatOnlineStatusServiceTest {
             service.disconnect("session-1");
 
             verify(setOps, never()).remove(any(), any());
+        }
+
+        @Test
+        @DisplayName("roomId 파싱 실패 시에도 세션 키는 삭제한다")
+        void deletesSessionKeyEvenOnParseFailure() {
+            when(valueOps.get("chat:session:session-1")).thenReturn("10:invalid");
+
+            service.disconnect("session-1");
+
+            verify(redisTemplate).delete("chat:session:session-1");
         }
     }
 

--- a/src/test/java/com/dduru/gildongmu/chat/service/ChatOnlineStatusServiceTest.java
+++ b/src/test/java/com/dduru/gildongmu/chat/service/ChatOnlineStatusServiceTest.java
@@ -1,0 +1,120 @@
+package com.dduru.gildongmu.chat.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.SetOperations;
+import org.springframework.data.redis.core.ValueOperations;
+
+import java.time.Duration;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("ChatOnlineStatusService 테스트")
+class ChatOnlineStatusServiceTest {
+
+    @Mock private RedisTemplate<String, String> redisTemplate;
+    @Mock private SetOperations<String, String> setOps;
+    @Mock private ValueOperations<String, String> valueOps;
+
+    private ChatOnlineStatusService service;
+
+    @BeforeEach
+    void setUp() {
+        when(redisTemplate.opsForSet()).thenReturn(setOps);
+        when(redisTemplate.opsForValue()).thenReturn(valueOps);
+        service = new ChatOnlineStatusService(redisTemplate);
+    }
+
+    @Nested
+    @DisplayName("enter — 채팅방 입장")
+    class Enter {
+
+        @Test
+        @DisplayName("유저를 online 셋에 추가하고 세션 매핑을 저장한다")
+        void addsUserToOnlineSetAndStoresSession() {
+            service.enter(5L, 10L, "session-1");
+
+            verify(setOps).add("chat:online:5", "10");
+            verify(redisTemplate).expire(eq("chat:online:5"), eq(Duration.ofHours(2)));
+            verify(valueOps).set("chat:session:session-1", "10:5", Duration.ofHours(2));
+        }
+    }
+
+    @Nested
+    @DisplayName("leave — 채팅방 퇴장")
+    class Leave {
+
+        @Test
+        @DisplayName("유저를 online 셋에서 제거하고 세션 매핑을 삭제한다")
+        void removesUserFromOnlineSetAndDeletesSession() {
+            service.leave(5L, 10L, "session-1");
+
+            verify(setOps).remove("chat:online:5", "10");
+            verify(redisTemplate).delete("chat:session:session-1");
+        }
+    }
+
+    @Nested
+    @DisplayName("disconnect — 연결 종료")
+    class Disconnect {
+
+        @Test
+        @DisplayName("세션 매핑을 조회해 online 셋에서 제거하고 세션 키를 삭제한다")
+        void cleansUpPresenceOnDisconnect() {
+            when(valueOps.get("chat:session:session-1")).thenReturn("10:5");
+
+            service.disconnect("session-1");
+
+            verify(setOps).remove("chat:online:5", "10");
+            verify(redisTemplate).delete("chat:session:session-1");
+        }
+
+        @Test
+        @DisplayName("세션 매핑이 없으면 아무 작업도 하지 않는다")
+        void doesNothingWhenSessionNotFound() {
+            when(valueOps.get("chat:session:session-1")).thenReturn(null);
+
+            service.disconnect("session-1");
+
+            verify(setOps, never()).remove(any(), any());
+        }
+    }
+
+    @Nested
+    @DisplayName("getOnlineUserIds — 접속 중 유저 조회")
+    class GetOnlineUserIds {
+
+        @Test
+        @DisplayName("채팅방 접속 중인 유저 ID 목록을 반환한다")
+        void returnsOnlineUserIds() {
+            when(setOps.members("chat:online:5")).thenReturn(Set.of("10", "20"));
+
+            Set<Long> result = service.getOnlineUserIds(5L);
+
+            assertThat(result).containsExactlyInAnyOrder(10L, 20L);
+        }
+
+        @Test
+        @DisplayName("접속 중인 유저가 없으면 빈 셋을 반환한다")
+        void returnsEmptySetWhenNoOneOnline() {
+            when(setOps.members("chat:online:5")).thenReturn(Set.of());
+
+            Set<Long> result = service.getOnlineUserIds(5L);
+
+            assertThat(result).isEmpty();
+        }
+    }
+}

--- a/src/test/java/com/dduru/gildongmu/chat/service/ChatPushNotificationServiceTest.java
+++ b/src/test/java/com/dduru/gildongmu/chat/service/ChatPushNotificationServiceTest.java
@@ -1,0 +1,141 @@
+package com.dduru.gildongmu.chat.service;
+
+import com.dduru.gildongmu.chat.domain.enums.ChatMessageType;
+import com.dduru.gildongmu.chat.domain.enums.ChatRoomType;
+import com.dduru.gildongmu.fcm.service.FcmPushService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+import java.time.Duration;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("ChatPushNotificationService 테스트")
+class ChatPushNotificationServiceTest {
+
+    @Mock private RedisTemplate<String, String> redisTemplate;
+    @Mock private ValueOperations<String, String> valueOps;
+    @Mock private FcmPushService fcmPushService;
+
+    private ChatPushNotificationService service;
+
+    @BeforeEach
+    void setUp() {
+        when(redisTemplate.opsForValue()).thenReturn(valueOps);
+        service = new ChatPushNotificationService(redisTemplate, fcmPushService);
+    }
+
+    @Nested
+    @DisplayName("canSendPush — Leading Edge Debounce")
+    class CanSendPush {
+
+        @Test
+        @DisplayName("키가 없으면 SET NX 성공 → true 반환 (발송 가능)")
+        void returnsTrueWhenKeyAbsent() {
+            when(valueOps.setIfAbsent(eq("chat:push:lastsent:5"), eq("1"), eq(Duration.ofSeconds(30))))
+                    .thenReturn(true);
+
+            assertThat(service.canSendPush(5L)).isTrue();
+        }
+
+        @Test
+        @DisplayName("키가 이미 있으면 SET NX 실패 → false 반환 (쿨다운 중)")
+        void returnsFalseWhenKeyExists() {
+            when(valueOps.setIfAbsent(eq("chat:push:lastsent:5"), eq("1"), eq(Duration.ofSeconds(30))))
+                    .thenReturn(false);
+
+            assertThat(service.canSendPush(5L)).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("sendPush — FCM 발송")
+    class SendPush {
+
+        @Test
+        @DisplayName("TEXT 메시지는 닉네임: 내용 형식으로 발송한다")
+        void sendsTextMessageWithNicknameAndContent() {
+            service.sendPush(List.of(1L), "도쿄 여행", "홍길동", "오늘 저녁 어때?", ChatMessageType.TEXT, ChatRoomType.GROUP, 5L);
+
+            verify(fcmPushService).sendToUsers(
+                    eq(List.of(1L)), eq("도쿄 여행"), eq("홍길동: 오늘 저녁 어때?"), eq("chat:5")
+            );
+        }
+
+        @Test
+        @DisplayName("GROUP TEXT가 30자를 초과하면 30자 + ...으로 잘린다")
+        void truncatesTextContentExceeding30Chars() {
+            String longContent = "가".repeat(35);
+
+            service.sendPush(List.of(1L), "도쿄 여행", "홍길동", longContent, ChatMessageType.TEXT, ChatRoomType.GROUP, 5L);
+
+            ArgumentCaptor<String> bodyCaptor = ArgumentCaptor.forClass(String.class);
+            verify(fcmPushService).sendToUsers(any(), any(), bodyCaptor.capture(), any());
+
+            assertThat(bodyCaptor.getValue()).isEqualTo("홍길동: " + "가".repeat(30) + "...");
+        }
+
+        @Test
+        @DisplayName("GROUP TEXT가 30자 이하면 그대로 발송한다")
+        void doesNotTruncateContentWithin30Chars() {
+            String shortContent = "가".repeat(30);
+
+            service.sendPush(List.of(1L), "도쿄 여행", "홍길동", shortContent, ChatMessageType.TEXT, ChatRoomType.GROUP, 5L);
+
+            ArgumentCaptor<String> bodyCaptor = ArgumentCaptor.forClass(String.class);
+            verify(fcmPushService).sendToUsers(any(), any(), bodyCaptor.capture(), any());
+
+            assertThat(bodyCaptor.getValue()).isEqualTo("홍길동: " + shortContent);
+        }
+
+        @Test
+        @DisplayName("GROUP IMAGE는 '닉네임: 사진을 보냈습니다.' 형식으로 발송한다")
+        void sendsGroupImageMessage() {
+            service.sendPush(List.of(1L), "도쿄 여행", "홍길동", "https://s3.example.com/img.jpg",
+                    ChatMessageType.IMAGE, ChatRoomType.GROUP, 5L);
+
+            verify(fcmPushService).sendToUsers(any(), any(), eq("홍길동: 사진을 보냈습니다."), any());
+        }
+
+        @Test
+        @DisplayName("PRIVATE TEXT는 닉네임 없이 내용만 body에 담아 발송한다")
+        void sendsPrivateTextWithoutNickname() {
+            service.sendPush(List.of(1L), "홍길동", "홍길동", "안녕하세요", ChatMessageType.TEXT, ChatRoomType.PRIVATE, 5L);
+
+            verify(fcmPushService).sendToUsers(any(), any(), eq("안녕하세요"), any());
+        }
+
+        @Test
+        @DisplayName("PRIVATE IMAGE는 닉네임 없이 '사진을 보냈습니다.'로 발송한다")
+        void sendsPrivateImageWithoutNickname() {
+            service.sendPush(List.of(1L), "홍길동", "홍길동", "https://s3.example.com/img.jpg",
+                    ChatMessageType.IMAGE, ChatRoomType.PRIVATE, 5L);
+
+            verify(fcmPushService).sendToUsers(any(), any(), eq("사진을 보냈습니다."), any());
+        }
+
+        @Test
+        @DisplayName("collapseKey는 chat:{roomId} 형식으로 전달된다")
+        void sendsWithCorrectCollapseKey() {
+            service.sendPush(List.of(1L), "도쿄 여행", "홍길동", "안녕", ChatMessageType.TEXT, ChatRoomType.GROUP, 5L);
+
+            verify(fcmPushService).sendToUsers(any(), any(), any(), eq("chat:5"));
+        }
+    }
+}

--- a/src/test/java/com/dduru/gildongmu/chat/service/GroupChatRoomServiceTest.java
+++ b/src/test/java/com/dduru/gildongmu/chat/service/GroupChatRoomServiceTest.java
@@ -74,7 +74,7 @@ class GroupChatRoomServiceTest {
 
             when(chatRoomRepository.getByJourneyIdAndRoomTypeWithLock(journeyId, ChatRoomType.GROUP)).thenReturn(room);
             when(userRepository.getByIdOrThrow(inviteeId)).thenReturn(createUser(inviteeId, "invitee"));
-            when(chatRoomMemberRepository.existsByChatRoom_IdAndUser_Id(roomId, inviteeId)).thenReturn(false, true);
+            when(chatRoomMemberRepository.isMember(roomId, inviteeId)).thenReturn(false, true);
             when(chatRoomMemberRepository.countByRoom(room)).thenReturn(1);
             when(chatRoomMemberRepository.save(any())).thenThrow(new DataIntegrityViolationException("duplicate"));
 
@@ -98,7 +98,7 @@ class GroupChatRoomServiceTest {
 
             when(chatRoomRepository.getByJourneyIdAndRoomTypeWithLock(journeyId, ChatRoomType.GROUP)).thenReturn(room);
             when(userRepository.getByIdOrThrow(inviteeId)).thenReturn(invitee);
-            when(chatRoomMemberRepository.existsByChatRoom_IdAndUser_Id(roomId, inviteeId)).thenReturn(false);
+            when(chatRoomMemberRepository.isMember(roomId, inviteeId)).thenReturn(false);
             when(chatRoomMemberRepository.countByRoom(room)).thenReturn(1);
 
             GroupChatInviteMemberResponse response = groupChatRoomService.inviteMemberOrGetRoom(ownerId, journeyId, inviteeId);
@@ -125,7 +125,7 @@ class GroupChatRoomServiceTest {
 
             when(chatRoomRepository.getByJourneyIdAndRoomTypeWithLock(journeyId, ChatRoomType.GROUP)).thenReturn(room);
             when(userRepository.getByIdOrThrow(inviteeId)).thenReturn(createUser(inviteeId, "invitee"));
-            when(chatRoomMemberRepository.existsByChatRoom_IdAndUser_Id(roomId, inviteeId)).thenReturn(false);
+            when(chatRoomMemberRepository.isMember(roomId, inviteeId)).thenReturn(false);
             when(chatRoomMemberRepository.countByRoom(room)).thenReturn(2);
 
             assertThatThrownBy(() -> groupChatRoomService.inviteMemberOrGetRoom(ownerId, journeyId, inviteeId))

--- a/src/test/java/com/dduru/gildongmu/chat/websocket/ChatStompPresenceInterceptorTest.java
+++ b/src/test/java/com/dduru/gildongmu/chat/websocket/ChatStompPresenceInterceptorTest.java
@@ -1,0 +1,142 @@
+package com.dduru.gildongmu.chat.websocket;
+
+import com.dduru.gildongmu.chat.repository.ChatRoomMemberRepository;
+import com.dduru.gildongmu.chat.service.ChatOnlineStatusService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.MessageBuilder;
+
+import java.security.Principal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ChatStompPresenceInterceptor 테스트")
+class ChatStompPresenceInterceptorTest {
+
+    private static final Long ROOM_ID = 10L;
+    private static final Long USER_ID = 1L;
+    private static final String SESSION_ID = "session-abc";
+    private static final String SUBSCRIPTION_ID = "sub-0";
+    private static final String CHAT_DESTINATION = "/topic/chat/rooms/" + ROOM_ID;
+    private static final String OTHER_DESTINATION = "/topic/notifications";
+
+    @Mock private ChatOnlineStatusService chatOnlineStatusService;
+    @Mock private ChatRoomMemberRepository chatRoomMemberRepository;
+
+    @InjectMocks
+    private ChatStompPresenceInterceptor interceptor;
+
+    @Nested
+    @DisplayName("SUBSCRIBE")
+    class Subscribe {
+
+        @Test
+        @DisplayName("채팅방 멤버가 구독하면 presence 등록 후 프레임을 통과시킨다")
+        void allowsMemberSubscription() {
+            when(chatRoomMemberRepository.isMember(ROOM_ID, USER_ID)).thenReturn(true);
+
+            Message<?> result = interceptor.preSend(
+                    subscribeMessage(CHAT_DESTINATION, USER_ID),
+                    mock(MessageChannel.class)
+            );
+
+            assertThat(result).isNotNull();
+            verify(chatOnlineStatusService).enter(eq(ROOM_ID), eq(USER_ID), eq(SESSION_ID), eq(SUBSCRIPTION_ID));
+        }
+
+        @Test
+        @DisplayName("채팅방 비멤버가 구독하면 null을 반환해 프레임을 차단한다")
+        void blocksNonMemberSubscription() {
+            when(chatRoomMemberRepository.isMember(ROOM_ID, USER_ID)).thenReturn(false);
+
+            Message<?> result = interceptor.preSend(
+                    subscribeMessage(CHAT_DESTINATION, USER_ID),
+                    mock(MessageChannel.class)
+            );
+
+            assertThat(result).isNull();
+            verify(chatOnlineStatusService, never()).enter(any(), any(), any(), any());
+        }
+
+        @Test
+        @DisplayName("인증 정보 없이 채팅방 구독 시도하면 null을 반환해 프레임을 차단한다")
+        void blocksUnauthenticatedSubscription() {
+            Message<?> result = interceptor.preSend(
+                    subscribeMessage(CHAT_DESTINATION, null),
+                    mock(MessageChannel.class)
+            );
+
+            assertThat(result).isNull();
+            verify(chatRoomMemberRepository, never()).isMember(any(), any());
+            verify(chatOnlineStatusService, never()).enter(any(), any(), any(), any());
+        }
+
+        @Test
+        @DisplayName("채팅방이 아닌 destination 구독은 멤버 검증 없이 통과시킨다")
+        void allowsNonChatSubscription() {
+            Message<?> result = interceptor.preSend(
+                    subscribeMessage(OTHER_DESTINATION, USER_ID),
+                    mock(MessageChannel.class)
+            );
+
+            assertThat(result).isNotNull();
+            verify(chatRoomMemberRepository, never()).isMember(any(), any());
+            verify(chatOnlineStatusService, never()).enter(any(), any(), any(), any());
+        }
+    }
+
+    @Nested
+    @DisplayName("UNSUBSCRIBE")
+    class Unsubscribe {
+
+        @Test
+        @DisplayName("UNSUBSCRIBE 프레임은 presence 해제 후 통과시킨다")
+        void leavesOnUnsubscribe() {
+            Message<?> result = interceptor.preSend(
+                    unsubscribeMessage(USER_ID),
+                    mock(MessageChannel.class)
+            );
+
+            assertThat(result).isNotNull();
+            verify(chatOnlineStatusService).leave(SESSION_ID, SUBSCRIPTION_ID, USER_ID);
+        }
+    }
+
+    // ── 헬퍼 메서드 ──────────────────────────────────────────────────────────
+
+    private static Message<byte[]> subscribeMessage(String destination, Long userId) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.SUBSCRIBE);
+        accessor.setDestination(destination);
+        accessor.setSubscriptionId(SUBSCRIPTION_ID);
+        accessor.setSessionId(SESSION_ID);
+        if (userId != null) {
+            accessor.setUser(principal(userId));
+        }
+        accessor.setLeaveMutable(true);
+        return MessageBuilder.createMessage(new byte[0], accessor.getMessageHeaders());
+    }
+
+    private static Message<byte[]> unsubscribeMessage(Long userId) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.UNSUBSCRIBE);
+        accessor.setSubscriptionId(SUBSCRIPTION_ID);
+        accessor.setSessionId(SESSION_ID);
+        accessor.setUser(principal(userId));
+        accessor.setLeaveMutable(true);
+        return MessageBuilder.createMessage(new byte[0], accessor.getMessageHeaders());
+    }
+
+    private static Principal principal(Long userId) {
+        return () -> String.valueOf(userId);
+    }
+}


### PR DESCRIPTION
## 🔎 작업 내용
  - ChatOnlineStatusService — Redis 기반 채팅방 접속 상태 관리 (enter/leave/disconnect/getOnlineUserIds)
  - ChatStompPresenceInterceptor — STOMP SUBSCRIBE/UNSUBSCRIBE 감지 → 접속 상태 갱신
  - ChatStompDisconnectListener — SessionDisconnectEvent 수신 → 강제 종료 시 접속 상태 정리
  - ChatPushNotificationService — 30초 Leading Edge Debounce (SET NX EX 30) + GROUP/PRIVATE 타입별 body 포맷팅
  - ChatMessagePushEventListener — 이벤트 수신 → 필터 파이프라인(SYSTEM 제외 → 발신자 제외 → 접속 중 제외 → 쿨다운 → 알림 off 제외) → FCM 발송
  - FcmPushService — collapseKey 오버로드 추가 (Android collapseKey / APNS apns-collapse-id)
  - ChatMessageRepository — findByIdWithSenderAndRoom JOIN FETCH 쿼리 추가
  
## ➕ 이슈 링크
* CLOSED #294 


## 😎 리뷰 요구사항
 > 30초 Leading Edge Debounce를 `SET NX EX 30` 단일 명령으로 구현했습니다.
  > Redis의 원자적 연산 특성상 다중 인스턴스 환경에서도 중복 발송 없이 동작합니다.
  > 이 방식 외에 더 나은 접근이 있다면 의견 부탁드립니다.


## 🧑‍💻 예정 작업
- 없음

## 📝 체크리스트
- [x] 브랜치 이름은 `feat/#이슈번호-개발내용` 형식으로 작성했는가?
- [x] 커밋 메시지는 `[#이슈번호] feat(scope): 커밋 내용` 형식으로 작성했는가?
- [x] PR 제목은 `feat(scope): PR 제목` 형식으로 작성했는가?
- [x] 작업 전 Issue를 작성했는가?
- [x] `dev` 브랜치로 병합을 요청했는가?
- [x] 불필요한 주석과 공백은 제거했는가?
- [ ] 코드 리뷰어의 피드백을 반영했는가?
- [x] 테스트를 진행했는가?
- [x] 테스트 코드를 작성했는가?
