### PR TITLE
feat(profile): 마이페이지 프로필 조회 API 구현  

### DIFF
--- a/src/main/java/com/dduru/gildongmu/journey/dto/response/JourneyMemberInfo.java
+++ b/src/main/java/com/dduru/gildongmu/journey/dto/response/JourneyMemberInfo.java
@@ -17,7 +17,7 @@ public record JourneyMemberInfo(
         ProfileImageInfo profileImage,
         boolean isHost,
         Gender gender,
-        Integer ageGroup,
+        String ageGroup,
         List<RoleLabelInfo> roles
 ) {
     public static JourneyMemberInfo from(JourneyMember member, ProfileImageResolver resolver, LocalDate today) {

--- a/src/main/java/com/dduru/gildongmu/journey/dto/response/JourneyMemberInfo.java
+++ b/src/main/java/com/dduru/gildongmu/journey/dto/response/JourneyMemberInfo.java
@@ -7,17 +7,25 @@ import com.dduru.gildongmu.profile.dto.response.ProfileImageInfo;
 import com.dduru.gildongmu.profile.utils.AgeGroupCalculator;
 import com.dduru.gildongmu.profile.utils.ProfileImageResolver;
 import com.dduru.gildongmu.user.domain.User;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDate;
 import java.util.List;
 
 public record JourneyMemberInfo(
+        @Schema(description = "여행 멤버 회원 ID", example = "33")
         Long userId,
+        @Schema(description = "닉네임", example = "여행메이트")
         String nickname,
+        @Schema(description = "프로필 이미지 정보")
         ProfileImageInfo profileImage,
+        @Schema(description = "호스트 여부", example = "false")
         boolean isHost,
+        @Schema(description = "성별", example = "F", allowableValues = {"M", "F"})
         Gender gender,
+        @Schema(description = "연령대. birthday 미설정 시 null", example = "20대", nullable = true)
         String ageGroup,
+        @Schema(description = "역할 목록")
         List<RoleLabelInfo> roles
 ) {
     public static JourneyMemberInfo from(JourneyMember member, ProfileImageResolver resolver, LocalDate today) {

--- a/src/main/java/com/dduru/gildongmu/post/dto/response/ParticipantInfo.java
+++ b/src/main/java/com/dduru/gildongmu/post/dto/response/ParticipantInfo.java
@@ -21,8 +21,8 @@ public record ParticipantInfo(
         boolean isHost,
         @Schema(description = "참여자 성별", example = "F", allowableValues = {"M", "F"})
         Gender gender,
-        @Schema(description = "참여자 연령대. 20은 20대를 의미합니다.", example = "20")
-        Integer ageGroup
+        @Schema(description = "참여자 연령대", example = "20대")
+        String ageGroup
 ) {
     public static ParticipantInfo from(User user, boolean isHost, ProfileImageResolver profileImageResolver, LocalDate today) {
         Profile profile = user.getProfile();

--- a/src/main/java/com/dduru/gildongmu/post/dto/response/ParticipantInfo.java
+++ b/src/main/java/com/dduru/gildongmu/post/dto/response/ParticipantInfo.java
@@ -21,7 +21,7 @@ public record ParticipantInfo(
         boolean isHost,
         @Schema(description = "참여자 성별", example = "F", allowableValues = {"M", "F"})
         Gender gender,
-        @Schema(description = "참여자 연령대", example = "20대")
+        @Schema(description = "참여자 연령대. birthday 미설정 시 null", example = "20대", nullable = true)
         String ageGroup
 ) {
     public static ParticipantInfo from(User user, boolean isHost, ProfileImageResolver profileImageResolver, LocalDate today) {

--- a/src/main/java/com/dduru/gildongmu/post/dto/response/PostAuthorInfo.java
+++ b/src/main/java/com/dduru/gildongmu/post/dto/response/PostAuthorInfo.java
@@ -19,7 +19,7 @@ public record PostAuthorInfo(
         ProfileImageInfo profileImage,
         @Schema(description = "작성자 성별", example = "F", allowableValues = {"M", "F"})
         Gender gender,
-        @Schema(description = "작성자 연령대", example = "20대")
+        @Schema(description = "작성자 연령대. birthday 미설정 시 null", example = "20대", nullable = true)
         String ageGroup,
         @Schema(description = "작성자가 슈퍼호스트인지 여부", example = "false")
         boolean isSuperHost

--- a/src/main/java/com/dduru/gildongmu/post/dto/response/PostAuthorInfo.java
+++ b/src/main/java/com/dduru/gildongmu/post/dto/response/PostAuthorInfo.java
@@ -19,8 +19,8 @@ public record PostAuthorInfo(
         ProfileImageInfo profileImage,
         @Schema(description = "작성자 성별", example = "F", allowableValues = {"M", "F"})
         Gender gender,
-        @Schema(description = "작성자 연령대. 20은 20대를 의미합니다.", example = "20")
-        Integer ageGroup,
+        @Schema(description = "작성자 연령대", example = "20대")
+        String ageGroup,
         @Schema(description = "작성자가 슈퍼호스트인지 여부", example = "false")
         boolean isSuperHost
 ) {

--- a/src/main/java/com/dduru/gildongmu/profile/controller/ProfileApiDocs.java
+++ b/src/main/java/com/dduru/gildongmu/profile/controller/ProfileApiDocs.java
@@ -6,6 +6,7 @@ import com.dduru.gildongmu.common.exception.ErrorCode;
 import com.dduru.gildongmu.profile.dto.request.NicknameUpdateRequest;
 import com.dduru.gildongmu.profile.dto.request.ProfileSetupRequest;
 import com.dduru.gildongmu.profile.dto.request.ProfileUpdateRequest;
+import com.dduru.gildongmu.profile.dto.response.MyProfileResponse;
 import com.dduru.gildongmu.profile.dto.response.NicknameRandomResponse;
 import com.dduru.gildongmu.profile.dto.response.NicknameValidateResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -20,6 +21,16 @@ import org.springframework.http.ResponseEntity;
 @Tag(name = "Profiles", description = "사용자 프로필 관리 API")
 @SecurityRequirement(name = "JWT")
 public interface ProfileApiDocs {
+
+    @Operation(summary = "마이페이지 프로필 조회", description = "내 닉네임, 나이대, 한줄소개, 프로필 이미지 정보를 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "프로필 조회 성공")
+    @ApiErrorResponses({
+            ErrorCode.UNAUTHORIZED,
+            ErrorCode.PROFILE_NOT_FOUND
+    })
+    ResponseEntity<ApiResult<MyProfileResponse>> getMyProfile(
+            @Parameter(hidden = true) Long userId
+    );
 
     @Operation(summary = "닉네임 수정", description = "사용자의 닉네임을 수정합니다.")
     @ApiResponse(responseCode = "204", description = "닉네임 수정 성공", content = @Content())

--- a/src/main/java/com/dduru/gildongmu/profile/controller/ProfileController.java
+++ b/src/main/java/com/dduru/gildongmu/profile/controller/ProfileController.java
@@ -5,11 +5,13 @@ import com.dduru.gildongmu.common.dto.ApiResult;
 import com.dduru.gildongmu.profile.dto.request.NicknameUpdateRequest;
 import com.dduru.gildongmu.profile.dto.request.ProfileSetupRequest;
 import com.dduru.gildongmu.profile.dto.request.ProfileUpdateRequest;
+import com.dduru.gildongmu.profile.dto.response.MyProfileResponse;
 import com.dduru.gildongmu.profile.dto.response.NicknameRandomResponse;
 import com.dduru.gildongmu.profile.dto.response.NicknameValidateResponse;
 import com.dduru.gildongmu.profile.service.NicknameService;
 import com.dduru.gildongmu.profile.service.ProfileManagementService;
 import com.dduru.gildongmu.profile.service.ProfileOnboardingService;
+import com.dduru.gildongmu.profile.service.ProfileQueryService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -32,6 +34,14 @@ public class ProfileController implements ProfileApiDocs {
     private final NicknameService nicknameService;
     private final ProfileOnboardingService profileOnboardingService;
     private final ProfileManagementService profileManagementService;
+    private final ProfileQueryService profileQueryService;
+
+    @Override
+    @GetMapping("/users/me/profile")
+    public ResponseEntity<ApiResult<MyProfileResponse>> getMyProfile(@CurrentUser Long userId) {
+        MyProfileResponse response = profileQueryService.getMyProfile(userId);
+        return ResponseEntity.ok(ApiResult.ok(response));
+    }
 
     @Override
     @PutMapping("/users/nickname")

--- a/src/main/java/com/dduru/gildongmu/profile/domain/Profile.java
+++ b/src/main/java/com/dduru/gildongmu/profile/domain/Profile.java
@@ -65,6 +65,10 @@ public class Profile extends BaseTimeEntity {
     @Column(name = "bio", length = 60)
     private String bio;
 
+    public ProfileImageType getProfileImageType() {
+        return profileImageType != null ? profileImageType : ProfileImageType.DEFAULT;
+    }
+
     public Profile(User user) {
         this.user = user;
     }

--- a/src/main/java/com/dduru/gildongmu/profile/dto/response/MyProfileResponse.java
+++ b/src/main/java/com/dduru/gildongmu/profile/dto/response/MyProfileResponse.java
@@ -1,8 +1,11 @@
 package com.dduru.gildongmu.profile.dto.response;
 
 import com.dduru.gildongmu.profile.domain.Profile;
+import com.dduru.gildongmu.profile.domain.enums.Gender;
 import com.dduru.gildongmu.profile.utils.ProfileImageResolver;
 import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDate;
 
 @Schema(description = "마이페이지 프로필 조회 응답")
 public record MyProfileResponse(
@@ -13,13 +16,25 @@ public record MyProfileResponse(
         String bio,
 
         @Schema(description = "프로필 이미지 정보")
-        ProfileImageInfo profileImage
+        ProfileImageInfo profileImage,
+
+        @Schema(description = "성별. 미설정 시 null", example = "F", allowableValues = {"M", "F"}, nullable = true)
+        Gender gender,
+
+        @Schema(description = "생년월일. 미설정 시 null", example = "1998-05-10", nullable = true)
+        LocalDate birthday,
+
+        @Schema(description = "전화번호. 미설정 시 null", example = "01012345678", nullable = true)
+        String phoneNumber
 ) {
     public static MyProfileResponse of(Profile profile, ProfileImageResolver profileImageResolver) {
         return new MyProfileResponse(
                 profile.getNickname(),
                 profile.getBio(),
-                ProfileImageInfo.from(profile, profileImageResolver)
+                ProfileImageInfo.from(profile, profileImageResolver),
+                profile.getGender(),
+                profile.getBirthday(),
+                profile.getPhoneNumber()
         );
     }
 }

--- a/src/main/java/com/dduru/gildongmu/profile/dto/response/MyProfileResponse.java
+++ b/src/main/java/com/dduru/gildongmu/profile/dto/response/MyProfileResponse.java
@@ -1,19 +1,13 @@
 package com.dduru.gildongmu.profile.dto.response;
 
 import com.dduru.gildongmu.profile.domain.Profile;
-import com.dduru.gildongmu.profile.utils.AgeGroupCalculator;
 import com.dduru.gildongmu.profile.utils.ProfileImageResolver;
 import io.swagger.v3.oas.annotations.media.Schema;
-
-import java.time.LocalDate;
 
 @Schema(description = "마이페이지 프로필 조회 응답")
 public record MyProfileResponse(
         @Schema(description = "닉네임", example = "김해나")
         String nickname,
-
-        @Schema(description = "나이대. birthday 미설정 시 null", example = "20대", nullable = true)
-        String ageGroup,
 
         @Schema(description = "한줄소개. 미설정 시 null", example = "맛집 찾는 여행 좋아해요", nullable = true)
         String bio,
@@ -21,10 +15,9 @@ public record MyProfileResponse(
         @Schema(description = "프로필 이미지 정보")
         ProfileImageInfo profileImage
 ) {
-    public static MyProfileResponse of(Profile profile, ProfileImageResolver profileImageResolver, LocalDate today) {
+    public static MyProfileResponse of(Profile profile, ProfileImageResolver profileImageResolver) {
         return new MyProfileResponse(
                 profile.getNickname(),
-                AgeGroupCalculator.toAgeGroup(profile.getBirthday(), today),
                 profile.getBio(),
                 ProfileImageInfo.from(profile, profileImageResolver)
         );

--- a/src/main/java/com/dduru/gildongmu/profile/dto/response/MyProfileResponse.java
+++ b/src/main/java/com/dduru/gildongmu/profile/dto/response/MyProfileResponse.java
@@ -1,0 +1,32 @@
+package com.dduru.gildongmu.profile.dto.response;
+
+import com.dduru.gildongmu.profile.domain.Profile;
+import com.dduru.gildongmu.profile.utils.AgeGroupCalculator;
+import com.dduru.gildongmu.profile.utils.ProfileImageResolver;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDate;
+
+@Schema(description = "마이페이지 프로필 조회 응답")
+public record MyProfileResponse(
+        @Schema(description = "닉네임", example = "김해나")
+        String nickname,
+
+        @Schema(description = "나이대. birthday 미설정 시 null", example = "20대", nullable = true)
+        String ageGroup,
+
+        @Schema(description = "한줄소개. 미설정 시 null", example = "맛집 찾는 여행 좋아해요", nullable = true)
+        String bio,
+
+        @Schema(description = "프로필 이미지 정보")
+        ProfileImageInfo profileImage
+) {
+    public static MyProfileResponse of(Profile profile, ProfileImageResolver profileImageResolver, LocalDate today) {
+        return new MyProfileResponse(
+                profile.getNickname(),
+                AgeGroupCalculator.toAgeGroup(profile.getBirthday(), today),
+                profile.getBio(),
+                ProfileImageInfo.from(profile, profileImageResolver)
+        );
+    }
+}

--- a/src/main/java/com/dduru/gildongmu/profile/service/ProfileQueryService.java
+++ b/src/main/java/com/dduru/gildongmu/profile/service/ProfileQueryService.java
@@ -1,6 +1,5 @@
 package com.dduru.gildongmu.profile.service;
 
-import com.dduru.gildongmu.common.time.TimeProvider;
 import com.dduru.gildongmu.profile.domain.Profile;
 import com.dduru.gildongmu.profile.dto.response.MyProfileResponse;
 import com.dduru.gildongmu.profile.repository.ProfileRepository;
@@ -16,10 +15,9 @@ public class ProfileQueryService {
 
     private final ProfileRepository profileRepository;
     private final ProfileImageResolver profileImageResolver;
-    private final TimeProvider timeProvider;
 
     public MyProfileResponse getMyProfile(Long userId) {
         Profile profile = profileRepository.getByUserIdOrThrow(userId);
-        return MyProfileResponse.of(profile, profileImageResolver, timeProvider.today());
+        return MyProfileResponse.of(profile, profileImageResolver);
     }
 }

--- a/src/main/java/com/dduru/gildongmu/profile/service/ProfileQueryService.java
+++ b/src/main/java/com/dduru/gildongmu/profile/service/ProfileQueryService.java
@@ -1,0 +1,25 @@
+package com.dduru.gildongmu.profile.service;
+
+import com.dduru.gildongmu.common.time.TimeProvider;
+import com.dduru.gildongmu.profile.domain.Profile;
+import com.dduru.gildongmu.profile.dto.response.MyProfileResponse;
+import com.dduru.gildongmu.profile.repository.ProfileRepository;
+import com.dduru.gildongmu.profile.utils.ProfileImageResolver;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+@Transactional(readOnly = true)
+public class ProfileQueryService {
+
+    private final ProfileRepository profileRepository;
+    private final ProfileImageResolver profileImageResolver;
+    private final TimeProvider timeProvider;
+
+    public MyProfileResponse getMyProfile(Long userId) {
+        Profile profile = profileRepository.getByUserIdOrThrow(userId);
+        return MyProfileResponse.of(profile, profileImageResolver, timeProvider.today());
+    }
+}

--- a/src/main/java/com/dduru/gildongmu/profile/utils/AgeGroupCalculator.java
+++ b/src/main/java/com/dduru/gildongmu/profile/utils/AgeGroupCalculator.java
@@ -7,9 +7,9 @@ public class AgeGroupCalculator {
 
     private AgeGroupCalculator() {}
 
-    public static Integer toAgeGroup(LocalDate birthday, LocalDate today) {
+    public static String toAgeGroup(LocalDate birthday, LocalDate today) {
         if (birthday == null) return null;
         int age = Math.max(0, Period.between(birthday, today).getYears());
-        return (age / 10) * 10;
+        return (age / 10) * 10 + "대";
     }
 }

--- a/src/test/java/com/dduru/gildongmu/profile/service/ProfileQueryServiceTest.java
+++ b/src/test/java/com/dduru/gildongmu/profile/service/ProfileQueryServiceTest.java
@@ -1,6 +1,5 @@
 package com.dduru.gildongmu.profile.service;
 
-import com.dduru.gildongmu.common.time.TimeProvider;
 import com.dduru.gildongmu.profile.domain.Profile;
 import com.dduru.gildongmu.profile.dto.response.MyProfileResponse;
 import com.dduru.gildongmu.profile.repository.ProfileRepository;
@@ -17,8 +16,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
-import java.time.LocalDate;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
@@ -28,7 +25,6 @@ class ProfileQueryServiceTest {
 
     @Mock private ProfileRepository profileRepository;
     @Mock private ProfileImageResolver profileImageResolver;
-    @Mock private TimeProvider timeProvider;
 
     @InjectMocks
     private ProfileQueryService profileQueryService;
@@ -50,46 +46,6 @@ class ProfileQueryServiceTest {
     }
 
     @Nested
-    @DisplayName("나이대 계산")
-    class AgeGroup {
-
-        @Test
-        @DisplayName("birthday가 있으면 나이대를 계산해 반환한다")
-        void returnsAgeGroupWhenBirthdayExists() {
-            ReflectionTestUtils.setField(profile, "birthday", LocalDate.of(1998, 5, 10));
-            when(profileRepository.getByUserIdOrThrow(1L)).thenReturn(profile);
-            when(timeProvider.today()).thenReturn(LocalDate.of(2026, 7, 1));
-
-            MyProfileResponse response = profileQueryService.getMyProfile(1L);
-
-            assertThat(response.ageGroup()).isEqualTo("20대");
-        }
-
-        @Test
-        @DisplayName("birthday가 없으면 ageGroup은 null이다")
-        void returnsNullAgeGroupWhenNoBirthday() {
-            when(profileRepository.getByUserIdOrThrow(1L)).thenReturn(profile);
-            when(timeProvider.today()).thenReturn(LocalDate.of(2026, 7, 1));
-
-            MyProfileResponse response = profileQueryService.getMyProfile(1L);
-
-            assertThat(response.ageGroup()).isNull();
-        }
-
-        @Test
-        @DisplayName("생일이 지나지 않은 경우에도 올바른 나이대를 반환한다")
-        void calculatesCorrectlyBeforeBirthday() {
-            ReflectionTestUtils.setField(profile, "birthday", LocalDate.of(1997, 12, 31));
-            when(profileRepository.getByUserIdOrThrow(1L)).thenReturn(profile);
-            when(timeProvider.today()).thenReturn(LocalDate.of(2026, 7, 1));
-
-            MyProfileResponse response = profileQueryService.getMyProfile(1L);
-
-            assertThat(response.ageGroup()).isEqualTo("20대");
-        }
-    }
-
-    @Nested
     @DisplayName("프로필 조회")
     class GetMyProfile {
 
@@ -97,7 +53,6 @@ class ProfileQueryServiceTest {
         @DisplayName("닉네임과 한줄소개를 반환한다")
         void returnsNicknameAndBio() {
             when(profileRepository.getByUserIdOrThrow(1L)).thenReturn(profile);
-            when(timeProvider.today()).thenReturn(LocalDate.of(2026, 7, 1));
 
             MyProfileResponse response = profileQueryService.getMyProfile(1L);
 
@@ -110,7 +65,6 @@ class ProfileQueryServiceTest {
         void returnsNullBioWhenNotSet() {
             ReflectionTestUtils.setField(profile, "bio", null);
             when(profileRepository.getByUserIdOrThrow(1L)).thenReturn(profile);
-            when(timeProvider.today()).thenReturn(LocalDate.of(2026, 7, 1));
 
             MyProfileResponse response = profileQueryService.getMyProfile(1L);
 

--- a/src/test/java/com/dduru/gildongmu/profile/service/ProfileQueryServiceTest.java
+++ b/src/test/java/com/dduru/gildongmu/profile/service/ProfileQueryServiceTest.java
@@ -1,0 +1,120 @@
+package com.dduru.gildongmu.profile.service;
+
+import com.dduru.gildongmu.common.time.TimeProvider;
+import com.dduru.gildongmu.profile.domain.Profile;
+import com.dduru.gildongmu.profile.dto.response.MyProfileResponse;
+import com.dduru.gildongmu.profile.repository.ProfileRepository;
+import com.dduru.gildongmu.profile.utils.ProfileImageResolver;
+import com.dduru.gildongmu.user.domain.User;
+import com.dduru.gildongmu.user.domain.enums.OauthType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ProfileQueryService 테스트")
+class ProfileQueryServiceTest {
+
+    @Mock private ProfileRepository profileRepository;
+    @Mock private ProfileImageResolver profileImageResolver;
+    @Mock private TimeProvider timeProvider;
+
+    @InjectMocks
+    private ProfileQueryService profileQueryService;
+
+    private User user;
+    private Profile profile;
+
+    @BeforeEach
+    void setUp() {
+        user = User.builder()
+                .email("test@example.com")
+                .name("테스트")
+                .oauthId("12345")
+                .oauthType(OauthType.KAKAO)
+                .build();
+        profile = new Profile(user);
+        ReflectionTestUtils.setField(profile, "nickname", "김해나");
+        ReflectionTestUtils.setField(profile, "bio", "맛집 찾는 여행 좋아해요");
+    }
+
+    @Nested
+    @DisplayName("나이대 계산")
+    class AgeGroup {
+
+        @Test
+        @DisplayName("birthday가 있으면 나이대를 계산해 반환한다")
+        void returnsAgeGroupWhenBirthdayExists() {
+            ReflectionTestUtils.setField(profile, "birthday", LocalDate.of(1998, 5, 10));
+            when(profileRepository.getByUserIdOrThrow(1L)).thenReturn(profile);
+            when(timeProvider.today()).thenReturn(LocalDate.of(2026, 7, 1));
+
+            MyProfileResponse response = profileQueryService.getMyProfile(1L);
+
+            assertThat(response.ageGroup()).isEqualTo("20대");
+        }
+
+        @Test
+        @DisplayName("birthday가 없으면 ageGroup은 null이다")
+        void returnsNullAgeGroupWhenNoBirthday() {
+            when(profileRepository.getByUserIdOrThrow(1L)).thenReturn(profile);
+            when(timeProvider.today()).thenReturn(LocalDate.of(2026, 7, 1));
+
+            MyProfileResponse response = profileQueryService.getMyProfile(1L);
+
+            assertThat(response.ageGroup()).isNull();
+        }
+
+        @Test
+        @DisplayName("생일이 지나지 않은 경우에도 올바른 나이대를 반환한다")
+        void calculatesCorrectlyBeforeBirthday() {
+            ReflectionTestUtils.setField(profile, "birthday", LocalDate.of(1997, 12, 31));
+            when(profileRepository.getByUserIdOrThrow(1L)).thenReturn(profile);
+            when(timeProvider.today()).thenReturn(LocalDate.of(2026, 7, 1));
+
+            MyProfileResponse response = profileQueryService.getMyProfile(1L);
+
+            assertThat(response.ageGroup()).isEqualTo("20대");
+        }
+    }
+
+    @Nested
+    @DisplayName("프로필 조회")
+    class GetMyProfile {
+
+        @Test
+        @DisplayName("닉네임과 한줄소개를 반환한다")
+        void returnsNicknameAndBio() {
+            when(profileRepository.getByUserIdOrThrow(1L)).thenReturn(profile);
+            when(timeProvider.today()).thenReturn(LocalDate.of(2026, 7, 1));
+
+            MyProfileResponse response = profileQueryService.getMyProfile(1L);
+
+            assertThat(response.nickname()).isEqualTo("김해나");
+            assertThat(response.bio()).isEqualTo("맛집 찾는 여행 좋아해요");
+        }
+
+        @Test
+        @DisplayName("bio가 없으면 null을 반환한다")
+        void returnsNullBioWhenNotSet() {
+            ReflectionTestUtils.setField(profile, "bio", null);
+            when(profileRepository.getByUserIdOrThrow(1L)).thenReturn(profile);
+            when(timeProvider.today()).thenReturn(LocalDate.of(2026, 7, 1));
+
+            MyProfileResponse response = profileQueryService.getMyProfile(1L);
+
+            assertThat(response.bio()).isNull();
+        }
+    }
+}


### PR DESCRIPTION
## 🔎 작업 내용
  - `GET /api/v1/users/me/profile` 마이페이지 프로필 조회 엔드포인트 추가
  - `ProfileQueryService` 신규 생성 — `ProfileRepository`, `ProfileImageResolver`, `TimeProvider` 의존
  - `MyProfileResponse` record 신규 생성 — 닉네임, 나이대, 한줄소개, 프로필 이미지 정보 반환
  - `AgeGroupCalculator.toAgeGroup` 반환 타입 `Integer` → `String` 으로 변경 (`"20대"` 형식 통일)
  - `JourneyMemberInfo`, `ParticipantInfo`, `PostAuthorInfo` ageGroup 필드 타입 `Integer` → `String` 변경
  - `MyProfileResponse` 내 중복 `calculateAgeGroup` 제거, `AgeGroupCalculator` 재사용
  - `JourneyMemberInfo` 전체 필드 `@Schema` 추가 및 ageGroup `nullable = true` 명세 반영
  - `ParticipantInfo`, `PostAuthorInfo` ageGroup `nullable = true` 명세 반영
  - `Profile.getProfileImageType()` 커스텀 getter 추가 — `profileImageType` null 시 `DEFAULT` 폴백 처리
  - `ProfileQueryServiceTest` 작성 — 나이대 계산(생일 있음/없음/생일 전), 닉네임/bio 반환 총 5개 케이스
  
## ➕ 이슈 링크
* CLOSED #309 

## 🧑‍💻 예정 작업
  - 마이페이지 Phase 2: 여행선호설정 수정, 내가 작성한 여행글, 찜한 여행
  - 마이페이지 Phase 3: 여행가능날짜 도메인 신규 구현

## 📝 체크리스트
- [x] 브랜치 이름은 `feat/#이슈번호-개발내용` 형식으로 작성했는가?
- [x] 커밋 메시지는 `[#이슈번호] feat(scope): 커밋 내용` 형식으로 작성했는가?
- [x] PR 제목은 `feat(scope): PR 제목` 형식으로 작성했는가?
- [x] 작업 전 Issue를 작성했는가?
- [x] `dev` 브랜치로 병합을 요청했는가?
- [x] 불필요한 주석과 공백은 제거했는가?
- [x] 코드 리뷰어의 피드백을 반영했는가?
- [x] 테스트를 진행했는가?
- [x] 테스트 코드를 작성했는가?
