### PR TITLE
feat(mypage): 내가 작성한 게시글 조회 API 구현

### DIFF
--- a/src/main/java/com/dduru/gildongmu/post/domain/enums/MyPagePostFilter.java
+++ b/src/main/java/com/dduru/gildongmu/post/domain/enums/MyPagePostFilter.java
@@ -1,0 +1,8 @@
+package com.dduru.gildongmu.post.domain.enums;
+
+public enum MyPagePostFilter {
+    ALL,
+    RECRUITING,
+    RECRUITMENT_CLOSED,
+    TRAVEL_ENDED
+}

--- a/src/main/java/com/dduru/gildongmu/post/dto/request/MyPagePostListRequest.java
+++ b/src/main/java/com/dduru/gildongmu/post/dto/request/MyPagePostListRequest.java
@@ -1,0 +1,19 @@
+package com.dduru.gildongmu.post.dto.request;
+
+import com.dduru.gildongmu.post.domain.enums.MyPagePostFilter;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record MyPagePostListRequest(
+        @Schema(description = "다음 페이지 조회용 커서 게시글 ID. 첫 페이지에서는 생략합니다.", example = "120", nullable = true)
+        Long cursor,
+        @Schema(description = "페이지 크기. 생략하거나 1 미만 또는 50 초과이면 10으로 보정됩니다.", example = "10")
+        Integer size,
+        @Schema(description = "상태 필터. 생략 시 전체 조회합니다.", example = "ALL",
+                allowableValues = {"ALL", "RECRUITING", "RECRUITMENT_CLOSED", "TRAVEL_ENDED"})
+        MyPagePostFilter status
+) {
+    public MyPagePostListRequest {
+        if (size == null || size <= 0 || size > 50) size = 10;
+        if (status == null) status = MyPagePostFilter.ALL;
+    }
+}

--- a/src/main/java/com/dduru/gildongmu/post/dto/response/MyPagePostDisplayStatus.java
+++ b/src/main/java/com/dduru/gildongmu/post/dto/response/MyPagePostDisplayStatus.java
@@ -1,0 +1,22 @@
+package com.dduru.gildongmu.post.dto.response;
+
+import com.dduru.gildongmu.post.domain.Post;
+import com.dduru.gildongmu.post.domain.enums.PostStatus;
+
+import java.time.LocalDate;
+
+public enum MyPagePostDisplayStatus {
+    RECRUITING,
+    RECRUITMENT_CLOSED,
+    TRAVEL_ENDED;
+
+    public static MyPagePostDisplayStatus from(Post post, LocalDate today) {
+        if (post.hasTravelEnded(today)) {
+            return TRAVEL_ENDED;
+        }
+        if (post.getStatus() == PostStatus.OPEN && !post.isFull()) {
+            return RECRUITING;
+        }
+        return RECRUITMENT_CLOSED;
+    }
+}

--- a/src/main/java/com/dduru/gildongmu/post/dto/response/MyPagePostListResponse.java
+++ b/src/main/java/com/dduru/gildongmu/post/dto/response/MyPagePostListResponse.java
@@ -14,12 +14,12 @@ public record MyPagePostListResponse(
         @Schema(description = "현재 응답에 포함된 게시글 수", example = "10")
         int size,
         @Schema(description = "삭제되지 않은 내 전체 게시글 수. 전체보기 탭의 '전체 N' 표시에 사용됩니다.", example = "4")
-        int totalPostCount
+        long totalPostCount
 ) {
     public static MyPagePostListResponse of(
             List<MyPagePostSummaryResponse> posts,
             boolean hasNext,
-            int totalPostCount
+            long totalPostCount
     ) {
         Long nextCursor = hasNext && !posts.isEmpty() ? posts.get(posts.size() - 1).id() : null;
         return new MyPagePostListResponse(posts, nextCursor, hasNext, posts.size(), totalPostCount);

--- a/src/main/java/com/dduru/gildongmu/post/dto/response/MyPagePostListResponse.java
+++ b/src/main/java/com/dduru/gildongmu/post/dto/response/MyPagePostListResponse.java
@@ -13,18 +13,15 @@ public record MyPagePostListResponse(
         boolean hasNext,
         @Schema(description = "현재 응답에 포함된 게시글 수", example = "10")
         int size,
-        @Schema(description = "모집 중인 내 게시글 수 (status=OPEN, 정원 미달, 여행 미종료)", example = "2")
-        int currentRecruitingCount,
-        @Schema(description = "모집 중 + 모집 완료 게시글 수 (여행 종료 제외)", example = "5")
-        int activePostCount
+        @Schema(description = "삭제되지 않은 내 전체 게시글 수. 전체보기 탭의 '전체 N' 표시에 사용됩니다.", example = "4")
+        int totalPostCount
 ) {
     public static MyPagePostListResponse of(
             List<MyPagePostSummaryResponse> posts,
             boolean hasNext,
-            int currentRecruitingCount,
-            int activePostCount
+            int totalPostCount
     ) {
         Long nextCursor = hasNext && !posts.isEmpty() ? posts.get(posts.size() - 1).id() : null;
-        return new MyPagePostListResponse(posts, nextCursor, hasNext, posts.size(), currentRecruitingCount, activePostCount);
+        return new MyPagePostListResponse(posts, nextCursor, hasNext, posts.size(), totalPostCount);
     }
 }

--- a/src/main/java/com/dduru/gildongmu/post/dto/response/MyPagePostListResponse.java
+++ b/src/main/java/com/dduru/gildongmu/post/dto/response/MyPagePostListResponse.java
@@ -1,0 +1,30 @@
+package com.dduru.gildongmu.post.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+public record MyPagePostListResponse(
+        @Schema(description = "게시글 목록")
+        List<MyPagePostSummaryResponse> posts,
+        @Schema(description = "다음 페이지 조회용 커서 게시글 ID. hasNext=false이면 null입니다.", example = "101", nullable = true)
+        Long nextCursor,
+        @Schema(description = "다음 페이지 존재 여부", example = "true")
+        boolean hasNext,
+        @Schema(description = "현재 응답에 포함된 게시글 수", example = "10")
+        int size,
+        @Schema(description = "모집 중인 내 게시글 수 (status=OPEN, 정원 미달, 여행 미종료)", example = "2")
+        int currentRecruitingCount,
+        @Schema(description = "모집 중 + 모집 완료 게시글 수 (여행 종료 제외)", example = "5")
+        int activePostCount
+) {
+    public static MyPagePostListResponse of(
+            List<MyPagePostSummaryResponse> posts,
+            boolean hasNext,
+            int currentRecruitingCount,
+            int activePostCount
+    ) {
+        Long nextCursor = hasNext && !posts.isEmpty() ? posts.get(posts.size() - 1).id() : null;
+        return new MyPagePostListResponse(posts, nextCursor, hasNext, posts.size(), currentRecruitingCount, activePostCount);
+    }
+}

--- a/src/main/java/com/dduru/gildongmu/post/dto/response/MyPagePostSummaryResponse.java
+++ b/src/main/java/com/dduru/gildongmu/post/dto/response/MyPagePostSummaryResponse.java
@@ -1,0 +1,36 @@
+package com.dduru.gildongmu.post.dto.response;
+
+import com.dduru.gildongmu.post.domain.Post;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDate;
+
+public record MyPagePostSummaryResponse(
+        @Schema(description = "게시글 ID", example = "101")
+        Long id,
+        @Schema(description = "게시글 제목", example = "제주도 2박 3일 동행 구해요")
+        String title,
+        @Schema(description = "여행지 도시명", example = "제주")
+        String destination,
+        @Schema(description = "여행 시작일", example = "2026-07-10")
+        LocalDate startDate,
+        @Schema(description = "여행 종료일", example = "2026-07-12")
+        LocalDate endDate,
+        @Schema(description = "게시글 작성일", example = "2026-01-10")
+        LocalDate createdAt,
+        @Schema(description = "화면 표시용 게시글 상태. 여행 종료일 기준으로 계산됩니다.", example = "RECRUITING",
+                allowableValues = {"RECRUITING", "RECRUITMENT_CLOSED", "TRAVEL_ENDED"})
+        MyPagePostDisplayStatus displayStatus
+) {
+    public static MyPagePostSummaryResponse from(Post post, LocalDate today) {
+        return new MyPagePostSummaryResponse(
+                post.getId(),
+                post.getTitle(),
+                post.getDestination().getCity(),
+                post.getStartDate(),
+                post.getEndDate(),
+                post.getCreatedAt() != null ? post.getCreatedAt().toLocalDate() : null,
+                MyPagePostDisplayStatus.from(post, today)
+        );
+    }
+}

--- a/src/main/java/com/dduru/gildongmu/post/dto/response/MyPagePostSummaryResponse.java
+++ b/src/main/java/com/dduru/gildongmu/post/dto/response/MyPagePostSummaryResponse.java
@@ -29,7 +29,7 @@ public record MyPagePostSummaryResponse(
                 post.getDestination().getCity(),
                 post.getStartDate(),
                 post.getEndDate(),
-                post.getCreatedAt() != null ? post.getCreatedAt().toLocalDate() : null,
+                post.getCreatedAt().toLocalDate(),
                 MyPagePostDisplayStatus.from(post, today)
         );
     }

--- a/src/main/java/com/dduru/gildongmu/post/repository/PostRepositoryCustom.java
+++ b/src/main/java/com/dduru/gildongmu/post/repository/PostRepositoryCustom.java
@@ -11,6 +11,5 @@ import java.util.List;
 public interface PostRepositoryCustom {
     List<Post> findPostsWithFilters(PostListRequest request, LocalDate today, Integer cursorValue, Pageable pageable);
     List<Post> findPostsByUserId(Long userId, MyPagePostFilter filter, Long cursor, Pageable pageable, LocalDate today);
-    int countActivePostsByUserId(Long userId, LocalDate today);
-    int countRecruitingPostsByUserId(Long userId, LocalDate today);
+    int countTotalPostsByUserId(Long userId);
 }

--- a/src/main/java/com/dduru/gildongmu/post/repository/PostRepositoryCustom.java
+++ b/src/main/java/com/dduru/gildongmu/post/repository/PostRepositoryCustom.java
@@ -1,6 +1,7 @@
 package com.dduru.gildongmu.post.repository;
 
 import com.dduru.gildongmu.post.domain.Post;
+import com.dduru.gildongmu.post.domain.enums.MyPagePostFilter;
 import com.dduru.gildongmu.post.dto.request.PostListRequest;
 import org.springframework.data.domain.Pageable;
 
@@ -9,4 +10,7 @@ import java.util.List;
 
 public interface PostRepositoryCustom {
     List<Post> findPostsWithFilters(PostListRequest request, LocalDate today, Integer cursorValue, Pageable pageable);
+    List<Post> findPostsByUserId(Long userId, MyPagePostFilter filter, Long cursor, Pageable pageable, LocalDate today);
+    int countActivePostsByUserId(Long userId, LocalDate today);
+    int countRecruitingPostsByUserId(Long userId, LocalDate today);
 }

--- a/src/main/java/com/dduru/gildongmu/post/repository/PostRepositoryCustom.java
+++ b/src/main/java/com/dduru/gildongmu/post/repository/PostRepositoryCustom.java
@@ -11,5 +11,5 @@ import java.util.List;
 public interface PostRepositoryCustom {
     List<Post> findPostsWithFilters(PostListRequest request, LocalDate today, Integer cursorValue, Pageable pageable);
     List<Post> findPostsByUserId(Long userId, MyPagePostFilter filter, Long cursor, Pageable pageable, LocalDate today);
-    int countTotalPostsByUserId(Long userId);
+    long countTotalPostsByUserId(Long userId);
 }

--- a/src/main/java/com/dduru/gildongmu/post/repository/PostRepositoryImpl.java
+++ b/src/main/java/com/dduru/gildongmu/post/repository/PostRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.dduru.gildongmu.post.repository;
 
 import com.dduru.gildongmu.post.domain.Post;
 import com.dduru.gildongmu.post.domain.enums.CompanionType;
+import com.dduru.gildongmu.post.domain.enums.MyPagePostFilter;
 import com.dduru.gildongmu.post.domain.enums.RecruitmentStatusFilter;
 import com.dduru.gildongmu.post.domain.enums.PostSortType;
 import com.dduru.gildongmu.post.domain.enums.PostStatus;
@@ -57,6 +58,62 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
             case VIEW -> new OrderSpecifier[]{post.viewCount.desc(), post.id.desc()};
             case LIKE -> new OrderSpecifier[]{post.likeCount.desc(), post.id.desc()};
             default -> new OrderSpecifier[]{post.id.desc()};
+        };
+    }
+
+    @Override
+    public List<Post> findPostsByUserId(Long userId, MyPagePostFilter filter, Long cursor, Pageable pageable, LocalDate today) {
+        return queryFactory
+                .selectFrom(post)
+                .leftJoin(post.destination, destination).fetchJoin()
+                .where(
+                        post.user.id.eq(userId),
+                        isNotDeleted(),
+                        cursor != null ? post.id.lt(cursor) : null,
+                        myPageStatusFilter(filter, today)
+                )
+                .orderBy(post.id.desc())
+                .limit(pageable.getPageSize())
+                .fetch();
+    }
+
+    @Override
+    public int countActivePostsByUserId(Long userId, LocalDate today) {
+        Long count = queryFactory
+                .select(post.count())
+                .from(post)
+                .where(post.user.id.eq(userId), isNotDeleted(), post.endDate.goe(today))
+                .fetchOne();
+        return count == null ? 0 : count.intValue();
+    }
+
+    @Override
+    public int countRecruitingPostsByUserId(Long userId, LocalDate today) {
+        Long count = queryFactory
+                .select(post.count())
+                .from(post)
+                .where(
+                        post.user.id.eq(userId),
+                        isNotDeleted(),
+                        post.endDate.goe(today),
+                        post.status.eq(PostStatus.OPEN),
+                        post.recruitCount.lt(post.recruitCapacity)
+                )
+                .fetchOne();
+        return count == null ? 0 : count.intValue();
+    }
+
+    private BooleanExpression myPageStatusFilter(MyPagePostFilter filter, LocalDate today) {
+        if (filter == null || filter == MyPagePostFilter.ALL) return null;
+        return switch (filter) {
+            case RECRUITING -> post.endDate.goe(today)
+                    .and(post.status.eq(PostStatus.OPEN))
+                    .and(post.recruitCount.lt(post.recruitCapacity));
+            case RECRUITMENT_CLOSED -> post.endDate.goe(today)
+                    .and(post.status.eq(PostStatus.CLOSED)
+                            .or(post.recruitCount.goe(post.recruitCapacity)));
+            case TRAVEL_ENDED -> post.endDate.lt(today);
+            default -> null;
         };
     }
 

--- a/src/main/java/com/dduru/gildongmu/post/repository/PostRepositoryImpl.java
+++ b/src/main/java/com/dduru/gildongmu/post/repository/PostRepositoryImpl.java
@@ -78,27 +78,11 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
     }
 
     @Override
-    public int countActivePostsByUserId(Long userId, LocalDate today) {
+    public int countTotalPostsByUserId(Long userId) {
         Long count = queryFactory
                 .select(post.count())
                 .from(post)
-                .where(post.user.id.eq(userId), isNotDeleted(), post.endDate.goe(today))
-                .fetchOne();
-        return count == null ? 0 : count.intValue();
-    }
-
-    @Override
-    public int countRecruitingPostsByUserId(Long userId, LocalDate today) {
-        Long count = queryFactory
-                .select(post.count())
-                .from(post)
-                .where(
-                        post.user.id.eq(userId),
-                        isNotDeleted(),
-                        post.endDate.goe(today),
-                        post.status.eq(PostStatus.OPEN),
-                        post.recruitCount.lt(post.recruitCapacity)
-                )
+                .where(post.user.id.eq(userId), isNotDeleted())
                 .fetchOne();
         return count == null ? 0 : count.intValue();
     }

--- a/src/main/java/com/dduru/gildongmu/post/repository/PostRepositoryImpl.java
+++ b/src/main/java/com/dduru/gildongmu/post/repository/PostRepositoryImpl.java
@@ -78,17 +78,17 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
     }
 
     @Override
-    public int countTotalPostsByUserId(Long userId) {
+    public long countTotalPostsByUserId(Long userId) {
         Long count = queryFactory
                 .select(post.count())
                 .from(post)
                 .where(post.user.id.eq(userId), isNotDeleted())
                 .fetchOne();
-        return count == null ? 0 : count.intValue();
+        return count == null ? 0L : count;
     }
 
     private BooleanExpression myPageStatusFilter(MyPagePostFilter filter, LocalDate today) {
-        if (filter == null || filter == MyPagePostFilter.ALL) return null;
+        if (filter == MyPagePostFilter.ALL) return null;
         return switch (filter) {
             case RECRUITING -> post.endDate.goe(today)
                     .and(post.status.eq(PostStatus.OPEN))

--- a/src/main/java/com/dduru/gildongmu/post/service/PostQueryService.java
+++ b/src/main/java/com/dduru/gildongmu/post/service/PostQueryService.java
@@ -3,6 +3,7 @@ package com.dduru.gildongmu.post.service;
 import com.dduru.gildongmu.common.time.TimeProvider;
 import com.dduru.gildongmu.like.repository.PostLikeRepository;
 import com.dduru.gildongmu.post.domain.Post;
+import com.dduru.gildongmu.post.domain.enums.MyPagePostFilter;
 import com.dduru.gildongmu.post.domain.enums.PostSortType;
 import com.dduru.gildongmu.post.dto.request.MyPagePostListRequest;
 import com.dduru.gildongmu.post.dto.request.PostListRequest;
@@ -23,6 +24,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 
@@ -70,13 +72,14 @@ public class PostQueryService {
     public MyPagePostListResponse retrieveMyPosts(Long userId, MyPagePostListRequest request) {
         LocalDate today = today();
         Pageable pageable = PageRequest.of(0, request.size() + 1);
-        List<Post> posts = postRepository.findPostsByUserId(userId, request.status(), request.cursor(), pageable, today);
+        MyPagePostFilter status = Objects.requireNonNullElse(request.status(), MyPagePostFilter.ALL);
+        List<Post> posts = postRepository.findPostsByUserId(userId, status, request.cursor(), pageable, today);
         boolean hasNext = posts.size() > request.size();
         if (hasNext) posts = posts.subList(0, request.size());
         List<MyPagePostSummaryResponse> summaries = posts.stream()
                 .map(p -> MyPagePostSummaryResponse.from(p, today))
                 .toList();
-        int totalPostCount = postRepository.countTotalPostsByUserId(userId);
+        long totalPostCount = postRepository.countTotalPostsByUserId(userId);
         return MyPagePostListResponse.of(summaries, hasNext, totalPostCount);
     }
 

--- a/src/main/java/com/dduru/gildongmu/post/service/PostQueryService.java
+++ b/src/main/java/com/dduru/gildongmu/post/service/PostQueryService.java
@@ -4,7 +4,10 @@ import com.dduru.gildongmu.common.time.TimeProvider;
 import com.dduru.gildongmu.like.repository.PostLikeRepository;
 import com.dduru.gildongmu.post.domain.Post;
 import com.dduru.gildongmu.post.domain.enums.PostSortType;
+import com.dduru.gildongmu.post.dto.request.MyPagePostListRequest;
 import com.dduru.gildongmu.post.dto.request.PostListRequest;
+import com.dduru.gildongmu.post.dto.response.MyPagePostListResponse;
+import com.dduru.gildongmu.post.dto.response.MyPagePostSummaryResponse;
 import com.dduru.gildongmu.post.dto.response.PostListResponse;
 import com.dduru.gildongmu.post.dto.response.PostSummaryResponse;
 import com.dduru.gildongmu.post.repository.PostRepository;
@@ -21,6 +24,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
 
 @Service
 @RequiredArgsConstructor
@@ -61,6 +65,20 @@ public class PostQueryService {
                 .toList();
 
         return PostListResponse.of(summaries, hasNext, nextCursorValue);
+    }
+
+    public MyPagePostListResponse retrieveMyPosts(Long userId, MyPagePostListRequest request) {
+        LocalDate today = today();
+        Pageable pageable = PageRequest.of(0, request.size() + 1);
+        List<Post> posts = postRepository.findPostsByUserId(userId, request.status(), request.cursor(), pageable, today);
+        boolean hasNext = posts.size() > request.size();
+        if (hasNext) posts = posts.subList(0, request.size());
+        List<MyPagePostSummaryResponse> summaries = posts.stream()
+                .map(p -> MyPagePostSummaryResponse.from(p, today))
+                .toList();
+        int currentRecruitingCount = postRepository.countRecruitingPostsByUserId(userId, today);
+        int activePostCount = postRepository.countActivePostsByUserId(userId, today);
+        return MyPagePostListResponse.of(summaries, hasNext, currentRecruitingCount, activePostCount);
     }
 
     private Integer computeNextCursorValue(PostSortType sort, boolean hasNext, List<Post> posts) {

--- a/src/main/java/com/dduru/gildongmu/post/service/PostQueryService.java
+++ b/src/main/java/com/dduru/gildongmu/post/service/PostQueryService.java
@@ -76,9 +76,8 @@ public class PostQueryService {
         List<MyPagePostSummaryResponse> summaries = posts.stream()
                 .map(p -> MyPagePostSummaryResponse.from(p, today))
                 .toList();
-        int currentRecruitingCount = postRepository.countRecruitingPostsByUserId(userId, today);
-        int activePostCount = postRepository.countActivePostsByUserId(userId, today);
-        return MyPagePostListResponse.of(summaries, hasNext, currentRecruitingCount, activePostCount);
+        int totalPostCount = postRepository.countTotalPostsByUserId(userId);
+        return MyPagePostListResponse.of(summaries, hasNext, totalPostCount);
     }
 
     private Integer computeNextCursorValue(PostSortType sort, boolean hasNext, List<Post> posts) {

--- a/src/main/java/com/dduru/gildongmu/user/controller/UserApiDocs.java
+++ b/src/main/java/com/dduru/gildongmu/user/controller/UserApiDocs.java
@@ -1,0 +1,34 @@
+package com.dduru.gildongmu.user.controller;
+
+import com.dduru.gildongmu.common.annotation.ApiErrorResponses;
+import com.dduru.gildongmu.common.dto.ApiResult;
+import com.dduru.gildongmu.common.exception.ErrorCode;
+import com.dduru.gildongmu.post.dto.request.MyPagePostListRequest;
+import com.dduru.gildongmu.post.dto.response.MyPagePostListResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "User", description = "사용자 마이페이지 API")
+public interface UserApiDocs {
+
+    @Operation(
+            summary = "내가 작성한 게시글 목록 조회",
+            description = "내가 작성한 게시글 목록을 커서 기반 페이지네이션으로 조회합니다.",
+            security = @SecurityRequirement(name = "JWT")
+    )
+    @ApiResponse(responseCode = "200", description = "조회 성공")
+    @ApiErrorResponses({
+            ErrorCode.UNAUTHORIZED
+    })
+    ResponseEntity<ApiResult<MyPagePostListResponse>> retrieveMyPosts(
+            @Parameter(hidden = true) Long userId,
+            @Valid @ParameterObject MyPagePostListRequest request
+    );
+
+}

--- a/src/main/java/com/dduru/gildongmu/user/controller/UserController.java
+++ b/src/main/java/com/dduru/gildongmu/user/controller/UserController.java
@@ -1,0 +1,32 @@
+package com.dduru.gildongmu.user.controller;
+
+import com.dduru.gildongmu.common.annotation.CurrentUser;
+import com.dduru.gildongmu.common.dto.ApiResult;
+import com.dduru.gildongmu.post.dto.request.MyPagePostListRequest;
+import com.dduru.gildongmu.post.dto.response.MyPagePostListResponse;
+import com.dduru.gildongmu.post.service.PostQueryService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/users/me")
+public class UserController implements UserApiDocs {
+
+    private final PostQueryService postQueryService;
+
+    @Override
+    @GetMapping("/posts")
+    public ResponseEntity<ApiResult<MyPagePostListResponse>> retrieveMyPosts(
+            @CurrentUser Long userId,
+            @Valid MyPagePostListRequest request
+    ) {
+        MyPagePostListResponse response = postQueryService.retrieveMyPosts(userId, request);
+        return ResponseEntity.ok(ApiResult.ok(response));
+    }
+
+}

--- a/src/test/java/com/dduru/gildongmu/post/service/PostQueryServiceTest.java
+++ b/src/test/java/com/dduru/gildongmu/post/service/PostQueryServiceTest.java
@@ -391,8 +391,7 @@ class PostQueryServiceTest {
         void passesRecruitingFilterToRepository() {
             when(postRepository.findPostsByUserId(eq(1L), eq(MyPagePostFilter.RECRUITING), isNull(), any(Pageable.class), eq(TODAY)))
                     .thenReturn(List.of());
-            lenient().when(postRepository.countActivePostsByUserId(any(), any())).thenReturn(0);
-            lenient().when(postRepository.countRecruitingPostsByUserId(any(), any())).thenReturn(0);
+            lenient().when(postRepository.countTotalPostsByUserId(any())).thenReturn(0);
 
             postQueryService.retrieveMyPosts(1L, myPageRequest(null, 10, MyPagePostFilter.RECRUITING));
 
@@ -404,8 +403,7 @@ class PostQueryServiceTest {
         void passesTravelEndedFilterToRepository() {
             when(postRepository.findPostsByUserId(eq(1L), eq(MyPagePostFilter.TRAVEL_ENDED), isNull(), any(Pageable.class), eq(TODAY)))
                     .thenReturn(List.of());
-            lenient().when(postRepository.countActivePostsByUserId(any(), any())).thenReturn(0);
-            lenient().when(postRepository.countRecruitingPostsByUserId(any(), any())).thenReturn(0);
+            lenient().when(postRepository.countTotalPostsByUserId(any())).thenReturn(0);
 
             postQueryService.retrieveMyPosts(1L, myPageRequest(null, 10, MyPagePostFilter.TRAVEL_ENDED));
 
@@ -417,8 +415,7 @@ class PostQueryServiceTest {
         void passesAllFilterToRepository() {
             when(postRepository.findPostsByUserId(eq(1L), eq(MyPagePostFilter.ALL), isNull(), any(Pageable.class), eq(TODAY)))
                     .thenReturn(List.of());
-            lenient().when(postRepository.countActivePostsByUserId(any(), any())).thenReturn(0);
-            lenient().when(postRepository.countRecruitingPostsByUserId(any(), any())).thenReturn(0);
+            lenient().when(postRepository.countTotalPostsByUserId(any())).thenReturn(0);
 
             postQueryService.retrieveMyPosts(1L, myPageRequest(null, 10, MyPagePostFilter.ALL));
 
@@ -431,35 +428,30 @@ class PostQueryServiceTest {
     // ─────────────────────────────────────────────────────────────────────────
 
     @Nested
-    @DisplayName("요약 카드 카운트")
-    class SummaryCount {
+    @DisplayName("전체 게시글 수")
+    class TotalPostCount {
 
         @Test
-        @DisplayName("currentRecruitingCount와 activePostCount를 응답에 포함한다")
-        void includesSummaryCountsInResponse() {
+        @DisplayName("totalPostCount를 응답에 포함한다")
+        void includesTotalPostCountInResponse() {
             when(postRepository.findPostsByUserId(any(), any(), any(), any(), any())).thenReturn(List.of());
-            when(postRepository.countRecruitingPostsByUserId(eq(1L), eq(TODAY))).thenReturn(3);
-            when(postRepository.countActivePostsByUserId(eq(1L), eq(TODAY))).thenReturn(7);
+            when(postRepository.countTotalPostsByUserId(eq(1L))).thenReturn(4);
 
             MyPagePostListResponse response = postQueryService.retrieveMyPosts(1L, myPageRequest(null, 10, MyPagePostFilter.ALL));
 
-            assertThat(response.currentRecruitingCount()).isEqualTo(3);
-            assertThat(response.activePostCount()).isEqualTo(7);
+            assertThat(response.totalPostCount()).isEqualTo(4);
         }
 
         @Test
-        @DisplayName("필터와 무관하게 전체 카운트를 조회한다")
-        void countsAreIndependentOfFilter() {
+        @DisplayName("필터와 무관하게 삭제되지 않은 전체 게시글 수를 조회한다")
+        void totalCountIsIndependentOfFilter() {
             when(postRepository.findPostsByUserId(any(), any(), any(), any(), any())).thenReturn(List.of());
-            when(postRepository.countRecruitingPostsByUserId(eq(1L), eq(TODAY))).thenReturn(2);
-            when(postRepository.countActivePostsByUserId(eq(1L), eq(TODAY))).thenReturn(5);
+            when(postRepository.countTotalPostsByUserId(eq(1L))).thenReturn(5);
 
             MyPagePostListResponse response = postQueryService.retrieveMyPosts(1L, myPageRequest(null, 10, MyPagePostFilter.TRAVEL_ENDED));
 
-            assertThat(response.currentRecruitingCount()).isEqualTo(2);
-            assertThat(response.activePostCount()).isEqualTo(5);
-            verify(postRepository).countRecruitingPostsByUserId(eq(1L), eq(TODAY));
-            verify(postRepository).countActivePostsByUserId(eq(1L), eq(TODAY));
+            assertThat(response.totalPostCount()).isEqualTo(5);
+            verify(postRepository).countTotalPostsByUserId(eq(1L));
         }
     }
 
@@ -477,8 +469,7 @@ class PostQueryServiceTest {
             Long userId = 1L;
             when(postRepository.findPostsByUserId(eq(userId), eq(MyPagePostFilter.ALL), isNull(), any(Pageable.class), eq(TODAY)))
                     .thenReturn(List.of(createPost(10L), createPost(5L), createPost(1L)));
-            lenient().when(postRepository.countActivePostsByUserId(any(), any())).thenReturn(3);
-            lenient().when(postRepository.countRecruitingPostsByUserId(any(), any())).thenReturn(3);
+            lenient().when(postRepository.countTotalPostsByUserId(any())).thenReturn(3);
 
             MyPagePostListResponse response = postQueryService.retrieveMyPosts(userId, myPageRequest(null, 2, MyPagePostFilter.ALL));
 
@@ -493,8 +484,7 @@ class PostQueryServiceTest {
             Long userId = 1L;
             when(postRepository.findPostsByUserId(eq(userId), eq(MyPagePostFilter.ALL), isNull(), any(Pageable.class), eq(TODAY)))
                     .thenReturn(List.of());
-            lenient().when(postRepository.countActivePostsByUserId(any(), any())).thenReturn(0);
-            lenient().when(postRepository.countRecruitingPostsByUserId(any(), any())).thenReturn(0);
+            lenient().when(postRepository.countTotalPostsByUserId(any())).thenReturn(0);
 
             MyPagePostListResponse response = postQueryService.retrieveMyPosts(userId, myPageRequest(null, 10, MyPagePostFilter.ALL));
 
@@ -510,8 +500,7 @@ class PostQueryServiceTest {
             Long cursor = 50L;
             when(postRepository.findPostsByUserId(eq(userId), any(), eq(cursor), any(Pageable.class), eq(TODAY)))
                     .thenReturn(List.of());
-            lenient().when(postRepository.countActivePostsByUserId(any(), any())).thenReturn(0);
-            lenient().when(postRepository.countRecruitingPostsByUserId(any(), any())).thenReturn(0);
+            lenient().when(postRepository.countTotalPostsByUserId(any())).thenReturn(0);
 
             postQueryService.retrieveMyPosts(userId, myPageRequest(cursor, 10, MyPagePostFilter.ALL));
 
@@ -527,8 +516,7 @@ class PostQueryServiceTest {
             Post post1 = createPost(1L);
             when(postRepository.findPostsByUserId(eq(userId), any(), isNull(), any(Pageable.class), eq(TODAY)))
                     .thenReturn(List.of(post10, post5, post1));
-            lenient().when(postRepository.countActivePostsByUserId(any(), any())).thenReturn(3);
-            lenient().when(postRepository.countRecruitingPostsByUserId(any(), any())).thenReturn(3);
+            lenient().when(postRepository.countTotalPostsByUserId(any())).thenReturn(3);
 
             MyPagePostListResponse response = postQueryService.retrieveMyPosts(userId, myPageRequest(null, 2, MyPagePostFilter.ALL));
 
@@ -544,8 +532,7 @@ class PostQueryServiceTest {
 
     private void stubMyPosts(List<Post> posts) {
         lenient().when(postRepository.findPostsByUserId(any(), any(), any(), any(), any())).thenReturn(posts);
-        lenient().when(postRepository.countActivePostsByUserId(any(), any())).thenReturn(posts.size());
-        lenient().when(postRepository.countRecruitingPostsByUserId(any(), any())).thenReturn(0);
+        lenient().when(postRepository.countTotalPostsByUserId(any())).thenReturn(posts.size());
     }
 
     private MyPagePostListRequest myPageRequest(Long cursor, int size, MyPagePostFilter filter) {

--- a/src/test/java/com/dduru/gildongmu/post/service/PostQueryServiceTest.java
+++ b/src/test/java/com/dduru/gildongmu/post/service/PostQueryServiceTest.java
@@ -33,6 +33,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -391,7 +392,7 @@ class PostQueryServiceTest {
         void passesRecruitingFilterToRepository() {
             when(postRepository.findPostsByUserId(eq(1L), eq(MyPagePostFilter.RECRUITING), isNull(), any(Pageable.class), eq(TODAY)))
                     .thenReturn(List.of());
-            lenient().when(postRepository.countTotalPostsByUserId(any())).thenReturn(0);
+            lenient().when(postRepository.countTotalPostsByUserId(any())).thenReturn(0L);
 
             postQueryService.retrieveMyPosts(1L, myPageRequest(null, 10, MyPagePostFilter.RECRUITING));
 
@@ -403,7 +404,7 @@ class PostQueryServiceTest {
         void passesTravelEndedFilterToRepository() {
             when(postRepository.findPostsByUserId(eq(1L), eq(MyPagePostFilter.TRAVEL_ENDED), isNull(), any(Pageable.class), eq(TODAY)))
                     .thenReturn(List.of());
-            lenient().when(postRepository.countTotalPostsByUserId(any())).thenReturn(0);
+            lenient().when(postRepository.countTotalPostsByUserId(any())).thenReturn(0L);
 
             postQueryService.retrieveMyPosts(1L, myPageRequest(null, 10, MyPagePostFilter.TRAVEL_ENDED));
 
@@ -415,7 +416,7 @@ class PostQueryServiceTest {
         void passesAllFilterToRepository() {
             when(postRepository.findPostsByUserId(eq(1L), eq(MyPagePostFilter.ALL), isNull(), any(Pageable.class), eq(TODAY)))
                     .thenReturn(List.of());
-            lenient().when(postRepository.countTotalPostsByUserId(any())).thenReturn(0);
+            lenient().when(postRepository.countTotalPostsByUserId(any())).thenReturn(0L);
 
             postQueryService.retrieveMyPosts(1L, myPageRequest(null, 10, MyPagePostFilter.ALL));
 
@@ -435,7 +436,7 @@ class PostQueryServiceTest {
         @DisplayName("totalPostCount를 응답에 포함한다")
         void includesTotalPostCountInResponse() {
             when(postRepository.findPostsByUserId(any(), any(), any(), any(), any())).thenReturn(List.of());
-            when(postRepository.countTotalPostsByUserId(eq(1L))).thenReturn(4);
+            when(postRepository.countTotalPostsByUserId(eq(1L))).thenReturn(4L);
 
             MyPagePostListResponse response = postQueryService.retrieveMyPosts(1L, myPageRequest(null, 10, MyPagePostFilter.ALL));
 
@@ -446,7 +447,7 @@ class PostQueryServiceTest {
         @DisplayName("필터와 무관하게 삭제되지 않은 전체 게시글 수를 조회한다")
         void totalCountIsIndependentOfFilter() {
             when(postRepository.findPostsByUserId(any(), any(), any(), any(), any())).thenReturn(List.of());
-            when(postRepository.countTotalPostsByUserId(eq(1L))).thenReturn(5);
+            when(postRepository.countTotalPostsByUserId(eq(1L))).thenReturn(5L);
 
             MyPagePostListResponse response = postQueryService.retrieveMyPosts(1L, myPageRequest(null, 10, MyPagePostFilter.TRAVEL_ENDED));
 
@@ -469,7 +470,7 @@ class PostQueryServiceTest {
             Long userId = 1L;
             when(postRepository.findPostsByUserId(eq(userId), eq(MyPagePostFilter.ALL), isNull(), any(Pageable.class), eq(TODAY)))
                     .thenReturn(List.of(createPost(10L), createPost(5L), createPost(1L)));
-            lenient().when(postRepository.countTotalPostsByUserId(any())).thenReturn(3);
+            lenient().when(postRepository.countTotalPostsByUserId(any())).thenReturn(3L);
 
             MyPagePostListResponse response = postQueryService.retrieveMyPosts(userId, myPageRequest(null, 2, MyPagePostFilter.ALL));
 
@@ -484,7 +485,7 @@ class PostQueryServiceTest {
             Long userId = 1L;
             when(postRepository.findPostsByUserId(eq(userId), eq(MyPagePostFilter.ALL), isNull(), any(Pageable.class), eq(TODAY)))
                     .thenReturn(List.of());
-            lenient().when(postRepository.countTotalPostsByUserId(any())).thenReturn(0);
+            lenient().when(postRepository.countTotalPostsByUserId(any())).thenReturn(0L);
 
             MyPagePostListResponse response = postQueryService.retrieveMyPosts(userId, myPageRequest(null, 10, MyPagePostFilter.ALL));
 
@@ -500,7 +501,7 @@ class PostQueryServiceTest {
             Long cursor = 50L;
             when(postRepository.findPostsByUserId(eq(userId), any(), eq(cursor), any(Pageable.class), eq(TODAY)))
                     .thenReturn(List.of());
-            lenient().when(postRepository.countTotalPostsByUserId(any())).thenReturn(0);
+            lenient().when(postRepository.countTotalPostsByUserId(any())).thenReturn(0L);
 
             postQueryService.retrieveMyPosts(userId, myPageRequest(cursor, 10, MyPagePostFilter.ALL));
 
@@ -516,7 +517,7 @@ class PostQueryServiceTest {
             Post post1 = createPost(1L);
             when(postRepository.findPostsByUserId(eq(userId), any(), isNull(), any(Pageable.class), eq(TODAY)))
                     .thenReturn(List.of(post10, post5, post1));
-            lenient().when(postRepository.countTotalPostsByUserId(any())).thenReturn(3);
+            lenient().when(postRepository.countTotalPostsByUserId(any())).thenReturn(3L);
 
             MyPagePostListResponse response = postQueryService.retrieveMyPosts(userId, myPageRequest(null, 2, MyPagePostFilter.ALL));
 
@@ -532,7 +533,7 @@ class PostQueryServiceTest {
 
     private void stubMyPosts(List<Post> posts) {
         lenient().when(postRepository.findPostsByUserId(any(), any(), any(), any(), any())).thenReturn(posts);
-        lenient().when(postRepository.countTotalPostsByUserId(any())).thenReturn(posts.size());
+        lenient().when(postRepository.countTotalPostsByUserId(any())).thenReturn((long) posts.size());
     }
 
     private MyPagePostListRequest myPageRequest(Long cursor, int size, MyPagePostFilter filter) {
@@ -578,6 +579,7 @@ class PostQueryServiceTest {
                 Gender.U, true, null, null, null, "[]", CompanionType.FULL
         );
         ReflectionTestUtils.setField(post, "id", postId);
+        ReflectionTestUtils.setField(post, "createdAt", LocalDateTime.of(2026, 1, 10, 0, 0));
         return post;
     }
 }

--- a/src/test/java/com/dduru/gildongmu/post/service/PostQueryServiceTest.java
+++ b/src/test/java/com/dduru/gildongmu/post/service/PostQueryServiceTest.java
@@ -5,8 +5,13 @@ import com.dduru.gildongmu.destination.domain.Destination;
 import com.dduru.gildongmu.like.repository.PostLikeRepository;
 import com.dduru.gildongmu.post.domain.Post;
 import com.dduru.gildongmu.post.domain.enums.CompanionType;
+import com.dduru.gildongmu.post.domain.enums.MyPagePostFilter;
 import com.dduru.gildongmu.post.domain.enums.PostSortType;
+import com.dduru.gildongmu.post.domain.enums.PostStatus;
+import com.dduru.gildongmu.post.dto.request.MyPagePostListRequest;
 import com.dduru.gildongmu.post.dto.request.PostListRequest;
+import com.dduru.gildongmu.post.dto.response.MyPagePostDisplayStatus;
+import com.dduru.gildongmu.post.dto.response.MyPagePostListResponse;
 import com.dduru.gildongmu.post.dto.response.PostListResponse;
 import com.dduru.gildongmu.post.repository.PostRepository;
 import com.dduru.gildongmu.profile.domain.Profile;
@@ -58,7 +63,7 @@ class PostQueryServiceTest {
 
     @BeforeEach
     void setUp() {
-        when(timeProvider.today()).thenReturn(TODAY);
+        lenient().when(timeProvider.today()).thenReturn(TODAY);
         lenient().when(profileImageResolver.resolve(any(Profile.class))).thenReturn(null);
         lenient().when(superHostService.findActiveSuperHostExposures(any())).thenReturn(Map.of());
     }
@@ -307,8 +312,245 @@ class PostQueryServiceTest {
     }
 
     // ─────────────────────────────────────────────────────────────────────────
+    // 내가 작성한 게시글 - displayStatus 분류
+    // ─────────────────────────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("displayStatus 분류")
+    class DisplayStatus {
+
+        @Test
+        @DisplayName("endDate가 오늘 이전이면 TRAVEL_ENDED다")
+        void travelEndedWhenEndDateBeforeToday() {
+            Post post = createPostWithEndDate(1L, TODAY.minusDays(1));
+            stubMyPosts(List.of(post));
+
+            MyPagePostListResponse response = postQueryService.retrieveMyPosts(1L, myPageRequest(null, 10, MyPagePostFilter.ALL));
+
+            assertThat(response.posts().get(0).displayStatus()).isEqualTo(MyPagePostDisplayStatus.TRAVEL_ENDED);
+        }
+
+        @Test
+        @DisplayName("endDate가 오늘이고 OPEN이며 정원이 안 찼으면 RECRUITING이다")
+        void recruitingWhenEndDateTodayAndOpenAndNotFull() {
+            Post post = createPostWithEndDate(1L, TODAY);
+            stubMyPosts(List.of(post));
+
+            MyPagePostListResponse response = postQueryService.retrieveMyPosts(1L, myPageRequest(null, 10, MyPagePostFilter.ALL));
+
+            assertThat(response.posts().get(0).displayStatus()).isEqualTo(MyPagePostDisplayStatus.RECRUITING);
+        }
+
+        @Test
+        @DisplayName("endDate가 미래이고 OPEN이며 정원이 안 찼으면 RECRUITING이다")
+        void recruitingWhenOpenAndNotFull() {
+            Post post = createPost(1L);
+            stubMyPosts(List.of(post));
+
+            MyPagePostListResponse response = postQueryService.retrieveMyPosts(1L, myPageRequest(null, 10, MyPagePostFilter.ALL));
+
+            assertThat(response.posts().get(0).displayStatus()).isEqualTo(MyPagePostDisplayStatus.RECRUITING);
+        }
+
+        @Test
+        @DisplayName("CLOSED 상태이고 endDate가 미래이면 RECRUITMENT_CLOSED다")
+        void recruitmentClosedWhenStatusClosed() {
+            Post post = createPost(1L);
+            ReflectionTestUtils.setField(post, "status", PostStatus.CLOSED);
+            stubMyPosts(List.of(post));
+
+            MyPagePostListResponse response = postQueryService.retrieveMyPosts(1L, myPageRequest(null, 10, MyPagePostFilter.ALL));
+
+            assertThat(response.posts().get(0).displayStatus()).isEqualTo(MyPagePostDisplayStatus.RECRUITMENT_CLOSED);
+        }
+
+        @Test
+        @DisplayName("OPEN이지만 정원이 찼으면 RECRUITMENT_CLOSED다")
+        void recruitmentClosedWhenFull() {
+            Post post = createPost(1L);
+            ReflectionTestUtils.setField(post, "recruitCapacity", 2);
+            ReflectionTestUtils.setField(post, "recruitCount", 2);
+            stubMyPosts(List.of(post));
+
+            MyPagePostListResponse response = postQueryService.retrieveMyPosts(1L, myPageRequest(null, 10, MyPagePostFilter.ALL));
+
+            assertThat(response.posts().get(0).displayStatus()).isEqualTo(MyPagePostDisplayStatus.RECRUITMENT_CLOSED);
+        }
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // 내가 작성한 게시글 - 필터
+    // ─────────────────────────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("마이페이지 상태 필터")
+    class MyPageFilter {
+
+        @Test
+        @DisplayName("RECRUITING 필터를 레포지토리에 전달한다")
+        void passesRecruitingFilterToRepository() {
+            when(postRepository.findPostsByUserId(eq(1L), eq(MyPagePostFilter.RECRUITING), isNull(), any(Pageable.class), eq(TODAY)))
+                    .thenReturn(List.of());
+            lenient().when(postRepository.countActivePostsByUserId(any(), any())).thenReturn(0);
+            lenient().when(postRepository.countRecruitingPostsByUserId(any(), any())).thenReturn(0);
+
+            postQueryService.retrieveMyPosts(1L, myPageRequest(null, 10, MyPagePostFilter.RECRUITING));
+
+            verify(postRepository).findPostsByUserId(eq(1L), eq(MyPagePostFilter.RECRUITING), isNull(), any(Pageable.class), eq(TODAY));
+        }
+
+        @Test
+        @DisplayName("TRAVEL_ENDED 필터를 레포지토리에 전달한다")
+        void passesTravelEndedFilterToRepository() {
+            when(postRepository.findPostsByUserId(eq(1L), eq(MyPagePostFilter.TRAVEL_ENDED), isNull(), any(Pageable.class), eq(TODAY)))
+                    .thenReturn(List.of());
+            lenient().when(postRepository.countActivePostsByUserId(any(), any())).thenReturn(0);
+            lenient().when(postRepository.countRecruitingPostsByUserId(any(), any())).thenReturn(0);
+
+            postQueryService.retrieveMyPosts(1L, myPageRequest(null, 10, MyPagePostFilter.TRAVEL_ENDED));
+
+            verify(postRepository).findPostsByUserId(eq(1L), eq(MyPagePostFilter.TRAVEL_ENDED), isNull(), any(Pageable.class), eq(TODAY));
+        }
+
+        @Test
+        @DisplayName("ALL 필터를 레포지토리에 전달한다")
+        void passesAllFilterToRepository() {
+            when(postRepository.findPostsByUserId(eq(1L), eq(MyPagePostFilter.ALL), isNull(), any(Pageable.class), eq(TODAY)))
+                    .thenReturn(List.of());
+            lenient().when(postRepository.countActivePostsByUserId(any(), any())).thenReturn(0);
+            lenient().when(postRepository.countRecruitingPostsByUserId(any(), any())).thenReturn(0);
+
+            postQueryService.retrieveMyPosts(1L, myPageRequest(null, 10, MyPagePostFilter.ALL));
+
+            verify(postRepository).findPostsByUserId(eq(1L), eq(MyPagePostFilter.ALL), isNull(), any(Pageable.class), eq(TODAY));
+        }
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // 내가 작성한 게시글 - 요약 카드 카운트
+    // ─────────────────────────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("요약 카드 카운트")
+    class SummaryCount {
+
+        @Test
+        @DisplayName("currentRecruitingCount와 activePostCount를 응답에 포함한다")
+        void includesSummaryCountsInResponse() {
+            when(postRepository.findPostsByUserId(any(), any(), any(), any(), any())).thenReturn(List.of());
+            when(postRepository.countRecruitingPostsByUserId(eq(1L), eq(TODAY))).thenReturn(3);
+            when(postRepository.countActivePostsByUserId(eq(1L), eq(TODAY))).thenReturn(7);
+
+            MyPagePostListResponse response = postQueryService.retrieveMyPosts(1L, myPageRequest(null, 10, MyPagePostFilter.ALL));
+
+            assertThat(response.currentRecruitingCount()).isEqualTo(3);
+            assertThat(response.activePostCount()).isEqualTo(7);
+        }
+
+        @Test
+        @DisplayName("필터와 무관하게 전체 카운트를 조회한다")
+        void countsAreIndependentOfFilter() {
+            when(postRepository.findPostsByUserId(any(), any(), any(), any(), any())).thenReturn(List.of());
+            when(postRepository.countRecruitingPostsByUserId(eq(1L), eq(TODAY))).thenReturn(2);
+            when(postRepository.countActivePostsByUserId(eq(1L), eq(TODAY))).thenReturn(5);
+
+            MyPagePostListResponse response = postQueryService.retrieveMyPosts(1L, myPageRequest(null, 10, MyPagePostFilter.TRAVEL_ENDED));
+
+            assertThat(response.currentRecruitingCount()).isEqualTo(2);
+            assertThat(response.activePostCount()).isEqualTo(5);
+            verify(postRepository).countRecruitingPostsByUserId(eq(1L), eq(TODAY));
+            verify(postRepository).countActivePostsByUserId(eq(1L), eq(TODAY));
+        }
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // 내가 작성한 게시글 - 페이지네이션
+    // ─────────────────────────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("내가 작성한 게시글")
+    class MyPosts {
+
+        @Test
+        @DisplayName("결과가 있으면 게시글 목록과 nextCursor를 반환한다")
+        void returnsPostsWithNextCursor() {
+            Long userId = 1L;
+            when(postRepository.findPostsByUserId(eq(userId), eq(MyPagePostFilter.ALL), isNull(), any(Pageable.class), eq(TODAY)))
+                    .thenReturn(List.of(createPost(10L), createPost(5L), createPost(1L)));
+            lenient().when(postRepository.countActivePostsByUserId(any(), any())).thenReturn(3);
+            lenient().when(postRepository.countRecruitingPostsByUserId(any(), any())).thenReturn(3);
+
+            MyPagePostListResponse response = postQueryService.retrieveMyPosts(userId, myPageRequest(null, 2, MyPagePostFilter.ALL));
+
+            assertThat(response.posts()).hasSize(2);
+            assertThat(response.hasNext()).isTrue();
+            assertThat(response.nextCursor()).isEqualTo(5L);
+        }
+
+        @Test
+        @DisplayName("결과가 없으면 빈 목록을 반환한다")
+        void returnsEmptyWhenNoPosts() {
+            Long userId = 1L;
+            when(postRepository.findPostsByUserId(eq(userId), eq(MyPagePostFilter.ALL), isNull(), any(Pageable.class), eq(TODAY)))
+                    .thenReturn(List.of());
+            lenient().when(postRepository.countActivePostsByUserId(any(), any())).thenReturn(0);
+            lenient().when(postRepository.countRecruitingPostsByUserId(any(), any())).thenReturn(0);
+
+            MyPagePostListResponse response = postQueryService.retrieveMyPosts(userId, myPageRequest(null, 10, MyPagePostFilter.ALL));
+
+            assertThat(response.posts()).isEmpty();
+            assertThat(response.hasNext()).isFalse();
+            assertThat(response.nextCursor()).isNull();
+        }
+
+        @Test
+        @DisplayName("커서가 있으면 레포지토리에 커서를 전달한다")
+        void passesCursorToRepository() {
+            Long userId = 1L;
+            Long cursor = 50L;
+            when(postRepository.findPostsByUserId(eq(userId), any(), eq(cursor), any(Pageable.class), eq(TODAY)))
+                    .thenReturn(List.of());
+            lenient().when(postRepository.countActivePostsByUserId(any(), any())).thenReturn(0);
+            lenient().when(postRepository.countRecruitingPostsByUserId(any(), any())).thenReturn(0);
+
+            postQueryService.retrieveMyPosts(userId, myPageRequest(cursor, 10, MyPagePostFilter.ALL));
+
+            verify(postRepository).findPostsByUserId(eq(userId), any(), eq(cursor), any(Pageable.class), eq(TODAY));
+        }
+
+        @Test
+        @DisplayName("페이지 크기 만큼만 반환하고 마지막 항목의 ID가 nextCursor다")
+        void returnsExactSizeAndCorrectNextCursor() {
+            Long userId = 1L;
+            Post post10 = createPost(10L);
+            Post post5 = createPost(5L);
+            Post post1 = createPost(1L);
+            when(postRepository.findPostsByUserId(eq(userId), any(), isNull(), any(Pageable.class), eq(TODAY)))
+                    .thenReturn(List.of(post10, post5, post1));
+            lenient().when(postRepository.countActivePostsByUserId(any(), any())).thenReturn(3);
+            lenient().when(postRepository.countRecruitingPostsByUserId(any(), any())).thenReturn(3);
+
+            MyPagePostListResponse response = postQueryService.retrieveMyPosts(userId, myPageRequest(null, 2, MyPagePostFilter.ALL));
+
+            assertThat(response.posts()).hasSize(2);
+            assertThat(response.nextCursor()).isEqualTo(5L);
+            assertThat(response.size()).isEqualTo(2);
+        }
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
     // 헬퍼
     // ─────────────────────────────────────────────────────────────────────────
+
+    private void stubMyPosts(List<Post> posts) {
+        lenient().when(postRepository.findPostsByUserId(any(), any(), any(), any(), any())).thenReturn(posts);
+        lenient().when(postRepository.countActivePostsByUserId(any(), any())).thenReturn(posts.size());
+        lenient().when(postRepository.countRecruitingPostsByUserId(any(), any())).thenReturn(0);
+    }
+
+    private MyPagePostListRequest myPageRequest(Long cursor, int size, MyPagePostFilter filter) {
+        return new MyPagePostListRequest(cursor, size, filter);
+    }
 
     private PostListRequest listRequest(int size, Long cursor) {
         return new PostListRequest(cursor, null, size, null, null, null, null, null, null, null, null, null, PostSortType.LATEST);
@@ -319,6 +561,10 @@ class PostQueryServiceTest {
     }
 
     private Post createPost(Long postId) {
+        return createPostWithEndDate(postId, TODAY.plusDays(5));
+    }
+
+    private Post createPostWithEndDate(Long postId, LocalDate endDate) {
         User user = User.builder()
                 .email("user" + postId + "@a.com")
                 .name("user" + postId)
@@ -335,13 +581,13 @@ class PostQueryServiceTest {
         Destination destination = Destination.builder()
                 .countryCode("KR").countryName("대한민국").city("서울").build();
 
-        LocalDate start = TODAY.plusDays(1);
-        LocalDate end = TODAY.plusDays(3);
+        LocalDate start = endDate.minusDays(2);
+        LocalDate recruitDeadline = endDate.minusDays(1);
         Post post = Post.createPost(
                 user, destination,
                 "서울 여행 같이 가실 분 모집합니다",
                 "함께 서울 여행할 동행자를 모집합니다. 편하게 신청해주세요.",
-                start, end, 3, end.minusDays(1),
+                start, endDate, 3, recruitDeadline,
                 Gender.U, true, null, null, null, "[]", CompanionType.FULL
         );
         ReflectionTestUtils.setField(post, "id", postId);


### PR DESCRIPTION
## 🔎 작업 내용
  * `MyPagePostFilter` enum 추가 — 탭 필터 쿼리 파라미터용 (ALL / RECRUITING / RECRUITMENT_CLOSED / TRAVEL_ENDED)
  * `MyPagePostDisplayStatus` enum 추가 — 게시글별 표시 상태 계산 (여행 종료일 기준)
  * `MyPagePostListRequest` record 추가 — 마이페이지 전용 요청 파라미터 DTO
  * `MyPagePostSummaryResponse` record 추가 — 마이페이지 게시글 카드 응답 DTO
  * `MyPagePostListResponse` record 추가 — 목록 + 커서 + totalPostCount 응답 DTO
  * `PostRepositoryCustom` / `PostRepositoryImpl` — `findPostsByUserId`, `countTotalPostsByUserId` QueryDSL 쿼리 추가
  * `PostQueryService.retrieveMyPosts` — 필터 조회, displayStatus 계산, 요약 카운트 조합 로직 추가
  * `UserController` / `UserApiDocs` 신규 생성 — `GET /api/v1/users/me/posts` 엔드포인트
  * `PostQueryServiceTest` — displayStatus 분류, 상태 필터, 요약 카운트, 페이지네이션 단위 테스트 추가

 ## 📌 참고사항
  - 마이페이지 메인의 "내가 작성한 여행글" 섹션은 `/api/v1/users/me/posts?size=3&status=ALL`로 호출한다.
    백엔드에 별도 메인용 API는 없으며, 프론트가 size와 status를 직접 지정해서 사용한다.
  - 전체보기 페이지에서도 동일 API에 cursor, size, status를 조합해 무한스크롤/필터를 처리한다.

## ➕ 이슈 링크
* CLOSED #313 

## 📝 체크리스트
- [x] 브랜치 이름은 `feat/#이슈번호-개발내용` 형식으로 작성했는가?
- [x] 커밋 메시지는 `[#이슈번호] feat(scope): 커밋 내용` 형식으로 작성했는가?
- [x] PR 제목은 `feat(scope): PR 제목` 형식으로 작성했는가?
- [x] 작업 전 Issue를 작성했는가?
- [x] `dev` 브랜치로 병합을 요청했는가?
- [x] 불필요한 주석과 공백은 제거했는가?
- [ ] 코드 리뷰어의 피드백을 반영했는가?
- [x] 테스트를 진행했는가?
- [x] 테스트 코드를 작성했는가?
