### PR TITLE
feat(mypage): 마이페이지 찜한 여행 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/dduru/gildongmu/like/controller/PostLikeController.java
+++ b/src/main/java/com/dduru/gildongmu/like/controller/PostLikeController.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class PostLikeController implements PostLikeApiDocs {
     private final PostLikeService postLikeService;
 
+    @Override
     @PostMapping("/{postId}/likes")
     public ResponseEntity<ApiResult<Void>> togglePostLike(@CurrentUser Long userId, @PathVariable Long postId) {
         postLikeService.togglePostLike(userId, postId);

--- a/src/main/java/com/dduru/gildongmu/like/repository/PostLikeRepository.java
+++ b/src/main/java/com/dduru/gildongmu/like/repository/PostLikeRepository.java
@@ -1,6 +1,7 @@
 package com.dduru.gildongmu.like.repository;
 
 import com.dduru.gildongmu.like.domain.PostLike;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -20,4 +21,19 @@ public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
 
     @Query("SELECT pl.user.id FROM PostLike pl WHERE pl.post.id = :postId")
     List<Long> findUserIdsByPostId(@Param("postId") Long postId);
+
+    @Query("""
+            SELECT pl FROM PostLike pl
+            JOIN FETCH pl.post post
+            JOIN FETCH post.destination
+            WHERE pl.user.id = :userId
+              AND post.isDeleted = false
+              AND (:cursor IS NULL OR pl.id < :cursor)
+            ORDER BY pl.id DESC
+            """)
+    List<PostLike> findLikedPostsByUserIdWithCursor(
+            @Param("userId") Long userId,
+            @Param("cursor") Long cursor,
+            Pageable pageable
+    );
 }

--- a/src/main/java/com/dduru/gildongmu/post/dto/request/MyPageLikedPostListRequest.java
+++ b/src/main/java/com/dduru/gildongmu/post/dto/request/MyPageLikedPostListRequest.java
@@ -1,0 +1,14 @@
+package com.dduru.gildongmu.post.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record MyPageLikedPostListRequest(
+        @Schema(description = "다음 페이지 조회용 커서 (PostLike ID). 첫 페이지에서는 생략합니다.", example = "120", nullable = true)
+        Long cursor,
+        @Schema(description = "페이지 크기. 생략하거나 1 미만 또는 50 초과이면 10으로 보정됩니다.", example = "10")
+        Integer size
+) {
+    public MyPageLikedPostListRequest {
+        if (size == null || size <= 0 || size > 50) size = 10;
+    }
+}

--- a/src/main/java/com/dduru/gildongmu/post/dto/response/MyPageLikedPostListResponse.java
+++ b/src/main/java/com/dduru/gildongmu/post/dto/response/MyPageLikedPostListResponse.java
@@ -1,0 +1,25 @@
+package com.dduru.gildongmu.post.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+public record MyPageLikedPostListResponse(
+        @Schema(description = "찜한 게시글 목록")
+        List<MyPageLikedPostSummaryResponse> posts,
+        @Schema(description = "다음 페이지 조회용 커서 (PostLike ID). hasNext=false이면 null입니다.", nullable = true)
+        Long nextCursor,
+        @Schema(description = "다음 페이지 존재 여부", example = "true")
+        boolean hasNext,
+        @Schema(description = "현재 응답에 포함된 게시글 수", example = "10")
+        int size
+) {
+    public static MyPageLikedPostListResponse of(
+            List<MyPageLikedPostSummaryResponse> posts,
+            boolean hasNext,
+            Long lastLikeId
+    ) {
+        Long nextCursor = hasNext ? lastLikeId : null;
+        return new MyPageLikedPostListResponse(posts, nextCursor, hasNext, posts.size());
+    }
+}

--- a/src/main/java/com/dduru/gildongmu/post/dto/response/MyPageLikedPostSummaryResponse.java
+++ b/src/main/java/com/dduru/gildongmu/post/dto/response/MyPageLikedPostSummaryResponse.java
@@ -1,0 +1,29 @@
+package com.dduru.gildongmu.post.dto.response;
+
+import com.dduru.gildongmu.post.domain.Post;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDate;
+
+public record MyPageLikedPostSummaryResponse(
+        @Schema(description = "게시글 ID", example = "101")
+        Long id,
+        @Schema(description = "게시글 제목", example = "제주도 2박 3일 동행 구해요")
+        String title,
+        @Schema(description = "여행지 도시명", example = "제주")
+        String destination,
+        @Schema(description = "여행 시작일", example = "2026-07-10")
+        LocalDate startDate,
+        @Schema(description = "여행 종료일", example = "2026-07-12")
+        LocalDate endDate
+) {
+    public static MyPageLikedPostSummaryResponse from(Post post) {
+        return new MyPageLikedPostSummaryResponse(
+                post.getId(),
+                post.getTitle(),
+                post.getDestination().getCity(),
+                post.getStartDate(),
+                post.getEndDate()
+        );
+    }
+}

--- a/src/main/java/com/dduru/gildongmu/post/service/PostQueryService.java
+++ b/src/main/java/com/dduru/gildongmu/post/service/PostQueryService.java
@@ -1,11 +1,15 @@
 package com.dduru.gildongmu.post.service;
 
 import com.dduru.gildongmu.common.time.TimeProvider;
+import com.dduru.gildongmu.like.domain.PostLike;
 import com.dduru.gildongmu.like.repository.PostLikeRepository;
 import com.dduru.gildongmu.post.domain.Post;
 import com.dduru.gildongmu.post.domain.enums.PostSortType;
+import com.dduru.gildongmu.post.dto.request.MyPageLikedPostListRequest;
 import com.dduru.gildongmu.post.dto.request.MyPagePostListRequest;
 import com.dduru.gildongmu.post.dto.request.PostListRequest;
+import com.dduru.gildongmu.post.dto.response.MyPageLikedPostListResponse;
+import com.dduru.gildongmu.post.dto.response.MyPageLikedPostSummaryResponse;
 import com.dduru.gildongmu.post.dto.response.MyPagePostListResponse;
 import com.dduru.gildongmu.post.dto.response.MyPagePostSummaryResponse;
 import com.dduru.gildongmu.post.dto.response.PostListResponse;
@@ -79,6 +83,18 @@ public class PostQueryService {
         int currentRecruitingCount = postRepository.countRecruitingPostsByUserId(userId, today);
         int activePostCount = postRepository.countActivePostsByUserId(userId, today);
         return MyPagePostListResponse.of(summaries, hasNext, currentRecruitingCount, activePostCount);
+    }
+
+    public MyPageLikedPostListResponse retrieveMyLikedPosts(Long userId, MyPageLikedPostListRequest request) {
+        Pageable pageable = PageRequest.of(0, request.size() + 1);
+        List<PostLike> postLikes = postLikeRepository.findLikedPostsByUserIdWithCursor(userId, request.cursor(), pageable);
+        boolean hasNext = postLikes.size() > request.size();
+        if (hasNext) postLikes = postLikes.subList(0, request.size());
+        List<MyPageLikedPostSummaryResponse> summaries = postLikes.stream()
+                .map(like -> MyPageLikedPostSummaryResponse.from(like.getPost()))
+                .toList();
+        Long lastLikeId = postLikes.isEmpty() ? null : postLikes.get(postLikes.size() - 1).getId();
+        return MyPageLikedPostListResponse.of(summaries, hasNext, lastLikeId);
     }
 
     private Integer computeNextCursorValue(PostSortType sort, boolean hasNext, List<Post> posts) {

--- a/src/main/java/com/dduru/gildongmu/user/controller/UserApiDocs.java
+++ b/src/main/java/com/dduru/gildongmu/user/controller/UserApiDocs.java
@@ -3,7 +3,9 @@ package com.dduru.gildongmu.user.controller;
 import com.dduru.gildongmu.common.annotation.ApiErrorResponses;
 import com.dduru.gildongmu.common.dto.ApiResult;
 import com.dduru.gildongmu.common.exception.ErrorCode;
+import com.dduru.gildongmu.post.dto.request.MyPageLikedPostListRequest;
 import com.dduru.gildongmu.post.dto.request.MyPagePostListRequest;
+import com.dduru.gildongmu.post.dto.response.MyPageLikedPostListResponse;
 import com.dduru.gildongmu.post.dto.response.MyPagePostListResponse;
 import com.dduru.gildongmu.recommendation.dto.request.TravelPreferenceUpdateRequest;
 import com.dduru.gildongmu.recommendation.dto.response.TravelPreferenceResponse;
@@ -31,6 +33,20 @@ public interface UserApiDocs {
     ResponseEntity<ApiResult<MyPagePostListResponse>> retrieveMyPosts(
             @Parameter(hidden = true) Long userId,
             @Valid @ParameterObject MyPagePostListRequest request
+    );
+
+    @Operation(
+            summary = "찜한 여행 목록 조회",
+            description = "내가 찜한 여행글 목록을 커서 기반 페이지네이션으로 조회합니다. 삭제된 게시글은 제외됩니다.",
+            security = @SecurityRequirement(name = "JWT")
+    )
+    @ApiResponse(responseCode = "200", description = "조회 성공")
+    @ApiErrorResponses({
+            ErrorCode.UNAUTHORIZED
+    })
+    ResponseEntity<ApiResult<MyPageLikedPostListResponse>> retrieveMyLikedPosts(
+            @Parameter(hidden = true) Long userId,
+            @Valid @ParameterObject MyPageLikedPostListRequest request
     );
 
     @Operation(

--- a/src/main/java/com/dduru/gildongmu/user/controller/UserController.java
+++ b/src/main/java/com/dduru/gildongmu/user/controller/UserController.java
@@ -2,7 +2,9 @@ package com.dduru.gildongmu.user.controller;
 
 import com.dduru.gildongmu.common.annotation.CurrentUser;
 import com.dduru.gildongmu.common.dto.ApiResult;
+import com.dduru.gildongmu.post.dto.request.MyPageLikedPostListRequest;
 import com.dduru.gildongmu.post.dto.request.MyPagePostListRequest;
+import com.dduru.gildongmu.post.dto.response.MyPageLikedPostListResponse;
 import com.dduru.gildongmu.post.dto.response.MyPagePostListResponse;
 import com.dduru.gildongmu.post.service.PostQueryService;
 import com.dduru.gildongmu.recommendation.dto.request.TravelPreferenceUpdateRequest;
@@ -21,6 +23,15 @@ public class UserController implements UserApiDocs {
 
     private final PostQueryService postQueryService;
     private final TravelPreferenceService travelPreferenceService;
+
+    @Override
+    @GetMapping("/liked-posts")
+    public ResponseEntity<ApiResult<MyPageLikedPostListResponse>> retrieveMyLikedPosts(
+            @CurrentUser Long userId,
+            @Valid MyPageLikedPostListRequest request
+    ) {
+        return ResponseEntity.ok(ApiResult.ok(postQueryService.retrieveMyLikedPosts(userId, request)));
+    }
 
     @Override
     @GetMapping("/posts")

--- a/src/test/java/com/dduru/gildongmu/post/service/PostQueryServiceTest.java
+++ b/src/test/java/com/dduru/gildongmu/post/service/PostQueryServiceTest.java
@@ -2,14 +2,17 @@ package com.dduru.gildongmu.post.service;
 
 import com.dduru.gildongmu.common.time.TimeProvider;
 import com.dduru.gildongmu.destination.domain.Destination;
+import com.dduru.gildongmu.like.domain.PostLike;
 import com.dduru.gildongmu.like.repository.PostLikeRepository;
 import com.dduru.gildongmu.post.domain.Post;
 import com.dduru.gildongmu.post.domain.enums.CompanionType;
 import com.dduru.gildongmu.post.domain.enums.MyPagePostFilter;
 import com.dduru.gildongmu.post.domain.enums.PostSortType;
 import com.dduru.gildongmu.post.domain.enums.PostStatus;
+import com.dduru.gildongmu.post.dto.request.MyPageLikedPostListRequest;
 import com.dduru.gildongmu.post.dto.request.MyPagePostListRequest;
 import com.dduru.gildongmu.post.dto.request.PostListRequest;
+import com.dduru.gildongmu.post.dto.response.MyPageLikedPostListResponse;
 import com.dduru.gildongmu.post.dto.response.MyPagePostDisplayStatus;
 import com.dduru.gildongmu.post.dto.response.MyPagePostListResponse;
 import com.dduru.gildongmu.post.dto.response.PostListResponse;
@@ -539,6 +542,92 @@ class PostQueryServiceTest {
     }
 
     // ─────────────────────────────────────────────────────────────────────────
+    // 찜한 여행 목록
+    // ─────────────────────────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("찜한 여행 목록")
+    class MyLikedPosts {
+
+        @Test
+        @DisplayName("결과가 있으면 찜한 게시글 목록과 nextCursor를 반환한다")
+        void returnsLikedPostsWithNextCursor() {
+            Long userId = 1L;
+            PostLike like10 = createPostLike(10L, createPost(1L));
+            PostLike like5 = createPostLike(5L, createPost(2L));
+            PostLike like1 = createPostLike(1L, createPost(3L));
+            when(postLikeRepository.findLikedPostsByUserIdWithCursor(eq(userId), isNull(), any(Pageable.class)))
+                    .thenReturn(List.of(like10, like5, like1));
+
+            MyPageLikedPostListResponse response = postQueryService.retrieveMyLikedPosts(userId, likedPostRequest(null, 2));
+
+            assertThat(response.posts()).hasSize(2);
+            assertThat(response.hasNext()).isTrue();
+            assertThat(response.nextCursor()).isEqualTo(5L);
+        }
+
+        @Test
+        @DisplayName("결과가 없으면 빈 목록을 반환한다")
+        void returnsEmptyWhenNoLikedPosts() {
+            Long userId = 1L;
+            when(postLikeRepository.findLikedPostsByUserIdWithCursor(eq(userId), isNull(), any(Pageable.class)))
+                    .thenReturn(List.of());
+
+            MyPageLikedPostListResponse response = postQueryService.retrieveMyLikedPosts(userId, likedPostRequest(null, 10));
+
+            assertThat(response.posts()).isEmpty();
+            assertThat(response.hasNext()).isFalse();
+            assertThat(response.nextCursor()).isNull();
+        }
+
+        @Test
+        @DisplayName("커서가 있으면 레포지토리에 커서를 전달한다")
+        void passesCursorToRepository() {
+            Long userId = 1L;
+            Long cursor = 50L;
+            when(postLikeRepository.findLikedPostsByUserIdWithCursor(eq(userId), eq(cursor), any(Pageable.class)))
+                    .thenReturn(List.of());
+
+            postQueryService.retrieveMyLikedPosts(userId, likedPostRequest(cursor, 10));
+
+            verify(postLikeRepository).findLikedPostsByUserIdWithCursor(eq(userId), eq(cursor), any(Pageable.class));
+        }
+
+        @Test
+        @DisplayName("페이지 크기만큼만 반환하고 마지막 PostLike ID가 nextCursor다")
+        void returnsExactSizeAndCorrectNextCursor() {
+            Long userId = 1L;
+            PostLike like10 = createPostLike(10L, createPost(1L));
+            PostLike like5 = createPostLike(5L, createPost(2L));
+            PostLike like1 = createPostLike(1L, createPost(3L));
+            when(postLikeRepository.findLikedPostsByUserIdWithCursor(eq(userId), isNull(), any(Pageable.class)))
+                    .thenReturn(List.of(like10, like5, like1));
+
+            MyPageLikedPostListResponse response = postQueryService.retrieveMyLikedPosts(userId, likedPostRequest(null, 2));
+
+            assertThat(response.posts()).hasSize(2);
+            assertThat(response.nextCursor()).isEqualTo(5L);
+            assertThat(response.size()).isEqualTo(2);
+        }
+
+        @Test
+        @DisplayName("정확히 size개 결과이면 hasNext=false이고 nextCursor=null이다")
+        void returnsHasNextFalseWhenExactSize() {
+            Long userId = 1L;
+            PostLike like5 = createPostLike(5L, createPost(1L));
+            PostLike like3 = createPostLike(3L, createPost(2L));
+            when(postLikeRepository.findLikedPostsByUserIdWithCursor(eq(userId), isNull(), any(Pageable.class)))
+                    .thenReturn(List.of(like5, like3));
+
+            MyPageLikedPostListResponse response = postQueryService.retrieveMyLikedPosts(userId, likedPostRequest(null, 2));
+
+            assertThat(response.posts()).hasSize(2);
+            assertThat(response.hasNext()).isFalse();
+            assertThat(response.nextCursor()).isNull();
+        }
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
     // 헬퍼
     // ─────────────────────────────────────────────────────────────────────────
 
@@ -550,6 +639,16 @@ class PostQueryServiceTest {
 
     private MyPagePostListRequest myPageRequest(Long cursor, int size, MyPagePostFilter filter) {
         return new MyPagePostListRequest(cursor, size, filter);
+    }
+
+    private MyPageLikedPostListRequest likedPostRequest(Long cursor, int size) {
+        return new MyPageLikedPostListRequest(cursor, size);
+    }
+
+    private PostLike createPostLike(Long likeId, Post post) {
+        PostLike postLike = PostLike.createPostLike(null, post);
+        ReflectionTestUtils.setField(postLike, "id", likeId);
+        return postLike;
     }
 
     private PostListRequest listRequest(int size, Long cursor) {


### PR DESCRIPTION
## 🔎 작업 내용
  * 찜한 여행 목록 조회 요청 DTO 추가 (`MyPageLikedPostListRequest`) — cursor(PostLike ID), size 파라미터, size 범위 초과 시 10으로 자동 보정
  * 찜한 여행 목록 단건 응답 DTO 추가 (`MyPageLikedPostSummaryResponse`) — id, title, destination, startDate, endDate
  * 찜한 여행 목록 응답 DTO 추가 (`MyPageLikedPostListResponse`) — posts, nextCursor, hasNext, size
  * `PostLikeRepository`에 커서 기반 찜 목록 조회 쿼리 추가 (`findLikedPostsByUserIdWithCursor`) — PostLike.id DESC 정렬, 소프트 삭제 게시글 제외, JOIN FETCH로 N+1 방지
  * `PostQueryService`에 찜한 여행 목록 조회 서비스 메서드 추가 (`retrieveMyLikedPosts`) — size+1 트릭으로 hasNext 판단, 별도 COUNT 쿼리 없음
  * `UserController` / `UserApiDocs`에 `GET /api/v1/users/me/liked-posts` 엔드포인트 추가
  * `PostQueryServiceTest`에 찜한 여행 목록 단위 테스트  추가
  
## ➕ 이슈 링크
* Closes #320 


## 📝 체크리스트
- [x] 브랜치 이름은 `feat/#이슈번호-개발내용` 형식으로 작성했는가?
- [x] 커밋 메시지는 `[#이슈번호] feat(scope): 커밋 내용` 형식으로 작성했는가?
- [x] PR 제목은 `feat(scope): PR 제목` 형식으로 작성했는가?
- [x] 작업 전 Issue를 작성했는가?
- [x] `dev` 브랜치로 병합을 요청했는가?
- [x] 불필요한 주석과 공백은 제거했는가?
- [ ] 코드 리뷰어의 피드백을 반영했는가?
- [x] 테스트를 진행했는가?
- [x] 테스트 코드를 작성했는가?
