### PR TITLE
feat(survey): 마이페이지 여행선호설정 수정 API  

### DIFF
--- a/src/main/java/com/dduru/gildongmu/common/exception/ErrorCode.java
+++ b/src/main/java/com/dduru/gildongmu/common/exception/ErrorCode.java
@@ -46,6 +46,7 @@ public enum ErrorCode {
     SURVEY_RESULT_NOT_FOUND(HttpStatus.NOT_FOUND, "설문 결과를 찾을 수 없습니다."),
     AVATAR_PROFILE_NOT_FOUND(HttpStatus.NOT_FOUND, "아바타 프로필을 찾을 수 없습니다."),
     SURVEY_ALREADY_COMPLETED(HttpStatus.BAD_REQUEST, "설문조사가 이미 완료된 상태에서는 스킵할 수 없습니다."),
+    SURVEY_ALREADY_SUBMITTED(HttpStatus.CONFLICT, "이미 제출된 설문이 존재합니다."),
     SURVEY_REQUIRED(HttpStatus.FORBIDDEN, "설문 완료가 필요한 기능입니다."),
 
     // 프로필 (PROFILE)

--- a/src/main/java/com/dduru/gildongmu/journey/dto/response/JourneyMemberInfo.java
+++ b/src/main/java/com/dduru/gildongmu/journey/dto/response/JourneyMemberInfo.java
@@ -17,7 +17,7 @@ public record JourneyMemberInfo(
         ProfileImageInfo profileImage,
         boolean isHost,
         Gender gender,
-        Integer ageGroup,
+        String ageGroup,
         List<RoleLabelInfo> roles
 ) {
     public static JourneyMemberInfo from(JourneyMember member, ProfileImageResolver resolver, LocalDate today) {

--- a/src/main/java/com/dduru/gildongmu/journey/dto/response/JourneyMemberInfo.java
+++ b/src/main/java/com/dduru/gildongmu/journey/dto/response/JourneyMemberInfo.java
@@ -7,17 +7,25 @@ import com.dduru.gildongmu.profile.dto.response.ProfileImageInfo;
 import com.dduru.gildongmu.profile.utils.AgeGroupCalculator;
 import com.dduru.gildongmu.profile.utils.ProfileImageResolver;
 import com.dduru.gildongmu.user.domain.User;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDate;
 import java.util.List;
 
 public record JourneyMemberInfo(
+        @Schema(description = "여행 멤버 회원 ID", example = "33")
         Long userId,
+        @Schema(description = "닉네임", example = "여행메이트")
         String nickname,
+        @Schema(description = "프로필 이미지 정보")
         ProfileImageInfo profileImage,
+        @Schema(description = "호스트 여부", example = "false")
         boolean isHost,
+        @Schema(description = "성별", example = "F", allowableValues = {"M", "F"})
         Gender gender,
+        @Schema(description = "연령대. birthday 미설정 시 null", example = "20대", nullable = true)
         String ageGroup,
+        @Schema(description = "역할 목록")
         List<RoleLabelInfo> roles
 ) {
     public static JourneyMemberInfo from(JourneyMember member, ProfileImageResolver resolver, LocalDate today) {

--- a/src/main/java/com/dduru/gildongmu/post/dto/response/ParticipantInfo.java
+++ b/src/main/java/com/dduru/gildongmu/post/dto/response/ParticipantInfo.java
@@ -21,8 +21,8 @@ public record ParticipantInfo(
         boolean isHost,
         @Schema(description = "참여자 성별", example = "F", allowableValues = {"M", "F"})
         Gender gender,
-        @Schema(description = "참여자 연령대. 20은 20대를 의미합니다.", example = "20")
-        Integer ageGroup
+        @Schema(description = "참여자 연령대", example = "20대")
+        String ageGroup
 ) {
     public static ParticipantInfo from(User user, boolean isHost, ProfileImageResolver profileImageResolver, LocalDate today) {
         Profile profile = user.getProfile();

--- a/src/main/java/com/dduru/gildongmu/post/dto/response/ParticipantInfo.java
+++ b/src/main/java/com/dduru/gildongmu/post/dto/response/ParticipantInfo.java
@@ -21,7 +21,7 @@ public record ParticipantInfo(
         boolean isHost,
         @Schema(description = "참여자 성별", example = "F", allowableValues = {"M", "F"})
         Gender gender,
-        @Schema(description = "참여자 연령대", example = "20대")
+        @Schema(description = "참여자 연령대. birthday 미설정 시 null", example = "20대", nullable = true)
         String ageGroup
 ) {
     public static ParticipantInfo from(User user, boolean isHost, ProfileImageResolver profileImageResolver, LocalDate today) {

--- a/src/main/java/com/dduru/gildongmu/post/dto/response/PostAuthorInfo.java
+++ b/src/main/java/com/dduru/gildongmu/post/dto/response/PostAuthorInfo.java
@@ -19,7 +19,7 @@ public record PostAuthorInfo(
         ProfileImageInfo profileImage,
         @Schema(description = "작성자 성별", example = "F", allowableValues = {"M", "F"})
         Gender gender,
-        @Schema(description = "작성자 연령대", example = "20대")
+        @Schema(description = "작성자 연령대. birthday 미설정 시 null", example = "20대", nullable = true)
         String ageGroup,
         @Schema(description = "작성자가 슈퍼호스트인지 여부", example = "false")
         boolean isSuperHost

--- a/src/main/java/com/dduru/gildongmu/post/dto/response/PostAuthorInfo.java
+++ b/src/main/java/com/dduru/gildongmu/post/dto/response/PostAuthorInfo.java
@@ -19,8 +19,8 @@ public record PostAuthorInfo(
         ProfileImageInfo profileImage,
         @Schema(description = "작성자 성별", example = "F", allowableValues = {"M", "F"})
         Gender gender,
-        @Schema(description = "작성자 연령대. 20은 20대를 의미합니다.", example = "20")
-        Integer ageGroup,
+        @Schema(description = "작성자 연령대", example = "20대")
+        String ageGroup,
         @Schema(description = "작성자가 슈퍼호스트인지 여부", example = "false")
         boolean isSuperHost
 ) {

--- a/src/main/java/com/dduru/gildongmu/profile/controller/ProfileApiDocs.java
+++ b/src/main/java/com/dduru/gildongmu/profile/controller/ProfileApiDocs.java
@@ -6,6 +6,7 @@ import com.dduru.gildongmu.common.exception.ErrorCode;
 import com.dduru.gildongmu.profile.dto.request.NicknameUpdateRequest;
 import com.dduru.gildongmu.profile.dto.request.ProfileSetupRequest;
 import com.dduru.gildongmu.profile.dto.request.ProfileUpdateRequest;
+import com.dduru.gildongmu.profile.dto.response.MyProfileResponse;
 import com.dduru.gildongmu.profile.dto.response.NicknameRandomResponse;
 import com.dduru.gildongmu.profile.dto.response.NicknameValidateResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -20,6 +21,16 @@ import org.springframework.http.ResponseEntity;
 @Tag(name = "Profiles", description = "사용자 프로필 관리 API")
 @SecurityRequirement(name = "JWT")
 public interface ProfileApiDocs {
+
+    @Operation(summary = "마이페이지 프로필 조회", description = "내 닉네임, 나이대, 한줄소개, 프로필 이미지 정보를 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "프로필 조회 성공")
+    @ApiErrorResponses({
+            ErrorCode.UNAUTHORIZED,
+            ErrorCode.PROFILE_NOT_FOUND
+    })
+    ResponseEntity<ApiResult<MyProfileResponse>> getMyProfile(
+            @Parameter(hidden = true) Long userId
+    );
 
     @Operation(summary = "닉네임 수정", description = "사용자의 닉네임을 수정합니다.")
     @ApiResponse(responseCode = "204", description = "닉네임 수정 성공", content = @Content())

--- a/src/main/java/com/dduru/gildongmu/profile/controller/ProfileController.java
+++ b/src/main/java/com/dduru/gildongmu/profile/controller/ProfileController.java
@@ -5,11 +5,13 @@ import com.dduru.gildongmu.common.dto.ApiResult;
 import com.dduru.gildongmu.profile.dto.request.NicknameUpdateRequest;
 import com.dduru.gildongmu.profile.dto.request.ProfileSetupRequest;
 import com.dduru.gildongmu.profile.dto.request.ProfileUpdateRequest;
+import com.dduru.gildongmu.profile.dto.response.MyProfileResponse;
 import com.dduru.gildongmu.profile.dto.response.NicknameRandomResponse;
 import com.dduru.gildongmu.profile.dto.response.NicknameValidateResponse;
 import com.dduru.gildongmu.profile.service.NicknameService;
 import com.dduru.gildongmu.profile.service.ProfileManagementService;
 import com.dduru.gildongmu.profile.service.ProfileOnboardingService;
+import com.dduru.gildongmu.profile.service.ProfileQueryService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -32,6 +34,14 @@ public class ProfileController implements ProfileApiDocs {
     private final NicknameService nicknameService;
     private final ProfileOnboardingService profileOnboardingService;
     private final ProfileManagementService profileManagementService;
+    private final ProfileQueryService profileQueryService;
+
+    @Override
+    @GetMapping("/users/me/profile")
+    public ResponseEntity<ApiResult<MyProfileResponse>> getMyProfile(@CurrentUser Long userId) {
+        MyProfileResponse response = profileQueryService.getMyProfile(userId);
+        return ResponseEntity.ok(ApiResult.ok(response));
+    }
 
     @Override
     @PutMapping("/users/nickname")

--- a/src/main/java/com/dduru/gildongmu/profile/domain/Profile.java
+++ b/src/main/java/com/dduru/gildongmu/profile/domain/Profile.java
@@ -65,6 +65,10 @@ public class Profile extends BaseTimeEntity {
     @Column(name = "bio", length = 60)
     private String bio;
 
+    public ProfileImageType getProfileImageType() {
+        return profileImageType != null ? profileImageType : ProfileImageType.DEFAULT;
+    }
+
     public Profile(User user) {
         this.user = user;
     }

--- a/src/main/java/com/dduru/gildongmu/profile/dto/response/MyProfileResponse.java
+++ b/src/main/java/com/dduru/gildongmu/profile/dto/response/MyProfileResponse.java
@@ -1,0 +1,32 @@
+package com.dduru.gildongmu.profile.dto.response;
+
+import com.dduru.gildongmu.profile.domain.Profile;
+import com.dduru.gildongmu.profile.utils.AgeGroupCalculator;
+import com.dduru.gildongmu.profile.utils.ProfileImageResolver;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDate;
+
+@Schema(description = "마이페이지 프로필 조회 응답")
+public record MyProfileResponse(
+        @Schema(description = "닉네임", example = "김해나")
+        String nickname,
+
+        @Schema(description = "나이대. birthday 미설정 시 null", example = "20대", nullable = true)
+        String ageGroup,
+
+        @Schema(description = "한줄소개. 미설정 시 null", example = "맛집 찾는 여행 좋아해요", nullable = true)
+        String bio,
+
+        @Schema(description = "프로필 이미지 정보")
+        ProfileImageInfo profileImage
+) {
+    public static MyProfileResponse of(Profile profile, ProfileImageResolver profileImageResolver, LocalDate today) {
+        return new MyProfileResponse(
+                profile.getNickname(),
+                AgeGroupCalculator.toAgeGroup(profile.getBirthday(), today),
+                profile.getBio(),
+                ProfileImageInfo.from(profile, profileImageResolver)
+        );
+    }
+}

--- a/src/main/java/com/dduru/gildongmu/profile/service/ProfileQueryService.java
+++ b/src/main/java/com/dduru/gildongmu/profile/service/ProfileQueryService.java
@@ -1,0 +1,25 @@
+package com.dduru.gildongmu.profile.service;
+
+import com.dduru.gildongmu.common.time.TimeProvider;
+import com.dduru.gildongmu.profile.domain.Profile;
+import com.dduru.gildongmu.profile.dto.response.MyProfileResponse;
+import com.dduru.gildongmu.profile.repository.ProfileRepository;
+import com.dduru.gildongmu.profile.utils.ProfileImageResolver;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+@Transactional(readOnly = true)
+public class ProfileQueryService {
+
+    private final ProfileRepository profileRepository;
+    private final ProfileImageResolver profileImageResolver;
+    private final TimeProvider timeProvider;
+
+    public MyProfileResponse getMyProfile(Long userId) {
+        Profile profile = profileRepository.getByUserIdOrThrow(userId);
+        return MyProfileResponse.of(profile, profileImageResolver, timeProvider.today());
+    }
+}

--- a/src/main/java/com/dduru/gildongmu/profile/utils/AgeGroupCalculator.java
+++ b/src/main/java/com/dduru/gildongmu/profile/utils/AgeGroupCalculator.java
@@ -7,9 +7,9 @@ public class AgeGroupCalculator {
 
     private AgeGroupCalculator() {}
 
-    public static Integer toAgeGroup(LocalDate birthday, LocalDate today) {
+    public static String toAgeGroup(LocalDate birthday, LocalDate today) {
         if (birthday == null) return null;
         int age = Math.max(0, Period.between(birthday, today).getYears());
-        return (age / 10) * 10;
+        return (age / 10) * 10 + "대";
     }
 }

--- a/src/main/java/com/dduru/gildongmu/survey/controller/SurveyApiDocs.java
+++ b/src/main/java/com/dduru/gildongmu/survey/controller/SurveyApiDocs.java
@@ -32,7 +32,7 @@ public interface SurveyApiDocs {
             ErrorCode.USER_ONBOARDING_NOT_FOUND,
             ErrorCode.AVATAR_PROFILE_NOT_FOUND
     })
-    ResponseEntity<ApiResult<SurveyResponse>> submitSurvey(@Parameter(hidden = true) Long userId, @Valid SurveyRequest request);
+    ResponseEntity<ApiResult<SurveyResponse>> createSurvey(@Parameter(hidden = true) Long userId, @Valid SurveyRequest request);
 
     @Operation(
             summary = "내 설문 결과 조회",
@@ -52,6 +52,19 @@ public interface SurveyApiDocs {
             ErrorCode.INVALID_INPUT_VALUE
     })
     ResponseEntity<ApiResult<SurveyQuestionListResponse>> getSurveyQuestions();
+
+    @Operation(
+            summary = "여행선호설정 수정",
+            description = "마이페이지에서 기존 설문 응답을 수정합니다. 온보딩 완료 처리 및 보상 지급은 실행되지 않습니다.",
+            security = @SecurityRequirement(name = "JWT")
+    )
+    @ApiResponse(responseCode = "200", description = "수정 성공")
+    @ApiErrorResponses({
+            ErrorCode.INVALID_INPUT_VALUE,
+            ErrorCode.UNAUTHORIZED,
+            ErrorCode.SURVEY_RESULT_NOT_FOUND
+    })
+    ResponseEntity<ApiResult<SurveyResponse>> updateSurvey(@Parameter(hidden = true) Long userId, @Valid SurveyRequest request);
 
     @Operation(
             summary = "설문조사 스킵",

--- a/src/main/java/com/dduru/gildongmu/survey/controller/SurveyController.java
+++ b/src/main/java/com/dduru/gildongmu/survey/controller/SurveyController.java
@@ -23,11 +23,11 @@ public class SurveyController implements SurveyApiDocs {
 
     @Override
     @PostMapping
-    public ResponseEntity<ApiResult<SurveyResponse>> submitSurvey(
+    public ResponseEntity<ApiResult<SurveyResponse>> createSurvey(
             @CurrentUser Long userId,
             @Valid @RequestBody SurveyRequest request
     ) {
-        SurveyResponse response = surveyService.submitSurvey(userId, request);
+        SurveyResponse response = surveyService.create(userId, request);
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResult.created(response));
     }
 
@@ -42,6 +42,16 @@ public class SurveyController implements SurveyApiDocs {
     @GetMapping("/questions")
     public ResponseEntity<ApiResult<SurveyQuestionListResponse>> getSurveyQuestions() {
         SurveyQuestionListResponse response = surveyQuestionService.getSurveyQuestions();
+        return ResponseEntity.ok(ApiResult.ok(response));
+    }
+
+    @Override
+    @PatchMapping("/me")
+    public ResponseEntity<ApiResult<SurveyResponse>> updateSurvey(
+            @CurrentUser Long userId,
+            @Valid @RequestBody SurveyRequest request
+    ) {
+        SurveyResponse response = surveyService.update(userId, request);
         return ResponseEntity.ok(ApiResult.ok(response));
     }
 

--- a/src/main/java/com/dduru/gildongmu/survey/exception/SurveyAlreadySubmittedException.java
+++ b/src/main/java/com/dduru/gildongmu/survey/exception/SurveyAlreadySubmittedException.java
@@ -1,0 +1,10 @@
+package com.dduru.gildongmu.survey.exception;
+
+import com.dduru.gildongmu.common.exception.BusinessException;
+import com.dduru.gildongmu.common.exception.ErrorCode;
+
+public class SurveyAlreadySubmittedException extends BusinessException {
+    public SurveyAlreadySubmittedException() {
+        super(ErrorCode.SURVEY_ALREADY_SUBMITTED);
+    }
+}

--- a/src/main/java/com/dduru/gildongmu/survey/repository/SurveyRepository.java
+++ b/src/main/java/com/dduru/gildongmu/survey/repository/SurveyRepository.java
@@ -1,6 +1,7 @@
 package com.dduru.gildongmu.survey.repository;
 
 import com.dduru.gildongmu.survey.domain.Survey;
+import com.dduru.gildongmu.survey.exception.SurveyResultNotFoundException;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -8,5 +9,10 @@ import java.util.Optional;
 
 @Repository
 public interface SurveyRepository extends JpaRepository<Survey, Long> {
-    Optional<Survey> findByUser_Id(Long userId);
+    Optional<Survey> findByUserId(Long userId);
+
+    default Survey getByUserIdOrThrow(Long userId) {
+        return findByUserId(userId)
+                .orElseThrow(SurveyResultNotFoundException::new);
+    }
 }

--- a/src/main/java/com/dduru/gildongmu/survey/repository/SurveyRepository.java
+++ b/src/main/java/com/dduru/gildongmu/survey/repository/SurveyRepository.java
@@ -9,6 +9,8 @@ import java.util.Optional;
 
 @Repository
 public interface SurveyRepository extends JpaRepository<Survey, Long> {
+    boolean existsByUserId(Long userId);
+
     Optional<Survey> findByUserId(Long userId);
 
     default Survey getByUserIdOrThrow(Long userId) {

--- a/src/main/java/com/dduru/gildongmu/survey/repository/TravelTendencyRepository.java
+++ b/src/main/java/com/dduru/gildongmu/survey/repository/TravelTendencyRepository.java
@@ -8,5 +8,5 @@ import java.util.Optional;
 
 @Repository
 public interface TravelTendencyRepository extends JpaRepository<TravelTendency, Long> {
-    Optional<TravelTendency> findByUser_Id(Long userId);
+    Optional<TravelTendency> findByUserId(Long userId);
 }

--- a/src/main/java/com/dduru/gildongmu/survey/service/SurveyService.java
+++ b/src/main/java/com/dduru/gildongmu/survey/service/SurveyService.java
@@ -11,6 +11,7 @@ import com.dduru.gildongmu.survey.dto.request.SurveyRequest;
 import com.dduru.gildongmu.survey.dto.response.AvatarProfileResponse;
 import com.dduru.gildongmu.survey.dto.response.SurveyResponse;
 import com.dduru.gildongmu.survey.dto.response.TendencyScoreResponse;
+import com.dduru.gildongmu.survey.exception.SurveyAlreadySubmittedException;
 import com.dduru.gildongmu.survey.exception.SurveyResultNotFoundException;
 import com.dduru.gildongmu.survey.repository.AvatarProfileRepository;
 import com.dduru.gildongmu.survey.repository.SurveyRepository;
@@ -45,6 +46,9 @@ public class SurveyService {
     private final SuperHostService superHostService;
 
     public SurveyResponse create(Long userId, SurveyRequest request) {
+        if (surveyRepository.existsByUserId(userId)) {
+            throw new SurveyAlreadySubmittedException();
+        }
         User user = userRepository.getByIdOrThrow(userId);
 
         ParsedSurveyData parsed = surveyConverter.parseRequest(request);

--- a/src/main/java/com/dduru/gildongmu/survey/service/SurveyService.java
+++ b/src/main/java/com/dduru/gildongmu/survey/service/SurveyService.java
@@ -44,17 +44,13 @@ public class SurveyService {
     private final OnboardingService onboardingService;
     private final SuperHostService superHostService;
 
-    public SurveyResponse submitSurvey(Long userId, SurveyRequest request) {
+    public SurveyResponse create(Long userId, SurveyRequest request) {
         User user = userRepository.getByIdOrThrow(userId);
 
-        Survey survey = saveOrUpdateSurvey(user, request);
+        ParsedSurveyData parsed = surveyConverter.parseRequest(request);
+        Survey survey = createSurvey(user, parsed);
         TendencyScoreResponse scores = tendencyCalculator.calculate(survey);
-        AvatarType avatarType = avatarMatcher.match(
-                scores.rhythmScore(),
-                scores.energyScore(),
-                scores.consumptionScore(),
-                scores.decisionScore()
-        );
+        AvatarType avatarType = matchAvatarType(scores);
 
         saveOrUpdateTravelTendency(user, scores, avatarType);
         updateProfileAvatar(userId, avatarType);
@@ -62,7 +58,6 @@ public class SurveyService {
         superHostService.grantOnboardingRewardTicket(userId);
 
         AvatarProfileResponse avatarProfile = avatarProfileService.getProfile(avatarType);
-
         log.info("설문조사 제출 완료 - userId: {}, avatarType: {}", userId, avatarType);
         return SurveyResponse.of(scores, avatarType, survey.getRecordStyle().getStyleType(), avatarProfile);
     }
@@ -74,19 +69,27 @@ public class SurveyService {
 
     @Transactional(readOnly = true)
     public SurveyResponse getMySurveyResult(Long userId) {
-        TravelTendency travelTendency = travelTendencyRepository.findByUser_Id(userId)
+        TravelTendency travelTendency = travelTendencyRepository.findByUserId(userId)
                 .orElseThrow(SurveyResultNotFoundException::new);
-        Survey survey = surveyRepository.findByUser_Id(userId)
-                .orElseThrow(SurveyResultNotFoundException::new);
+        Survey survey = surveyRepository.getByUserIdOrThrow(userId);
         return SurveyResponse.from(travelTendency, survey.getRecordStyle().getStyleType(), avatarProfileService);
     }
 
-    private Survey saveOrUpdateSurvey(User user, SurveyRequest request) {
-        ParsedSurveyData parsed = surveyConverter.parseRequest(request);
+    public SurveyResponse update(Long userId, SurveyRequest request) {
+        User user = userRepository.getByIdOrThrow(userId);
+        Survey survey = surveyRepository.getByUserIdOrThrow(userId);
 
-        return surveyRepository.findByUser_Id(user.getId())
-                .map(existing -> updateSurvey(existing, parsed))
-                .orElseGet(() -> createSurvey(user, parsed));
+        ParsedSurveyData parsed = surveyConverter.parseRequest(request);
+        updateSurvey(survey, parsed);
+
+        TendencyScoreResponse scores = tendencyCalculator.calculate(survey);
+        AvatarType avatarType = matchAvatarType(scores);
+
+        saveOrUpdateTravelTendency(user, scores, avatarType);
+        updateProfileAvatar(userId, avatarType);
+
+        AvatarProfileResponse avatarProfile = avatarProfileService.getProfile(avatarType);
+        return SurveyResponse.of(scores, avatarType, survey.getRecordStyle().getStyleType(), avatarProfile);
     }
 
     private Survey createSurvey(User user, ParsedSurveyData parsed) {
@@ -94,7 +97,7 @@ public class SurveyService {
         return surveyRepository.save(survey);
     }
 
-    private Survey updateSurvey(Survey survey, ParsedSurveyData parsed) {
+    private void updateSurvey(Survey survey, ParsedSurveyData parsed) {
         survey.updateSurvey(
                 parsed.rhythmQ1(),
                 parsed.rhythmQ2(),
@@ -111,7 +114,6 @@ public class SurveyService {
                 parsed.recordStyle(),
                 parsed.activityTags()
         );
-        return survey;
     }
 
     private void saveOrUpdateTravelTendency(User user, TendencyScoreResponse scores, AvatarType avatarType) {
@@ -120,7 +122,7 @@ public class SurveyService {
         BigDecimal consumption = toBigDecimal(scores.consumptionScore());
         BigDecimal decision = toBigDecimal(scores.decisionScore());
 
-        travelTendencyRepository.findByUser_Id(user.getId())
+        travelTendencyRepository.findByUserId(user.getId())
                 .ifPresentOrElse(
                         existing -> existing.update(rhythm, energy, consumption, decision, avatarType),
                         () -> travelTendencyRepository.save(
@@ -135,6 +137,15 @@ public class SurveyService {
                         avatarProfile -> profileManagementService.updateAvatar(userId, avatarProfile.getId()),
                         () -> log.warn("아바타 프로필을 찾을 수 없어 Profile에 저장하지 않음 - userId: {}, avatarType: {}", userId, avatarType)
                 );
+    }
+
+    private AvatarType matchAvatarType(TendencyScoreResponse scores) {
+        return avatarMatcher.match(
+                scores.rhythmScore(),
+                scores.energyScore(),
+                scores.consumptionScore(),
+                scores.decisionScore()
+        );
     }
 
     private BigDecimal toBigDecimal(double value) {

--- a/src/test/java/com/dduru/gildongmu/profile/service/ProfileQueryServiceTest.java
+++ b/src/test/java/com/dduru/gildongmu/profile/service/ProfileQueryServiceTest.java
@@ -1,0 +1,120 @@
+package com.dduru.gildongmu.profile.service;
+
+import com.dduru.gildongmu.common.time.TimeProvider;
+import com.dduru.gildongmu.profile.domain.Profile;
+import com.dduru.gildongmu.profile.dto.response.MyProfileResponse;
+import com.dduru.gildongmu.profile.repository.ProfileRepository;
+import com.dduru.gildongmu.profile.utils.ProfileImageResolver;
+import com.dduru.gildongmu.user.domain.User;
+import com.dduru.gildongmu.user.domain.enums.OauthType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ProfileQueryService 테스트")
+class ProfileQueryServiceTest {
+
+    @Mock private ProfileRepository profileRepository;
+    @Mock private ProfileImageResolver profileImageResolver;
+    @Mock private TimeProvider timeProvider;
+
+    @InjectMocks
+    private ProfileQueryService profileQueryService;
+
+    private User user;
+    private Profile profile;
+
+    @BeforeEach
+    void setUp() {
+        user = User.builder()
+                .email("test@example.com")
+                .name("테스트")
+                .oauthId("12345")
+                .oauthType(OauthType.KAKAO)
+                .build();
+        profile = new Profile(user);
+        ReflectionTestUtils.setField(profile, "nickname", "김해나");
+        ReflectionTestUtils.setField(profile, "bio", "맛집 찾는 여행 좋아해요");
+    }
+
+    @Nested
+    @DisplayName("나이대 계산")
+    class AgeGroup {
+
+        @Test
+        @DisplayName("birthday가 있으면 나이대를 계산해 반환한다")
+        void returnsAgeGroupWhenBirthdayExists() {
+            ReflectionTestUtils.setField(profile, "birthday", LocalDate.of(1998, 5, 10));
+            when(profileRepository.getByUserIdOrThrow(1L)).thenReturn(profile);
+            when(timeProvider.today()).thenReturn(LocalDate.of(2026, 7, 1));
+
+            MyProfileResponse response = profileQueryService.getMyProfile(1L);
+
+            assertThat(response.ageGroup()).isEqualTo("20대");
+        }
+
+        @Test
+        @DisplayName("birthday가 없으면 ageGroup은 null이다")
+        void returnsNullAgeGroupWhenNoBirthday() {
+            when(profileRepository.getByUserIdOrThrow(1L)).thenReturn(profile);
+            when(timeProvider.today()).thenReturn(LocalDate.of(2026, 7, 1));
+
+            MyProfileResponse response = profileQueryService.getMyProfile(1L);
+
+            assertThat(response.ageGroup()).isNull();
+        }
+
+        @Test
+        @DisplayName("생일이 지나지 않은 경우에도 올바른 나이대를 반환한다")
+        void calculatesCorrectlyBeforeBirthday() {
+            ReflectionTestUtils.setField(profile, "birthday", LocalDate.of(1997, 12, 31));
+            when(profileRepository.getByUserIdOrThrow(1L)).thenReturn(profile);
+            when(timeProvider.today()).thenReturn(LocalDate.of(2026, 7, 1));
+
+            MyProfileResponse response = profileQueryService.getMyProfile(1L);
+
+            assertThat(response.ageGroup()).isEqualTo("20대");
+        }
+    }
+
+    @Nested
+    @DisplayName("프로필 조회")
+    class GetMyProfile {
+
+        @Test
+        @DisplayName("닉네임과 한줄소개를 반환한다")
+        void returnsNicknameAndBio() {
+            when(profileRepository.getByUserIdOrThrow(1L)).thenReturn(profile);
+            when(timeProvider.today()).thenReturn(LocalDate.of(2026, 7, 1));
+
+            MyProfileResponse response = profileQueryService.getMyProfile(1L);
+
+            assertThat(response.nickname()).isEqualTo("김해나");
+            assertThat(response.bio()).isEqualTo("맛집 찾는 여행 좋아해요");
+        }
+
+        @Test
+        @DisplayName("bio가 없으면 null을 반환한다")
+        void returnsNullBioWhenNotSet() {
+            ReflectionTestUtils.setField(profile, "bio", null);
+            when(profileRepository.getByUserIdOrThrow(1L)).thenReturn(profile);
+            when(timeProvider.today()).thenReturn(LocalDate.of(2026, 7, 1));
+
+            MyProfileResponse response = profileQueryService.getMyProfile(1L);
+
+            assertThat(response.bio()).isNull();
+        }
+    }
+}

--- a/src/test/java/com/dduru/gildongmu/survey/service/SurveyServiceTest.java
+++ b/src/test/java/com/dduru/gildongmu/survey/service/SurveyServiceTest.java
@@ -133,7 +133,6 @@ class SurveyServiceTest {
         );
 
         when(userRepository.getByIdOrThrow(1L)).thenReturn(testUser);
-        when(surveyRepository.findByUser_Id(1L)).thenReturn(Optional.empty());
         when(surveyConverter.parseRequest(testRequest)).thenReturn(parsedData);
         when(surveyConverter.toEntity(testUser, parsedData)).thenReturn(testSurvey);
         when(surveyRepository.save(any(Survey.class))).thenReturn(testSurvey);
@@ -168,10 +167,10 @@ class SurveyServiceTest {
         ReflectionTestUtils.setField(avatarProfile, "id", 1L);
         when(avatarProfileRepository.findByAvatarType(AvatarType.TTUR_DASOM)).thenReturn(Optional.of(avatarProfile));
 
-        when(travelTendencyRepository.findByUser_Id(1L)).thenReturn(Optional.empty());
+        when(travelTendencyRepository.findByUserId(1L)).thenReturn(Optional.empty());
         when(travelTendencyRepository.save(any(TravelTendency.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
-        SurveyResponse response = surveyService.submitSurvey(1L, testRequest);
+        SurveyResponse response = surveyService.create(1L, testRequest);
 
         assertThat(response.tendencyScores().rhythmScore()).isEqualTo(5.5);
         assertThat(response.tendencyScores().energyScore()).isEqualTo(4.5);
@@ -194,102 +193,11 @@ class SurveyServiceTest {
     }
 
     @Test
-    @DisplayName("기존_설문_업데이트_성공")
-    void 기존_설문_업데이트_성공() {
-        Survey existingSurvey = Survey.createSurvey(
-                testUser,
-                RhythmQuestion1.IMPULSE_SIDE_TRIP,
-                RhythmQuestion2.PACK_LAST_MINUTE,
-                RhythmQuestion3.ROUGH_LIST_ONLY,
-                ConsumptionQuestion1.FLEX_OK,
-                ConsumptionQuestion2.SAVE_TIME_TAXI,
-                ConsumptionQuestion3.INVEST_EXPERIENCE,
-                EnergyQuestion1.PACKED_DAY,
-                EnergyQuestion2.BREAKFAST_SPRINT,
-                EnergyQuestion3.FILL_WITH_SPOTS,
-                DecisionQuestion1.LEAD_OR_ORGANIZE,
-                DecisionQuestion2.PROPOSE_FIRST,
-                DecisionQuestion3.DRIVE_CONCLUSION,
-                RecordStyleQuestion.SHOOT_NOW,
-                List.of(ActivityTag.FOOD, ActivityTag.SHOPPING, ActivityTag.ACTIVITY)
-        );
-
-        ParsedSurveyData parsedData = new ParsedSurveyData(
-                RhythmQuestion1.PLANNED_ROUTE,
-                RhythmQuestion2.PACK_EARLY,
-                RhythmQuestion3.ROUTE_TIME_SET,
-                ConsumptionQuestion1.ADJUST_BUDGET,
-                ConsumptionQuestion2.VALUE_TRANSPORT,
-                ConsumptionQuestion3.VALUE_CHOICE,
-                EnergyQuestion1.RELAXED_DAY,
-                EnergyQuestion2.BRUNCH_INSTEAD,
-                EnergyQuestion3.DO_NOTHING_OK,
-                DecisionQuestion1.DELEGATE_ROLE,
-                DecisionQuestion2.FOLLOW_OTHERS,
-                DecisionQuestion3.WAIT_AND_SEE,
-                RecordStyleQuestion.EYES_FIRST,
-                List.of(ActivityTag.SIGHTSEEING, ActivityTag.EXHIBITION, ActivityTag.NATURE)
-        );
-
-        when(userRepository.getByIdOrThrow(1L)).thenReturn(testUser);
-        when(surveyRepository.findByUser_Id(1L)).thenReturn(Optional.of(existingSurvey));
-        when(surveyConverter.parseRequest(testRequest)).thenReturn(parsedData);
-
-        TendencyScoreResponse scores =
-                new TendencyScoreResponse(6.0, 5.0, 7.5, 8.0);
-        when(tendencyCalculator.calculate(existingSurvey)).thenReturn(scores);
-        when(avatarMatcher.match(scores.rhythmScore(), scores.energyScore(), scores.consumptionScore(), scores.decisionScore()))
-                .thenReturn(AvatarType.TTUR_BANJJAK);
-
-        AvatarProfileResponse profile = new AvatarProfileResponse(
-                "뚜르 파도",
-                "설명2",
-                List.of("태그1", "태그2", "태그3"),
-                "성격2",
-                "강점2",
-                "팁2",
-                "https://example.com/avatar-pado.png"
-        );
-        when(avatarProfileService.getProfile(AvatarType.TTUR_BANJJAK)).thenReturn(profile);
-
-        AvatarProfile avatarProfile = AvatarProfile.builder()
-                .avatarType(AvatarType.TTUR_BANJJAK)
-                .displayName("뚜르 파도")
-                .speechBubbleText("설명2")
-                .descriptionLine1("성격2")
-                .descriptionLine2("강점2")
-                .descriptionLine3("팁2")
-                .imageUrl("https://example.com/avatar-pado.png")
-                .tags("[]")
-                .build();
-        ReflectionTestUtils.setField(avatarProfile, "id", 2L);
-        when(avatarProfileRepository.findByAvatarType(AvatarType.TTUR_BANJJAK)).thenReturn(Optional.of(avatarProfile));
-
-        TravelTendency existingTendency = TravelTendency.create(
-                testUser,
-                BigDecimal.valueOf(5.0),
-                BigDecimal.valueOf(4.0),
-                BigDecimal.valueOf(6.0),
-                BigDecimal.valueOf(7.0),
-                AvatarType.TTUR_DASOM
-        );
-        when(travelTendencyRepository.findByUser_Id(1L)).thenReturn(Optional.of(existingTendency));
-
-        SurveyResponse response = surveyService.submitSurvey(1L, testRequest);
-
-        assertThat(response.avatarType()).isEqualTo(AvatarType.TTUR_BANJJAK);
-        assertThat(response.recordStyleType()).isEqualTo(RecordStyleType.A);
-        assertThat(response.avatarLabel()).isEqualTo("뚜르 파도-A");
-        verify(surveyRepository, never()).save(any(Survey.class));
-        verify(superHostService).grantOnboardingRewardTicket(1L);
-    }
-
-    @Test
     @DisplayName("존재하지_않는_사용자_예외발생")
     void 존재하지_않는_사용자_예외발생() {
         when(userRepository.getByIdOrThrow(999L)).thenThrow(new UserNotFoundException());
 
-        assertThatThrownBy(() -> surveyService.submitSurvey(999L, testRequest))
+        assertThatThrownBy(() -> surveyService.create(999L, testRequest))
                 .isInstanceOf(UserNotFoundException.class);
 
         verify(surveyRepository, never()).save(any());
@@ -308,8 +216,8 @@ class SurveyServiceTest {
                 AvatarType.TTUR_DASOM
         );
 
-        when(travelTendencyRepository.findByUser_Id(1L)).thenReturn(Optional.of(travelTendency));
-        when(surveyRepository.findByUser_Id(1L)).thenReturn(Optional.of(testSurvey));
+        when(travelTendencyRepository.findByUserId(1L)).thenReturn(Optional.of(travelTendency));
+        when(surveyRepository.getByUserIdOrThrow(1L)).thenReturn(testSurvey);
 
         AvatarProfileResponse profile = new AvatarProfileResponse(
                 "뚜르 스윗",
@@ -338,9 +246,81 @@ class SurveyServiceTest {
     @Test
     @DisplayName("설문_결과_없을때_예외발생")
     void 설문_결과_없을때_예외발생() {
-        when(travelTendencyRepository.findByUser_Id(1L)).thenReturn(Optional.empty());
+        when(travelTendencyRepository.findByUserId(1L)).thenReturn(Optional.empty());
 
         assertThatThrownBy(() -> surveyService.getMySurveyResult(1L))
                 .isInstanceOf(SurveyResultNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("마이페이지_여행선호설정_수정_성공_온보딩_보상_미호출")
+    void 마이페이지_여행선호설정_수정_성공_온보딩_보상_미호출() {
+        ParsedSurveyData parsedData = new ParsedSurveyData(
+                RhythmQuestion1.PLANNED_ROUTE,
+                RhythmQuestion2.PACK_EARLY,
+                RhythmQuestion3.ROUTE_TIME_SET,
+                ConsumptionQuestion1.ADJUST_BUDGET,
+                ConsumptionQuestion2.VALUE_TRANSPORT,
+                ConsumptionQuestion3.VALUE_CHOICE,
+                EnergyQuestion1.RELAXED_DAY,
+                EnergyQuestion2.BRUNCH_INSTEAD,
+                EnergyQuestion3.DO_NOTHING_OK,
+                DecisionQuestion1.DELEGATE_ROLE,
+                DecisionQuestion2.FOLLOW_OTHERS,
+                DecisionQuestion3.WAIT_AND_SEE,
+                RecordStyleQuestion.EYES_FIRST,
+                List.of(ActivityTag.SIGHTSEEING)
+        );
+
+        when(userRepository.getByIdOrThrow(1L)).thenReturn(testUser);
+        when(surveyRepository.getByUserIdOrThrow(1L)).thenReturn(testSurvey);
+        when(surveyConverter.parseRequest(testRequest)).thenReturn(parsedData);
+
+        TendencyScoreResponse scores = new TendencyScoreResponse(5.5, 4.5, 6.0, 7.0);
+        when(tendencyCalculator.calculate(testSurvey)).thenReturn(scores);
+        when(avatarMatcher.match(scores.rhythmScore(), scores.energyScore(), scores.consumptionScore(), scores.decisionScore()))
+                .thenReturn(AvatarType.TTUR_DASOM);
+
+        AvatarProfileResponse profile = new AvatarProfileResponse(
+                "뚜르 스윗", "말풍선", List.of("태그1", "태그2", "태그3"), "성격", "강점", "팁",
+                "https://example.com/avatar-sweet.png"
+        );
+        when(avatarProfileService.getProfile(AvatarType.TTUR_DASOM)).thenReturn(profile);
+
+        AvatarProfile avatarProfile = AvatarProfile.builder()
+                .avatarType(AvatarType.TTUR_DASOM)
+                .displayName("뚜르 스윗")
+                .speechBubbleText("말풍선")
+                .descriptionLine1("성격")
+                .descriptionLine2("강점")
+                .descriptionLine3("팁")
+                .imageUrl("https://example.com/avatar-sweet.png")
+                .tags("[]")
+                .build();
+        ReflectionTestUtils.setField(avatarProfile, "id", 1L);
+        when(avatarProfileRepository.findByAvatarType(AvatarType.TTUR_DASOM)).thenReturn(Optional.of(avatarProfile));
+
+        when(travelTendencyRepository.findByUserId(1L)).thenReturn(Optional.empty());
+        when(travelTendencyRepository.save(any(TravelTendency.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        SurveyResponse response = surveyService.update(1L, testRequest);
+
+        assertThat(response.avatarType()).isEqualTo(AvatarType.TTUR_DASOM);
+        verify(onboardingService, never()).completeSurvey(any());
+        verify(superHostService, never()).grantOnboardingRewardTicket(any());
+    }
+
+    @Test
+    @DisplayName("마이페이지_여행선호설정_수정_설문없으면_예외발생")
+    void 마이페이지_여행선호설정_수정_설문없으면_예외발생() {
+        when(userRepository.getByIdOrThrow(1L)).thenReturn(testUser);
+        when(surveyRepository.getByUserIdOrThrow(1L)).thenThrow(SurveyResultNotFoundException.class);
+
+        assertThatThrownBy(() -> surveyService.update(1L, testRequest))
+                .isInstanceOf(SurveyResultNotFoundException.class);
+
+        verify(tendencyCalculator, never()).calculate(any());
+        verify(onboardingService, never()).completeSurvey(any());
+        verify(superHostService, never()).grantOnboardingRewardTicket(any());
     }
 }

--- a/src/test/java/com/dduru/gildongmu/survey/service/SurveyServiceTest.java
+++ b/src/test/java/com/dduru/gildongmu/survey/service/SurveyServiceTest.java
@@ -13,6 +13,7 @@ import com.dduru.gildongmu.survey.dto.response.AvatarProfileResponse;
 import com.dduru.gildongmu.survey.dto.request.SurveyRequest;
 import com.dduru.gildongmu.survey.dto.response.SurveyResponse;
 import com.dduru.gildongmu.survey.dto.response.TendencyScoreResponse;
+import com.dduru.gildongmu.survey.exception.SurveyAlreadySubmittedException;
 import com.dduru.gildongmu.survey.exception.SurveyResultNotFoundException;
 import com.dduru.gildongmu.survey.repository.AvatarProfileRepository;
 import com.dduru.gildongmu.survey.repository.SurveyRepository;
@@ -132,6 +133,7 @@ class SurveyServiceTest {
                 List.of(ActivityTag.SIGHTSEEING, ActivityTag.EXHIBITION, ActivityTag.NATURE)
         );
 
+        when(surveyRepository.existsByUserId(1L)).thenReturn(false);
         when(userRepository.getByIdOrThrow(1L)).thenReturn(testUser);
         when(surveyConverter.parseRequest(testRequest)).thenReturn(parsedData);
         when(surveyConverter.toEntity(testUser, parsedData)).thenReturn(testSurvey);
@@ -193,8 +195,21 @@ class SurveyServiceTest {
     }
 
     @Test
+    @DisplayName("이미_제출된_설문_중복_제출_예외발생")
+    void 이미_제출된_설문_중복_제출_예외발생() {
+        when(surveyRepository.existsByUserId(1L)).thenReturn(true);
+
+        assertThatThrownBy(() -> surveyService.create(1L, testRequest))
+                .isInstanceOf(SurveyAlreadySubmittedException.class);
+
+        verify(surveyRepository, never()).save(any());
+        verify(userRepository, never()).getByIdOrThrow(any());
+    }
+
+    @Test
     @DisplayName("존재하지_않는_사용자_예외발생")
     void 존재하지_않는_사용자_예외발생() {
+        when(surveyRepository.existsByUserId(999L)).thenReturn(false);
         when(userRepository.getByIdOrThrow(999L)).thenThrow(new UserNotFoundException());
 
         assertThatThrownBy(() -> surveyService.create(999L, testRequest))


### PR DESCRIPTION
## 🔎 작업 내용
  * `PATCH /api/v1/surveys/me` 엔드포인트 구현
  * `SurveyService.update()` — 기존 설문 수정, 온보딩 완료 처리 및 보상 지급 미호출
  * `SurveyRepository.getByUserIdOrThrow()` default 메서드 추가
  * `findByUser_Id` → `findByUserId` 네이밍 수정 (SurveyRepository, TravelTendencyRepository)
  * `saveOrUpdateSurvey` 제거 — `create`는 항상 신규 생성으로 단순화
  * `matchAvatarType` private 메서드 추출로 중복 제거
  * 서비스 public 메서드 네이밍 정리 (`create`, `update`)
  * 마이페이지 여행선호설정 수정 테스트 추가 (성공 시 온보딩·보상 미호출 검증, 설문 미존재 예외 검증)

## ➕ 이슈 링크
* CLOSED #311 


## 🧑‍💻 예정 작업
- 내가 작성한 게시글 목록 조회

## 📝 체크리스트
- [x] 브랜치 이름은 `feat/#이슈번호-개발내용` 형식으로 작성했는가?
- [x] 커밋 메시지는 `[#이슈번호] feat(scope): 커밋 내용` 형식으로 작성했는가?
- [x] PR 제목은 `feat(scope): PR 제목` 형식으로 작성했는가?
- [x] 작업 전 Issue를 작성했는가?
- [x] `dev` 브랜치로 병합을 요청했는가?
- [x] 불필요한 주석과 공백은 제거했는가?
- [x] 코드 리뷰어의 피드백을 반영했는가?
- [x] 테스트를 진행했는가?
- [x] 테스트 코드를 작성했는가?
