### PR TITLE
feat(fcm): 푸시 알림 클릭 시 특정 화면으로 이동하도록 데이터 추가

### DIFF
--- a/docs/001-design/flows/005-notification-flow.md
+++ b/docs/001-design/flows/005-notification-flow.md
@@ -80,12 +80,14 @@ NotificationEventListener
 ### FCM 푸시 발송 흐름
 
 ```
-fcmPushService.sendToUser(userId, title, body)  [fcmExecutor 스레드풀, @Async]
+fcmPushService.sendToUser(userId, title, body, data)  [fcmExecutor 스레드풀, @Async]
   │
   ├── Firebase 미초기화 → return (graceful skip)
   ├── user_fcm_tokens 에서 토큰 조회 → 없으면 return
   ├── 500개 단위 청크 분할
   └── FirebaseMessaging.sendEachForMulticast()
+        ├── notification payload: title, body
+        ├── data payload: resourceType, resourceId  ← 앱 딥링크용
         ├── 성공 → 완료
         └── UNREGISTERED / INVALID_ARGUMENT → 해당 토큰 즉시 삭제
 ```
@@ -147,14 +149,19 @@ FCM 발송은 인앱 알림 저장과 독립적이다. DB 저장 후 비동기�
 
 ### resourceType / resourceId (탭 시 이동 대상)
 
-| 타입 | resourceType | resourceId |
-|---|---|---|
-| `MATCH_APPLIED` | `MATCH` | `participationId` |
-| `MATCH_APPROVED` | `JOURNEY` | `journeyId` (승인된 여정으로 이동) |
-| `JOURNEY_NOTICE` | `JOURNEY_POST` | `journeyPostId` |
-| `SCHEDULE_*` | `SCHEDULE` | `scheduleId` |
-| `POST_UPDATED` | `JOURNEY_POST` | `postId` (모집글 상세로 이동) |
-| `TRIP_UPCOMING` | `JOURNEY` | `journeyId` |
+FCM data payload에 `resourceType`, `resourceId`를 실어 보낸다. 앱은 이 값을 읽어 알림 탭 시 해당 화면으로 딥링크 처리한다. 인앱 알림함 API도 동일한 필드를 응답에 포함하므로, 앱 내 알림함 탭 시에도 동일하게 동작한다.
+
+| 알림 종류 | resourceType | resourceId | 이동 화면 |
+|---|---|---|---|
+| `MATCH_APPLIED` | `MATCH` | `participationId` | 신청 목록 화면 |
+| `MATCH_APPROVED` | `JOURNEY` | `journeyId` | 여정 상세 화면 |
+| `JOURNEY_NOTICE` | `JOURNEY_POST` | `journeyPostId` | 공지 상세 화면 |
+| `SCHEDULE_*` | `SCHEDULE` | `scheduleId` | 일정 상세 화면 |
+| `POST_UPDATED` | `JOURNEY_POST` | `postId` | 모집글 상세 화면 |
+| `TRIP_UPCOMING` | `JOURNEY` | `journeyId` | 여정 상세 화면 |
+| 채팅 메시지 | `CHAT_ROOM` | `roomId` | 채팅방 화면 |
+
+> 채팅 메시지 알림은 `notifications` 테이블에 저장되지 않으므로 인앱 알림함에는 표시되지 않는다. FCM data payload로만 딥링크를 전달한다.
 
 ---
 
@@ -318,6 +325,20 @@ chat:subscription:{sessionId}:{subId}     → {roomId}           (TTL 2h, UNSUBS
 | PRIVATE IMAGE | 발신자 닉네임 | `사진을 보냈습니다.` |
 
 > SYSTEM 메시지(입장·퇴장 등)는 푸시 대상이 아니다.
+
+### FCM data payload
+
+```json
+{
+  "notification": { "title": "도쿄 여행", "body": "홍길동: 오늘 저녁 어때?" },
+  "data": {
+    "resourceType": "CHAT_ROOM",
+    "resourceId": "123"
+  }
+}
+```
+
+앱은 `data.resourceType == "CHAT_ROOM"` 확인 후 `data.resourceId`(roomId)로 해당 채팅방 화면으로 이동한다.
 
 ### collapseKey
 

--- a/src/main/java/com/dduru/gildongmu/chat/service/ChatPushNotificationService.java
+++ b/src/main/java/com/dduru/gildongmu/chat/service/ChatPushNotificationService.java
@@ -3,6 +3,7 @@ package com.dduru.gildongmu.chat.service;
 import com.dduru.gildongmu.chat.domain.enums.ChatMessageType;
 import com.dduru.gildongmu.chat.domain.enums.ChatRoomType;
 import com.dduru.gildongmu.fcm.service.FcmPushService;
+import com.dduru.gildongmu.notification.domain.enums.ResourceType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
@@ -33,7 +34,8 @@ public class ChatPushNotificationService {
     public void sendPush(List<Long> userIds, String roomTitle, String senderNickname,
                          String content, ChatMessageType messageType, ChatRoomType roomType, Long roomId) {
         String body = buildBody(senderNickname, content, messageType, roomType);
-        fcmPushService.sendToUsers(userIds, roomTitle, body, "chat:" + roomId);
+        fcmPushService.sendToUsers(userIds, roomTitle, body, "chat:" + roomId,
+                FcmPushService.dataPayload(ResourceType.CHAT_ROOM, roomId));
     }
 
     private String buildBody(String senderNickname, String content, ChatMessageType messageType, ChatRoomType roomType) {

--- a/src/main/java/com/dduru/gildongmu/fcm/service/FcmPushService.java
+++ b/src/main/java/com/dduru/gildongmu/fcm/service/FcmPushService.java
@@ -25,7 +25,7 @@ public class FcmPushService {
 
     // 앱 딥링크 스펙 계약 키 — 변경 시 앱팀 동기화 필요
     public static Map<String, String> dataPayload(ResourceType resourceType, Long resourceId) {
-        return Map.of("resourceType", resourceType.name(), "resourceId", resourceId.toString());
+        return Map.of("resourceType", resourceType.getPayloadValue(), "resourceId", resourceId.toString());
     }
 
     @Async("fcmExecutor")

--- a/src/main/java/com/dduru/gildongmu/fcm/service/FcmPushService.java
+++ b/src/main/java/com/dduru/gildongmu/fcm/service/FcmPushService.java
@@ -9,7 +9,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
+import com.dduru.gildongmu.notification.domain.enums.ResourceType;
+
 import java.util.List;
+import java.util.Map;
 
 @Slf4j
 @Service
@@ -20,8 +23,17 @@ public class FcmPushService {
 
     private final UserFcmTokenRepository userFcmTokenRepository;
 
+    // 앱 딥링크 스펙 계약 키 — 변경 시 앱팀 동기화 필요
+    public static Map<String, String> dataPayload(ResourceType resourceType, Long resourceId) {
+        return Map.of("resourceType", resourceType.name(), "resourceId", resourceId.toString());
+    }
+
     @Async("fcmExecutor")
-    public void sendToUser(Long userId, String title, String body) {
+    public void sendToUser(Long userId, String title, String body, Map<String, String> data) {
+        doSendToUser(userId, title, body, data);
+    }
+
+    private void doSendToUser(Long userId, String title, String body, Map<String, String> data) {
         if (isFirebaseNotInitialized()) return;
 
         List<String> tokens = userFcmTokenRepository.findAllByUserId(userId)
@@ -31,20 +43,15 @@ public class FcmPushService {
 
         if (tokens.isEmpty()) return;
 
-        sendMulticast(tokens, title, body, null);
+        sendMulticast(tokens, title, body, null, data);
     }
 
     @Async("fcmExecutor")
-    public void sendToUsers(List<Long> userIds, String title, String body) {
-        doSendToUsers(userIds, title, body, null);
+    public void sendToUsers(List<Long> userIds, String title, String body, String collapseKey, Map<String, String> data) {
+        doSendToUsers(userIds, title, body, collapseKey, data);
     }
 
-    @Async("fcmExecutor")
-    public void sendToUsers(List<Long> userIds, String title, String body, String collapseKey) {
-        doSendToUsers(userIds, title, body, collapseKey);
-    }
-
-    private void doSendToUsers(List<Long> userIds, String title, String body, String collapseKey) {
+    private void doSendToUsers(List<Long> userIds, String title, String body, String collapseKey, Map<String, String> data) {
         if (isFirebaseNotInitialized()) return;
         if (userIds.isEmpty()) return;
 
@@ -55,18 +62,18 @@ public class FcmPushService {
 
         if (tokens.isEmpty()) return;
 
-        sendMulticast(tokens, title, body, collapseKey);
+        sendMulticast(tokens, title, body, collapseKey, data);
     }
 
     // FCM 단일 요청 토큰 수 제한(500개)으로 인해 청크 단위로 분할 발송
-    private void sendMulticast(List<String> tokens, String title, String body, String collapseKey) {
+    private void sendMulticast(List<String> tokens, String title, String body, String collapseKey, Map<String, String> data) {
         for (int i = 0; i < tokens.size(); i += FCM_MAX_TOKENS) {
             List<String> chunk = tokens.subList(i, Math.min(i + FCM_MAX_TOKENS, tokens.size()));
-            sendBatch(chunk, title, body, collapseKey);
+            sendBatch(chunk, title, body, collapseKey, data);
         }
     }
 
-    private void sendBatch(List<String> tokens, String title, String body, String collapseKey) {
+    private void sendBatch(List<String> tokens, String title, String body, String collapseKey, Map<String, String> data) {
         MulticastMessage.Builder builder = MulticastMessage.builder()
                 .setNotification(Notification.builder()
                         .setTitle(title)
@@ -77,6 +84,10 @@ public class FcmPushService {
         if (collapseKey != null) {
             builder.setAndroidConfig(AndroidConfig.builder().setCollapseKey(collapseKey).build());
             builder.setApnsConfig(ApnsConfig.builder().putHeader("apns-collapse-id", collapseKey).build());
+        }
+
+        if (data != null && !data.isEmpty()) {
+            builder.putAllData(data);
         }
 
         MulticastMessage message = builder.build();

--- a/src/main/java/com/dduru/gildongmu/notification/domain/enums/ResourceType.java
+++ b/src/main/java/com/dduru/gildongmu/notification/domain/enums/ResourceType.java
@@ -1,9 +1,16 @@
 package com.dduru.gildongmu.notification.domain.enums;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
 public enum ResourceType {
-    JOURNEY,
-    JOURNEY_POST,
-    SCHEDULE,
-    MATCH,
-    CHAT_ROOM
+    JOURNEY("JOURNEY"),
+    JOURNEY_POST("JOURNEY_POST"),
+    SCHEDULE("SCHEDULE"),
+    MATCH("MATCH"),
+    CHAT_ROOM("CHAT_ROOM");
+
+    private final String payloadValue;
 }

--- a/src/main/java/com/dduru/gildongmu/notification/domain/enums/ResourceType.java
+++ b/src/main/java/com/dduru/gildongmu/notification/domain/enums/ResourceType.java
@@ -4,5 +4,6 @@ public enum ResourceType {
     JOURNEY,
     JOURNEY_POST,
     SCHEDULE,
-    MATCH
+    MATCH,
+    CHAT_ROOM
 }

--- a/src/main/java/com/dduru/gildongmu/notification/listener/NotificationEventListener.java
+++ b/src/main/java/com/dduru/gildongmu/notification/listener/NotificationEventListener.java
@@ -44,7 +44,8 @@ public class NotificationEventListener {
                     NotificationType.MATCH_APPLIED, body, ResourceType.MATCH, event.participationId()
             ));
             if (userRepository.existsByIdAndNotificationEnabled(event.recipientUserId(), true)) {
-                fcmPushService.sendToUser(event.recipientUserId(), "매칭 신청 도착", body);
+                fcmPushService.sendToUser(event.recipientUserId(), "매칭 신청 도착", body,
+                        FcmPushService.dataPayload(ResourceType.MATCH, event.participationId()));
             }
         } catch (Exception e) {
             log.error("MATCH_APPLIED 알림 저장 실패 - participationId={}", event.participationId(), e);
@@ -60,7 +61,8 @@ public class NotificationEventListener {
                     NotificationType.MATCH_APPROVED, body, ResourceType.JOURNEY, event.journeyId()
             ));
             if (userRepository.existsByIdAndNotificationEnabled(event.applicantUserId(), true)) {
-                fcmPushService.sendToUser(event.applicantUserId(), "매칭 승인", body);
+                fcmPushService.sendToUser(event.applicantUserId(), "매칭 승인", body,
+                        FcmPushService.dataPayload(ResourceType.JOURNEY, event.journeyId()));
             }
         } catch (Exception e) {
             log.error("MATCH_APPROVED 알림 저장 실패 - journeyId={}", event.journeyId(), e);
@@ -158,6 +160,7 @@ public class NotificationEventListener {
         notificationPersistService.saveAll(notifications);
         List<Long> fcmTargetIds = userRepository.findEnabledUserIds(recipientIds);
         if (fcmTargetIds.isEmpty()) return;
-        fcmPushService.sendToUsers(fcmTargetIds, pushTitle, body);
+        fcmPushService.sendToUsers(fcmTargetIds, pushTitle, body, null,
+                FcmPushService.dataPayload(resourceType, resourceId));
     }
 }

--- a/src/main/java/com/dduru/gildongmu/notification/service/TripUpcomingNotificationService.java
+++ b/src/main/java/com/dduru/gildongmu/notification/service/TripUpcomingNotificationService.java
@@ -78,7 +78,8 @@ public class TripUpcomingNotificationService {
 
         List<Long> fcmTargetIds = userRepository.findEnabledUserIds(pendingUserIds);
         if (fcmTargetIds.isEmpty()) return;
-        fcmPushService.sendToUsers(fcmTargetIds, PUSH_TITLE, PUSH_BODY);
+        fcmPushService.sendToUsers(fcmTargetIds, PUSH_TITLE, PUSH_BODY, null,
+                FcmPushService.dataPayload(ResourceType.JOURNEY, journeyId));
     }
 
     private List<Long> findPendingUserIds(List<Long> allUserIds, Long journeyId, LocalDateTime startOfToday) {

--- a/src/test/java/com/dduru/gildongmu/chat/service/ChatPushNotificationServiceTest.java
+++ b/src/test/java/com/dduru/gildongmu/chat/service/ChatPushNotificationServiceTest.java
@@ -18,6 +18,7 @@ import org.springframework.data.redis.core.ValueOperations;
 
 import java.time.Duration;
 import java.util.List;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -74,7 +75,7 @@ class ChatPushNotificationServiceTest {
             service.sendPush(List.of(1L), "도쿄 여행", "홍길동", "오늘 저녁 어때?", ChatMessageType.TEXT, ChatRoomType.GROUP, 5L);
 
             verify(fcmPushService).sendToUsers(
-                    eq(List.of(1L)), eq("도쿄 여행"), eq("홍길동: 오늘 저녁 어때?"), eq("chat:5")
+                    eq(List.of(1L)), eq("도쿄 여행"), eq("홍길동: 오늘 저녁 어때?"), eq("chat:5"), any()
             );
         }
 
@@ -86,7 +87,7 @@ class ChatPushNotificationServiceTest {
             service.sendPush(List.of(1L), "도쿄 여행", "홍길동", longContent, ChatMessageType.TEXT, ChatRoomType.GROUP, 5L);
 
             ArgumentCaptor<String> bodyCaptor = ArgumentCaptor.forClass(String.class);
-            verify(fcmPushService).sendToUsers(any(), any(), bodyCaptor.capture(), any());
+            verify(fcmPushService).sendToUsers(any(), any(), bodyCaptor.capture(), any(), any());
 
             assertThat(bodyCaptor.getValue()).isEqualTo("홍길동: " + "가".repeat(30) + "...");
         }
@@ -99,7 +100,7 @@ class ChatPushNotificationServiceTest {
             service.sendPush(List.of(1L), "도쿄 여행", "홍길동", shortContent, ChatMessageType.TEXT, ChatRoomType.GROUP, 5L);
 
             ArgumentCaptor<String> bodyCaptor = ArgumentCaptor.forClass(String.class);
-            verify(fcmPushService).sendToUsers(any(), any(), bodyCaptor.capture(), any());
+            verify(fcmPushService).sendToUsers(any(), any(), bodyCaptor.capture(), any(), any());
 
             assertThat(bodyCaptor.getValue()).isEqualTo("홍길동: " + shortContent);
         }
@@ -110,7 +111,7 @@ class ChatPushNotificationServiceTest {
             service.sendPush(List.of(1L), "도쿄 여행", "홍길동", "https://s3.example.com/img.jpg",
                     ChatMessageType.IMAGE, ChatRoomType.GROUP, 5L);
 
-            verify(fcmPushService).sendToUsers(any(), any(), eq("홍길동: 사진을 보냈습니다."), any());
+            verify(fcmPushService).sendToUsers(any(), any(), eq("홍길동: 사진을 보냈습니다."), any(), any());
         }
 
         @Test
@@ -118,7 +119,7 @@ class ChatPushNotificationServiceTest {
         void sendsPrivateTextWithoutNickname() {
             service.sendPush(List.of(1L), "홍길동", "홍길동", "안녕하세요", ChatMessageType.TEXT, ChatRoomType.PRIVATE, 5L);
 
-            verify(fcmPushService).sendToUsers(any(), any(), eq("안녕하세요"), any());
+            verify(fcmPushService).sendToUsers(any(), any(), eq("안녕하세요"), any(), any());
         }
 
         @Test
@@ -127,7 +128,7 @@ class ChatPushNotificationServiceTest {
             service.sendPush(List.of(1L), "홍길동", "홍길동", "https://s3.example.com/img.jpg",
                     ChatMessageType.IMAGE, ChatRoomType.PRIVATE, 5L);
 
-            verify(fcmPushService).sendToUsers(any(), any(), eq("사진을 보냈습니다."), any());
+            verify(fcmPushService).sendToUsers(any(), any(), eq("사진을 보냈습니다."), any(), any());
         }
 
         @Test
@@ -135,7 +136,20 @@ class ChatPushNotificationServiceTest {
         void sendsWithCorrectCollapseKey() {
             service.sendPush(List.of(1L), "도쿄 여행", "홍길동", "안녕", ChatMessageType.TEXT, ChatRoomType.GROUP, 5L);
 
-            verify(fcmPushService).sendToUsers(any(), any(), any(), eq("chat:5"));
+            verify(fcmPushService).sendToUsers(any(), any(), any(), eq("chat:5"), any());
+        }
+
+        @Test
+        @DisplayName("FCM data payload에 CHAT_ROOM resourceType과 roomId가 포함된다")
+        void sendsWithChatRoomDataPayload() {
+            service.sendPush(List.of(1L), "도쿄 여행", "홍길동", "안녕", ChatMessageType.TEXT, ChatRoomType.GROUP, 5L);
+
+            @SuppressWarnings("unchecked")
+            ArgumentCaptor<Map<String, String>> dataCaptor = ArgumentCaptor.forClass(Map.class);
+            verify(fcmPushService).sendToUsers(any(), any(), any(), any(), dataCaptor.capture());
+
+            assertThat(dataCaptor.getValue()).containsEntry("resourceType", "CHAT_ROOM");
+            assertThat(dataCaptor.getValue()).containsEntry("resourceId", "5");
         }
     }
 }

--- a/src/test/java/com/dduru/gildongmu/fcm/service/FcmPushServiceTest.java
+++ b/src/test/java/com/dduru/gildongmu/fcm/service/FcmPushServiceTest.java
@@ -17,6 +17,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.List;
+import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
@@ -45,7 +46,7 @@ class FcmPushServiceTest {
             try (MockedStatic<FirebaseApp> firebaseAppMock = mockStatic(FirebaseApp.class)) {
                 firebaseAppMock.when(FirebaseApp::getApps).thenReturn(List.of());
 
-                fcmPushService.sendToUser(1L, "제목", "내용");
+                fcmPushService.sendToUser(1L, "제목", "내용", Map.of("resourceType", "JOURNEY", "resourceId", "1"));
 
                 verify(userFcmTokenRepository, never()).findAllByUserId(any());
             }
@@ -58,7 +59,7 @@ class FcmPushServiceTest {
                 firebaseAppMock.when(FirebaseApp::getApps).thenReturn(List.of(mock(FirebaseApp.class)));
                 when(userFcmTokenRepository.findAllByUserId(1L)).thenReturn(List.of());
 
-                fcmPushService.sendToUser(1L, "제목", "내용");
+                fcmPushService.sendToUser(1L, "제목", "내용", Map.of("resourceType", "JOURNEY", "resourceId", "1"));
 
                 verify(userFcmTokenRepository).findAllByUserId(1L);
             }
@@ -75,7 +76,7 @@ class FcmPushServiceTest {
             try (MockedStatic<FirebaseApp> firebaseAppMock = mockStatic(FirebaseApp.class)) {
                 firebaseAppMock.when(FirebaseApp::getApps).thenReturn(List.of());
 
-                fcmPushService.sendToUsers(List.of(1L, 2L), "제목", "내용");
+                fcmPushService.sendToUsers(List.of(1L, 2L), "제목", "내용", null, Map.of());
 
                 verify(userFcmTokenRepository, never()).findAllByUserIdIn(any());
             }
@@ -84,7 +85,7 @@ class FcmPushServiceTest {
         @Test
         @DisplayName("userIds가 비어 있으면 토큰 조회 없이 종료한다")
         void skipsWhenUserIdsIsEmpty() {
-            fcmPushService.sendToUsers(List.of(), "제목", "내용");
+            fcmPushService.sendToUsers(List.of(), "제목", "내용", null, Map.of());
 
             verify(userFcmTokenRepository, never()).findAllByUserIdIn(any());
         }
@@ -96,7 +97,7 @@ class FcmPushServiceTest {
                 firebaseAppMock.when(FirebaseApp::getApps).thenReturn(List.of(mock(FirebaseApp.class)));
                 when(userFcmTokenRepository.findAllByUserIdIn(List.of(1L, 2L))).thenReturn(List.of());
 
-                fcmPushService.sendToUsers(List.of(1L, 2L), "제목", "내용");
+                fcmPushService.sendToUsers(List.of(1L, 2L), "제목", "내용", null, Map.of());
 
                 verify(userFcmTokenRepository).findAllByUserIdIn(List.of(1L, 2L));
             }
@@ -114,7 +115,7 @@ class FcmPushServiceTest {
                         .thenReturn(List.of(token1, token2));
 
                 try {
-                    fcmPushService.sendToUsers(List.of(1L, 2L), "제목", "내용");
+                    fcmPushService.sendToUsers(List.of(1L, 2L), "제목", "내용", null, Map.of());
                 } catch (Exception ignored) {
                     // Firebase 미초기화 환경에서 sendEachForMulticast 호출 시 발생하는 예외 무시
                 }

--- a/src/test/java/com/dduru/gildongmu/notification/service/TripUpcomingNotificationServiceTest.java
+++ b/src/test/java/com/dduru/gildongmu/notification/service/TripUpcomingNotificationServiceTest.java
@@ -68,7 +68,7 @@ class TripUpcomingNotificationServiceTest {
             service.notifyUpcomingTrips();
 
             verify(notificationPersistService, never()).saveAll(any());
-            verify(fcmPushService, never()).sendToUsers(any(), any(), any());
+            verify(fcmPushService, never()).sendToUsers(any(), any(), any(), any(), any());
         }
     }
 
@@ -126,7 +126,7 @@ class TripUpcomingNotificationServiceTest {
 
             service.notifyUpcomingTrips();
 
-            verify(fcmPushService).sendToUsers(eq(List.of(10L)), any(), any());
+            verify(fcmPushService).sendToUsers(eq(List.of(10L)), any(), any(), any(), any());
         }
 
         @Test
@@ -146,7 +146,7 @@ class TripUpcomingNotificationServiceTest {
             service.notifyUpcomingTrips();
 
             verify(notificationPersistService).saveAll(any());
-            verify(fcmPushService, never()).sendToUsers(any(), any(), any());
+            verify(fcmPushService, never()).sendToUsers(any(), any(), any(), any(), any());
         }
     }
 
@@ -169,7 +169,7 @@ class TripUpcomingNotificationServiceTest {
             service.notifyUpcomingTrips();
 
             verify(notificationPersistService, never()).saveAll(any());
-            verify(fcmPushService, never()).sendToUsers(any(), any(), any());
+            verify(fcmPushService, never()).sendToUsers(any(), any(), any(), any(), any());
         }
 
         @Test


### PR DESCRIPTION
## 🔎 작업 내용
  * `ResourceType` 열거형에 `CHAT_ROOM` 값 추가
  * `FcmPushService`에 `dataPayload(ResourceType, Long)` 정적 팩터리 메서드 추가
  * `FcmPushService.sendToUser / sendToUsers`에 `Map<String, String> data` 파라미터 추가
  * `FcmPushService.sendBatch`에서 FCM `data` payload(`putAllData`) 주입 처리
  * 모든 알림 타입 발송 호출부에 `resourceType`, `resourceId` data payload 연결

## ➕ 이슈 링크
* CLOSED #306 

## 📸 스크린샷


## 😎 리뷰 요구사항
  > `dataPayload()`를 `FcmPushService`의 `public static` 메서드로 두었습니다.
  > 앱팀과 합의한 키 이름(`resourceType`, `resourceId`)이 FCM 발송 로직과 같은 파일에 있는 게 자연스럽다고 판단했으나,
   별도 유틸 분리가 더 나을 수 있어 의견 부탁드립니다.

## 🧑‍💻 예정 작업
- 없음

## 📝 체크리스트
- [x] 브랜치 이름은 `feat/#이슈번호-개발내용` 형식으로 작성했는가?
- [x] 커밋 메시지는 `[#이슈번호] feat(scope): 커밋 내용` 형식으로 작성했는가?
- [x] PR 제목은 `feat(scope): PR 제목` 형식으로 작성했는가?
- [x] 작업 전 Issue를 작성했는가?
- [x] `dev` 브랜치로 병합을 요청했는가?
- [x] 불필요한 주석과 공백은 제거했는가?
- [ ] 코드 리뷰어의 피드백을 반영했는가?
- [x] 테스트를 진행했는가?
- [x] 테스트 코드를 작성했는가?
