### PR TITLE
refactor(time): 현재 시간 계산 TimeProvider 기준으로 통일

### DIFF
--- a/src/main/java/com/dduru/gildongmu/admin/post/service/AdminPostService.java
+++ b/src/main/java/com/dduru/gildongmu/admin/post/service/AdminPostService.java
@@ -1,6 +1,7 @@
 package com.dduru.gildongmu.admin.post.service;
 
 import com.dduru.gildongmu.admin.post.dto.response.AdminPostDetailResponse;
+import com.dduru.gildongmu.common.time.TimeProvider;
 import com.dduru.gildongmu.common.util.JsonConverter;
 import com.dduru.gildongmu.post.domain.Post;
 import com.dduru.gildongmu.post.repository.PostRepository;
@@ -17,6 +18,7 @@ public class AdminPostService {
 
     private final PostRepository postRepository;
     private final JsonConverter jsonConverter;
+    private final TimeProvider timeProvider;
 
     public AdminPostDetailResponse getDetail(Long postId) {
         Post post = postRepository.getByIdOrThrow(postId);
@@ -31,7 +33,7 @@ public class AdminPostService {
             return;
         }
 
-        post.softDelete(adminUserId);
+        post.softDelete(adminUserId, timeProvider.now());
         log.info("관리자 게시글 삭제됨 - postId={}, adminUserId={}", postId, adminUserId);
     }
 }

--- a/src/main/java/com/dduru/gildongmu/admin/report/service/AdminReportService.java
+++ b/src/main/java/com/dduru/gildongmu/admin/report/service/AdminReportService.java
@@ -3,6 +3,7 @@ package com.dduru.gildongmu.admin.report.service;
 import com.dduru.gildongmu.admin.report.dto.request.AdminReportUpdateRequest;
 import com.dduru.gildongmu.admin.report.dto.response.AdminReportListResponse;
 import com.dduru.gildongmu.admin.report.dto.response.AdminReportResponse;
+import com.dduru.gildongmu.common.time.TimeProvider;
 import com.dduru.gildongmu.report.domain.Report;
 import com.dduru.gildongmu.report.domain.enums.ReportStatus;
 import com.dduru.gildongmu.report.exception.ReportNotFoundException;
@@ -24,6 +25,7 @@ public class AdminReportService {
 
     private final ReportRepository reportRepository;
     private final UserRepository userRepository;
+    private final TimeProvider timeProvider;
 
     public AdminReportListResponse findAll(ReportStatus status, Pageable pageable) {
         Page<Report> page = reportRepository.findAllByStatusOptional(status, pageable);
@@ -35,7 +37,7 @@ public class AdminReportService {
         Report report = reportRepository.findById(reportId)
                 .orElseThrow(ReportNotFoundException::new);
         User reviewer = userRepository.getByIdOrThrow(reviewerId);
-        report.updateByAdmin(request.status(), reviewer, request.reviewNote());
+        report.updateByAdmin(request.status(), reviewer, request.reviewNote(), timeProvider.now());
         log.info("신고 처리 완료 - reportId={}, status={}, reviewerId={}", reportId, request.status(), reviewerId);
         return AdminReportResponse.from(report);
     }

--- a/src/main/java/com/dduru/gildongmu/common/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/dduru/gildongmu/common/jwt/JwtTokenProvider.java
@@ -1,5 +1,6 @@
 package com.dduru.gildongmu.common.jwt;
 
+import com.dduru.gildongmu.common.time.TimeProvider;
 import com.dduru.gildongmu.user.domain.User;
 import com.dduru.gildongmu.user.domain.enums.Role;
 import com.dduru.gildongmu.user.repository.UserRepository;
@@ -12,7 +13,6 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.stereotype.Component;
 
-import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Collections;
@@ -26,7 +26,7 @@ public class JwtTokenProvider {
     private static final String ROLE_CLAIM = "role";
 
     private final UserRepository userRepository;
-    private final Clock clock;
+    private final TimeProvider timeProvider;
 
     @Value("${jwt.secret}")
     private String jwtSecret;
@@ -38,7 +38,7 @@ public class JwtTokenProvider {
     private long jwtRefreshExpirationMs;
 
     public String createToken(Long userId, Role role) {
-        Instant issuedAt = clock.instant();
+        Instant issuedAt = timeProvider.instant();
 
         return Jwts.builder()
                 .setSubject(userId.toString())
@@ -51,7 +51,7 @@ public class JwtTokenProvider {
     }
 
     public String createRefreshToken(Long userId) {
-        Instant issuedAt = clock.instant();
+        Instant issuedAt = timeProvider.instant();
 
         return Jwts.builder()
                 .setSubject(userId.toString())
@@ -151,7 +151,7 @@ public class JwtTokenProvider {
     }
 
     public String createVerificationToken(Long userId, String phoneNumber) {
-        Instant issuedAt = clock.instant();
+        Instant issuedAt = timeProvider.instant();
 
         String subject = userId != null ? userId.toString() : phoneNumber;
 

--- a/src/main/java/com/dduru/gildongmu/common/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/dduru/gildongmu/common/jwt/JwtTokenProvider.java
@@ -12,6 +12,9 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.stereotype.Component;
 
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.Collections;
 import java.util.Date;
 
@@ -23,6 +26,7 @@ public class JwtTokenProvider {
     private static final String ROLE_CLAIM = "role";
 
     private final UserRepository userRepository;
+    private final Clock clock;
 
     @Value("${jwt.secret}")
     private String jwtSecret;
@@ -34,26 +38,26 @@ public class JwtTokenProvider {
     private long jwtRefreshExpirationMs;
 
     public String createToken(Long userId, Role role) {
-        Date expiryDate = new Date(System.currentTimeMillis() + jwtExpirationMs);
+        Instant issuedAt = clock.instant();
 
         return Jwts.builder()
                 .setSubject(userId.toString())
                 .claim("type", "access")
                 .claim(ROLE_CLAIM, role.name())
-                .setIssuedAt(new Date())
-                .setExpiration(expiryDate)
+                .setIssuedAt(toDate(issuedAt))
+                .setExpiration(toDate(issuedAt.plus(Duration.ofMillis(jwtExpirationMs))))
                 .signWith(SignatureAlgorithm.HS512, jwtSecret)
                 .compact();
     }
 
     public String createRefreshToken(Long userId) {
-        Date expiryDate = new Date(System.currentTimeMillis() + jwtRefreshExpirationMs);
+        Instant issuedAt = clock.instant();
 
         return Jwts.builder()
                 .setSubject(userId.toString())
                 .claim("type", "refresh")
-                .setIssuedAt(new Date())
-                .setExpiration(expiryDate)
+                .setIssuedAt(toDate(issuedAt))
+                .setExpiration(toDate(issuedAt.plus(Duration.ofMillis(jwtRefreshExpirationMs))))
                 .signWith(SignatureAlgorithm.HS512, jwtSecret)
                 .compact();
     }
@@ -147,7 +151,7 @@ public class JwtTokenProvider {
     }
 
     public String createVerificationToken(Long userId, String phoneNumber) {
-        Date expiryDate = new Date(System.currentTimeMillis() + jwtExpirationMs);
+        Instant issuedAt = clock.instant();
 
         String subject = userId != null ? userId.toString() : phoneNumber;
 
@@ -155,8 +159,8 @@ public class JwtTokenProvider {
                 .setSubject(subject)
                 .claim("type", "verification")
                 .claim("phone_number", phoneNumber)
-                .setIssuedAt(new Date())
-                .setExpiration(expiryDate)
+                .setIssuedAt(toDate(issuedAt))
+                .setExpiration(toDate(issuedAt.plus(Duration.ofMillis(jwtExpirationMs))))
                 .signWith(SignatureAlgorithm.HS512, jwtSecret)
                 .compact();
     }
@@ -210,5 +214,9 @@ public class JwtTokenProvider {
                 .setSigningKey(jwtSecret)
                 .parseClaimsJws(token)
                 .getBody();
+    }
+
+    private static Date toDate(Instant instant) {
+        return Date.from(instant);
     }
 }

--- a/src/main/java/com/dduru/gildongmu/common/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/dduru/gildongmu/common/jwt/JwtTokenProvider.java
@@ -44,8 +44,8 @@ public class JwtTokenProvider {
                 .setSubject(userId.toString())
                 .claim("type", "access")
                 .claim(ROLE_CLAIM, role.name())
-                .setIssuedAt(toDate(issuedAt))
-                .setExpiration(toDate(issuedAt.plus(Duration.ofMillis(jwtExpirationMs))))
+                .setIssuedAt(Date.from(issuedAt))
+                .setExpiration(Date.from(issuedAt.plus(Duration.ofMillis(jwtExpirationMs))))
                 .signWith(SignatureAlgorithm.HS512, jwtSecret)
                 .compact();
     }
@@ -56,8 +56,8 @@ public class JwtTokenProvider {
         return Jwts.builder()
                 .setSubject(userId.toString())
                 .claim("type", "refresh")
-                .setIssuedAt(toDate(issuedAt))
-                .setExpiration(toDate(issuedAt.plus(Duration.ofMillis(jwtRefreshExpirationMs))))
+                .setIssuedAt(Date.from(issuedAt))
+                .setExpiration(Date.from(issuedAt.plus(Duration.ofMillis(jwtRefreshExpirationMs))))
                 .signWith(SignatureAlgorithm.HS512, jwtSecret)
                 .compact();
     }
@@ -159,8 +159,8 @@ public class JwtTokenProvider {
                 .setSubject(subject)
                 .claim("type", "verification")
                 .claim("phone_number", phoneNumber)
-                .setIssuedAt(toDate(issuedAt))
-                .setExpiration(toDate(issuedAt.plus(Duration.ofMillis(jwtExpirationMs))))
+                .setIssuedAt(Date.from(issuedAt))
+                .setExpiration(Date.from(issuedAt.plus(Duration.ofMillis(jwtExpirationMs))))
                 .signWith(SignatureAlgorithm.HS512, jwtSecret)
                 .compact();
     }
@@ -216,7 +216,4 @@ public class JwtTokenProvider {
                 .getBody();
     }
 
-    private static Date toDate(Instant instant) {
-        return Date.from(instant);
-    }
 }

--- a/src/main/java/com/dduru/gildongmu/common/time/TimeProvider.java
+++ b/src/main/java/com/dduru/gildongmu/common/time/TimeProvider.java
@@ -3,6 +3,7 @@ package com.dduru.gildongmu.common.time;
 import org.springframework.stereotype.Component;
 
 import java.time.Clock;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -22,6 +23,10 @@ public class TimeProvider {
 
     public LocalDate today() {
         return LocalDate.now(clock);
+    }
+
+    public Instant instant() {
+        return clock.instant();
     }
 
     public ZoneId zoneId() {

--- a/src/main/java/com/dduru/gildongmu/destination/service/DestinationService.java
+++ b/src/main/java/com/dduru/gildongmu/destination/service/DestinationService.java
@@ -1,5 +1,6 @@
 package com.dduru.gildongmu.destination.service;
 
+import com.dduru.gildongmu.common.time.TimeProvider;
 import com.dduru.gildongmu.destination.domain.Destination;
 import com.dduru.gildongmu.destination.dto.DestinationInfo;
 import com.dduru.gildongmu.destination.repository.DestinationRepository;
@@ -28,9 +29,10 @@ public class DestinationService {
     );
 
     private final DestinationRepository destinationRepository;
+    private final TimeProvider timeProvider;
 
     public List<DestinationInfo> getPopularDestinations() {
-        LocalDateTime since = LocalDateTime.now().minusDays(POPULAR_DAYS_LIMIT);
+        LocalDateTime since = timeProvider.now().minusDays(POPULAR_DAYS_LIMIT);
         List<Long> ids = destinationRepository.findPopularDestinationIds(since);
 
         if (ids.isEmpty()) {

--- a/src/main/java/com/dduru/gildongmu/participation/domain/Participation.java
+++ b/src/main/java/com/dduru/gildongmu/participation/domain/Participation.java
@@ -64,22 +64,22 @@ public class Participation extends BaseTimeEntity {
                 .build();
     }
 
-    public void approve() {
+    public void approve(LocalDateTime now) {
         validateApprovalAllowed();
         this.status = ParticipationStatus.APPROVED;
-        this.approvedAt = LocalDateTime.now();
+        this.approvedAt = now;
     }
 
-    public void contact() {
+    public void contact(LocalDateTime now) {
         validateContactAllowed();
         this.status = ParticipationStatus.CONTACTING;
-        this.contactedAt = LocalDateTime.now();
+        this.contactedAt = now;
     }
 
-    public void reject() {
+    public void reject(LocalDateTime now) {
         validateRejectionAllowed();
         this.status = ParticipationStatus.REJECTED;
-        this.rejectedAt = LocalDateTime.now();
+        this.rejectedAt = now;
     }
 
     public boolean isPending() {

--- a/src/main/java/com/dduru/gildongmu/participation/service/ParticipationCommandService.java
+++ b/src/main/java/com/dduru/gildongmu/participation/service/ParticipationCommandService.java
@@ -63,7 +63,7 @@ public class ParticipationCommandService {
 
         PrivateChatRoomCreateResponse room = privateChatRoomService.createOrGetRoomWithLockedPost(userId, lockedPost, participantUserId);
 
-        participation.contact();
+        participation.contact(timeProvider.now());
         loggingStatusChange(participation);
 
         return new ParticipationContactResponse(
@@ -82,7 +82,7 @@ public class ParticipationCommandService {
         validatePostOwner(lockedPost, userId);
         lockedPost.validateIsOpen();
 
-        lockedPost.approveParticipation(participation);
+        lockedPost.approveParticipation(participation, timeProvider.now());
         Journey journey = journeyRepository.getByPostIdOrThrow(lockedPost.getId());
         // 신청 이력은 participations에, 협업 멤버는 journey_members에 남긴다.
         // REMOVED 상태 멤버가 있으면 재활성화하고, 없을 때만 새로 저장한다 (unique 제약 보장).
@@ -115,7 +115,7 @@ public class ParticipationCommandService {
         validatePostOwner(lockedPost, userId);
         lockedPost.validateIsOpen();
 
-        participation.reject();
+        participation.reject(timeProvider.now());
         loggingStatusChange(participation);
     }
 

--- a/src/main/java/com/dduru/gildongmu/post/domain/Post.java
+++ b/src/main/java/com/dduru/gildongmu/post/domain/Post.java
@@ -204,9 +204,9 @@ public class Post extends BaseTimeEntity {
         this.recruitDeadline = endDate.minusDays(1);
     }
 
-    public void softDelete(Long userId) {
+    public void softDelete(Long userId, LocalDateTime now) {
         this.isDeleted = true;
-        this.deletedAt = LocalDateTime.now();
+        this.deletedAt = now;
         this.deletedBy = userId;
     }
 
@@ -214,8 +214,8 @@ public class Post extends BaseTimeEntity {
         this.status = newStatus;
     }
 
-    public void approveParticipation(Participation participation) {
-        participation.approve();
+    public void approveParticipation(Participation participation, LocalDateTime now) {
+        participation.approve(now);
         incrementRecruitCount();
     }
 

--- a/src/main/java/com/dduru/gildongmu/post/service/PostService.java
+++ b/src/main/java/com/dduru/gildongmu/post/service/PostService.java
@@ -104,7 +104,7 @@ public class PostService {
     public void delete(Long postId, Long userId) {
         Post post = getOwnedPost(postId, userId);
 
-        post.softDelete(userId);
+        post.softDelete(userId, timeProvider.now());
         superHostService.cancelActiveExposureByPostId(postId);
 
         log.info("게시글 삭제됨 - postId={}, userId={}", postId, userId);

--- a/src/main/java/com/dduru/gildongmu/profile/service/NicknameService.java
+++ b/src/main/java/com/dduru/gildongmu/profile/service/NicknameService.java
@@ -21,7 +21,6 @@ public class NicknameService {
 
     private static final int NICKNAME_MAX_RETRY_ATTEMPTS = 10;
     private static final String FALLBACK_NICKNAME_PREFIX = "뚜비";
-    private static final int FALLBACK_RANDOM_BOUND = 10000;
 
     private final NicknameGenerator nicknameGenerator;
     private final ProfileRepository profileRepository;
@@ -64,7 +63,7 @@ public class NicknameService {
             }
         }
 
-        String fallbackNickname = FALLBACK_NICKNAME_PREFIX + (System.currentTimeMillis() % FALLBACK_RANDOM_BOUND);
+        String fallbackNickname = FALLBACK_NICKNAME_PREFIX + nicknameGenerator.generateRandomNumber();
         log.warn("유니크한 닉네임 생성에 {}회 실패하여 대체 닉네임 사용: {}", NICKNAME_MAX_RETRY_ATTEMPTS, fallbackNickname);
         return NicknameRandomResponse.of(fallbackNickname);
     }

--- a/src/main/java/com/dduru/gildongmu/report/domain/Report.java
+++ b/src/main/java/com/dduru/gildongmu/report/domain/Report.java
@@ -70,10 +70,10 @@ public class Report extends BaseTimeEntity {
                 .build();
     }
 
-    public void updateByAdmin(ReportStatus newStatus, User reviewer, String reviewNote) {
+    public void updateByAdmin(ReportStatus newStatus, User reviewer, String reviewNote, LocalDateTime now) {
         this.status = newStatus;
         this.reviewer = reviewer;
-        this.reviewedAt = LocalDateTime.now();
+        this.reviewedAt = now;
         this.reviewNote = reviewNote;
     }
 }

--- a/src/main/java/com/dduru/gildongmu/verification/service/VerificationCodeService.java
+++ b/src/main/java/com/dduru/gildongmu/verification/service/VerificationCodeService.java
@@ -1,6 +1,7 @@
 package com.dduru.gildongmu.verification.service;
 
 import com.dduru.gildongmu.common.exception.InternalServerException;
+import com.dduru.gildongmu.common.time.TimeProvider;
 import com.dduru.gildongmu.verification.dto.VerificationData;
 import com.dduru.gildongmu.verification.exception.*;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -26,6 +27,7 @@ public class VerificationCodeService {
 
     private final RedisTemplate<String, String> redisTemplate;
     private final ObjectMapper objectMapper;
+    private final TimeProvider timeProvider;
     
     private static final String REDIS_KEY_PREFIX = "sms:auth:";
     private static final String DAILY_LIMIT_KEY_PREFIX = "sms:daily:";
@@ -91,7 +93,7 @@ public class VerificationCodeService {
         VerificationData data = createVerificationData(phoneNumber, code);
         saveVerificationData(phoneNumber, data);
 
-        LocalDateTime expiresAt = LocalDateTime.now().plusMinutes(EXPIRATION_MINUTES);
+        LocalDateTime expiresAt = timeProvider.now().plusMinutes(EXPIRATION_MINUTES);
         
         return new VerificationCreateResult(code, expiresAt);
     }

--- a/src/test/java/com/dduru/gildongmu/admin/post/service/AdminPostServiceTest.java
+++ b/src/test/java/com/dduru/gildongmu/admin/post/service/AdminPostServiceTest.java
@@ -1,6 +1,7 @@
 package com.dduru.gildongmu.admin.post.service;
 
 import com.dduru.gildongmu.admin.post.dto.response.AdminPostDetailResponse;
+import com.dduru.gildongmu.common.time.TimeProvider;
 import com.dduru.gildongmu.common.util.JsonConverter;
 import com.dduru.gildongmu.destination.domain.Destination;
 import com.dduru.gildongmu.post.domain.Post;
@@ -20,6 +21,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -32,11 +34,16 @@ import static org.mockito.Mockito.when;
 @DisplayName("AdminPostService 테스트")
 class AdminPostServiceTest {
 
+    private static final LocalDateTime NOW = LocalDateTime.of(2026, 7, 11, 12, 0);
+
     @Mock
     private PostRepository postRepository;
 
     @Mock
     private JsonConverter jsonConverter;
+
+    @Mock
+    private TimeProvider timeProvider;
 
     @InjectMocks
     private AdminPostService adminPostService;
@@ -89,6 +96,7 @@ class AdminPostServiceTest {
             Post post = createPost(postId, false);
 
             when(postRepository.getByIdOrThrow(postId)).thenReturn(post);
+            when(timeProvider.now()).thenReturn(NOW);
 
             adminPostService.delete(postId, adminUserId);
 
@@ -152,7 +160,7 @@ class AdminPostServiceTest {
         ReflectionTestUtils.setField(post, "id", postId);
 
         if (deleted) {
-            post.softDelete(55L);
+            post.softDelete(55L, NOW);
         }
 
         return post;

--- a/src/test/java/com/dduru/gildongmu/admin/report/service/AdminReportServiceTest.java
+++ b/src/test/java/com/dduru/gildongmu/admin/report/service/AdminReportServiceTest.java
@@ -3,6 +3,7 @@ package com.dduru.gildongmu.admin.report.service;
 import com.dduru.gildongmu.admin.report.dto.request.AdminReportUpdateRequest;
 import com.dduru.gildongmu.admin.report.dto.response.AdminReportListResponse;
 import com.dduru.gildongmu.admin.report.dto.response.AdminReportResponse;
+import com.dduru.gildongmu.common.time.TimeProvider;
 import com.dduru.gildongmu.destination.domain.Destination;
 import com.dduru.gildongmu.post.domain.Post;
 import com.dduru.gildongmu.post.domain.enums.CompanionType;
@@ -30,6 +31,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -42,11 +44,16 @@ import static org.mockito.Mockito.when;
 @DisplayName("AdminReportService 테스트")
 class AdminReportServiceTest {
 
+    private static final LocalDateTime NOW = LocalDateTime.of(2026, 7, 11, 12, 0);
+
     @Mock
     private ReportRepository reportRepository;
 
     @Mock
     private UserRepository userRepository;
+
+    @Mock
+    private TimeProvider timeProvider;
 
     @InjectMocks
     private AdminReportService adminReportService;
@@ -88,13 +95,14 @@ class AdminReportServiceTest {
 
             when(reportRepository.findById(reportId)).thenReturn(Optional.of(report));
             when(userRepository.getByIdOrThrow(reviewerId)).thenReturn(reviewer);
+            when(timeProvider.now()).thenReturn(NOW);
 
             AdminReportResponse response = adminReportService.update(reportId, reviewerId, request);
 
             assertThat(response.status()).isEqualTo(ReportStatus.RESOLVED);
             assertThat(response.reviewerId()).isEqualTo(reviewerId);
             assertThat(response.reviewerName()).isEqualTo("관리자");
-            assertThat(response.reviewedAt()).isNotNull();
+            assertThat(response.reviewedAt()).isEqualTo(NOW);
             assertThat(response.reviewNote()).isEqualTo("검토 및 조치 완료");
         }
 

--- a/src/test/java/com/dduru/gildongmu/common/jwt/JwtTokenProviderTest.java
+++ b/src/test/java/com/dduru/gildongmu/common/jwt/JwtTokenProviderTest.java
@@ -1,11 +1,14 @@
 package com.dduru.gildongmu.common.jwt;
 
+import com.dduru.gildongmu.common.time.KoreaTime;
 import com.dduru.gildongmu.user.repository.UserRepository;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import java.time.Clock;
+import java.time.Instant;
 import java.util.Date;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -14,11 +17,16 @@ import static org.mockito.Mockito.mock;
 class JwtTokenProviderTest {
 
     private static final String SECRET = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==";
+    private static final Instant NOW = Instant.parse("2026-07-11T03:00:00Z");
+    private static final int ACCESS_EXPIRATION_MS = 60_000;
 
     private JwtTokenProvider createProvider() {
-        JwtTokenProvider provider = new JwtTokenProvider(mock(UserRepository.class));
+        JwtTokenProvider provider = new JwtTokenProvider(
+                mock(UserRepository.class),
+                Clock.fixed(NOW, KoreaTime.ZONE_ID)
+        );
         ReflectionTestUtils.setField(provider, "jwtSecret", SECRET);
-        ReflectionTestUtils.setField(provider, "jwtExpirationMs", 60_000);
+        ReflectionTestUtils.setField(provider, "jwtExpirationMs", ACCESS_EXPIRATION_MS);
         return provider;
     }
 
@@ -39,7 +47,8 @@ class JwtTokenProviderTest {
         assertThat(claims.getSubject()).isEqualTo("42");
         assertThat(claims.get("phone_number", String.class)).isEqualTo("01012345678");
         assertThat(claims.get("type", String.class)).isEqualTo("verification");
-        assertThat(claims.getExpiration()).isAfter(new Date());
+        assertThat(claims.getIssuedAt()).isEqualTo(Date.from(NOW));
+        assertThat(claims.getExpiration()).isEqualTo(Date.from(NOW.plusMillis(ACCESS_EXPIRATION_MS)));
     }
 
     @Test

--- a/src/test/java/com/dduru/gildongmu/common/jwt/JwtTokenProviderTest.java
+++ b/src/test/java/com/dduru/gildongmu/common/jwt/JwtTokenProviderTest.java
@@ -18,12 +18,13 @@ class JwtTokenProviderTest {
 
     private static final String SECRET = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==";
     private static final Instant NOW = Instant.parse("2026-07-11T03:00:00Z");
+    private static final Clock FIXED_CLOCK = Clock.fixed(NOW, KoreaTime.ZONE_ID);
     private static final int ACCESS_EXPIRATION_MS = 60_000;
 
     private JwtTokenProvider createProvider() {
         JwtTokenProvider provider = new JwtTokenProvider(
                 mock(UserRepository.class),
-                Clock.fixed(NOW, KoreaTime.ZONE_ID)
+                FIXED_CLOCK
         );
         ReflectionTestUtils.setField(provider, "jwtSecret", SECRET);
         ReflectionTestUtils.setField(provider, "jwtExpirationMs", ACCESS_EXPIRATION_MS);
@@ -39,10 +40,7 @@ class JwtTokenProviderTest {
         String token = provider.createVerificationToken(42L, "01012345678");
 
         // then
-        Claims claims = Jwts.parser()
-                .setSigningKey(SECRET)
-                .parseClaimsJws(token)
-                .getBody();
+        Claims claims = parseClaims(token);
 
         assertThat(claims.getSubject()).isEqualTo("42");
         assertThat(claims.get("phone_number", String.class)).isEqualTo("01012345678");
@@ -60,13 +58,18 @@ class JwtTokenProviderTest {
         String token = provider.createVerificationToken(null, "01099998888");
 
         // then
-        Claims claims = Jwts.parser()
-                .setSigningKey(SECRET)
-                .parseClaimsJws(token)
-                .getBody();
+        Claims claims = parseClaims(token);
 
         assertThat(claims.getSubject()).isEqualTo("01099998888");
         assertThat(claims.get("phone_number", String.class)).isEqualTo("01099998888");
         assertThat(claims.get("type", String.class)).isEqualTo("verification");
+    }
+
+    private Claims parseClaims(String token) {
+        return Jwts.parser()
+                .setClock(() -> Date.from(NOW.plusSeconds(30)))
+                .setSigningKey(SECRET)
+                .parseClaimsJws(token)
+                .getBody();
     }
 }

--- a/src/test/java/com/dduru/gildongmu/common/jwt/JwtTokenProviderTest.java
+++ b/src/test/java/com/dduru/gildongmu/common/jwt/JwtTokenProviderTest.java
@@ -1,6 +1,7 @@
 package com.dduru.gildongmu.common.jwt;
 
 import com.dduru.gildongmu.common.time.KoreaTime;
+import com.dduru.gildongmu.common.time.TimeProvider;
 import com.dduru.gildongmu.user.repository.UserRepository;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
@@ -24,7 +25,7 @@ class JwtTokenProviderTest {
     private JwtTokenProvider createProvider() {
         JwtTokenProvider provider = new JwtTokenProvider(
                 mock(UserRepository.class),
-                FIXED_CLOCK
+                new TimeProvider(FIXED_CLOCK)
         );
         ReflectionTestUtils.setField(provider, "jwtSecret", SECRET);
         ReflectionTestUtils.setField(provider, "jwtExpirationMs", ACCESS_EXPIRATION_MS);

--- a/src/test/java/com/dduru/gildongmu/destination/service/DestinationServiceTest.java
+++ b/src/test/java/com/dduru/gildongmu/destination/service/DestinationServiceTest.java
@@ -1,8 +1,10 @@
 package com.dduru.gildongmu.destination.service;
 
+import com.dduru.gildongmu.common.time.TimeProvider;
 import com.dduru.gildongmu.destination.domain.Destination;
 import com.dduru.gildongmu.destination.dto.DestinationInfo;
 import com.dduru.gildongmu.destination.repository.DestinationRepository;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -11,10 +13,12 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -22,8 +26,13 @@ import static org.mockito.Mockito.when;
 @DisplayName("DestinationService 테스트")
 class DestinationServiceTest {
 
+    private static final LocalDateTime NOW = LocalDateTime.of(2026, 7, 11, 12, 0);
+
     @Mock
     private DestinationRepository destinationRepository;
+
+    @Mock
+    private TimeProvider timeProvider;
 
     @InjectMocks
     private DestinationService destinationService;
@@ -31,6 +40,11 @@ class DestinationServiceTest {
     private static final List<String> FALLBACK_CITY_NAMES = List.of(
             "제주도", "부산", "강릉", "후쿠오카", "오사카", "서울", "도쿄", "교토", "방콕", "다낭"
     );
+
+    @BeforeEach
+    void setUpTimeProvider() {
+        lenient().when(timeProvider.now()).thenReturn(NOW);
+    }
 
     @DisplayName("집계 데이터가 없으면 추천 여행지 10개 순서대로 반환한다")
     @Test

--- a/src/test/java/com/dduru/gildongmu/journey/service/JourneyServiceTest.java
+++ b/src/test/java/com/dduru/gildongmu/journey/service/JourneyServiceTest.java
@@ -440,7 +440,7 @@ class JourneyServiceTest {
             User memberUser = createUser(memberUserId, "member");
             JourneyMember member = JourneyMember.createMember(journey, memberUser, LocalDateTime.now());
             Participation participation = Participation.createParticipation(post, memberUser, "같이 가고 싶어요.");
-            post.approveParticipation(participation);
+            post.approveParticipation(participation, LocalDateTime.of(2026, 5, 13, 16, 20));
             ChatRoom room = createGroupChatRoom(roomId, journey);
             ChatRoomMember chatRoomMember = ChatRoomMember.create(room, memberUser, ChatMemberRole.GUEST);
 

--- a/src/test/java/com/dduru/gildongmu/participation/domain/ParticipationTest.java
+++ b/src/test/java/com/dduru/gildongmu/participation/domain/ParticipationTest.java
@@ -14,12 +14,15 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @DisplayName("Participation 상태 전이 테스트")
 class ParticipationTest {
+
+    private static final LocalDateTime NOW = LocalDateTime.of(2026, 7, 11, 12, 0);
 
     @Nested
     @DisplayName("연락")
@@ -30,19 +33,19 @@ class ParticipationTest {
         void pendingChangesStatusAndTimestamp() {
             Participation participation = createParticipation();
 
-            participation.contact();
+            participation.contact(NOW);
 
             assertThat(participation.getStatus()).isEqualTo(ParticipationStatus.CONTACTING);
-            assertThat(participation.getContactedAt()).isNotNull();
+            assertThat(participation.getContactedAt()).isEqualTo(NOW);
         }
 
         @Test
         @DisplayName("REJECTED 상태에서 연락하면 예외가 발생한다")
         void rejectedThrowsException() {
             Participation participation = createParticipation();
-            participation.reject();
+            participation.reject(NOW);
 
-            assertThatThrownBy(participation::contact)
+            assertThatThrownBy(() -> participation.contact(NOW))
                     .isInstanceOf(BusinessException.class)
                     .extracting(e -> ((BusinessException) e).getErrorCode())
                     .isEqualTo(ErrorCode.PARTICIPATION_CONTACT_NOT_ALLOWED);
@@ -58,31 +61,31 @@ class ParticipationTest {
         void pendingChangesStatusAndTimestamp() {
             Participation participation = createParticipation();
 
-            participation.approve();
+            participation.approve(NOW);
 
             assertThat(participation.getStatus()).isEqualTo(ParticipationStatus.APPROVED);
-            assertThat(participation.getApprovedAt()).isNotNull();
+            assertThat(participation.getApprovedAt()).isEqualTo(NOW);
         }
 
         @Test
         @DisplayName("CONTACTING 상태에서도 승인할 수 있다")
         void contactingChangesStatusAndTimestamp() {
             Participation participation = createParticipation();
-            participation.contact();
+            participation.contact(NOW);
 
-            participation.approve();
+            participation.approve(NOW);
 
             assertThat(participation.getStatus()).isEqualTo(ParticipationStatus.APPROVED);
-            assertThat(participation.getApprovedAt()).isNotNull();
+            assertThat(participation.getApprovedAt()).isEqualTo(NOW);
         }
 
         @Test
         @DisplayName("APPROVED 상태에서 다시 승인하면 예외가 발생한다")
         void approvedThrowsException() {
             Participation participation = createParticipation();
-            participation.approve();
+            participation.approve(NOW);
 
-            assertThatThrownBy(participation::approve)
+            assertThatThrownBy(() -> participation.approve(NOW))
                     .isInstanceOf(BusinessException.class)
                     .extracting(e -> ((BusinessException) e).getErrorCode())
                     .isEqualTo(ErrorCode.PARTICIPATION_APPROVAL_NOT_ALLOWED);
@@ -98,31 +101,31 @@ class ParticipationTest {
         void pendingChangesStatusAndTimestamp() {
             Participation participation = createParticipation();
 
-            participation.reject();
+            participation.reject(NOW);
 
             assertThat(participation.getStatus()).isEqualTo(ParticipationStatus.REJECTED);
-            assertThat(participation.getRejectedAt()).isNotNull();
+            assertThat(participation.getRejectedAt()).isEqualTo(NOW);
         }
 
         @Test
         @DisplayName("CONTACTING 상태에서도 거절할 수 있다")
         void contactingChangesStatusAndTimestamp() {
             Participation participation = createParticipation();
-            participation.contact();
+            participation.contact(NOW);
 
-            participation.reject();
+            participation.reject(NOW);
 
             assertThat(participation.getStatus()).isEqualTo(ParticipationStatus.REJECTED);
-            assertThat(participation.getRejectedAt()).isNotNull();
+            assertThat(participation.getRejectedAt()).isEqualTo(NOW);
         }
 
         @Test
         @DisplayName("APPROVED 상태에서 거절하면 예외가 발생한다")
         void approvedThrowsException() {
             Participation participation = createParticipation();
-            participation.approve();
+            participation.approve(NOW);
 
-            assertThatThrownBy(participation::reject)
+            assertThatThrownBy(() -> participation.reject(NOW))
                     .isInstanceOf(BusinessException.class)
                     .extracting(e -> ((BusinessException) e).getErrorCode())
                     .isEqualTo(ErrorCode.PARTICIPATION_REJECTION_NOT_ALLOWED);

--- a/src/test/java/com/dduru/gildongmu/participation/service/ParticipationApplicantServiceTest.java
+++ b/src/test/java/com/dduru/gildongmu/participation/service/ParticipationApplicantServiceTest.java
@@ -27,6 +27,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -40,6 +41,8 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 @DisplayName("ParticipationApplicantService 테스트")
 class ParticipationApplicantServiceTest {
+
+    private static final LocalDateTime NOW = LocalDateTime.of(2026, 7, 11, 12, 0);
 
     @Mock
     private ParticipationRepository participationRepository;
@@ -156,9 +159,9 @@ class ParticipationApplicantServiceTest {
         switch (status) {
             case PENDING -> {
             }
-            case CONTACTING -> participation.contact();
-            case APPROVED -> participation.approve();
-            case REJECTED -> participation.reject();
+            case CONTACTING -> participation.contact(NOW);
+            case APPROVED -> participation.approve(NOW);
+            case REJECTED -> participation.reject(NOW);
         }
     }
 

--- a/src/test/java/com/dduru/gildongmu/participation/service/ParticipationCommandServiceTest.java
+++ b/src/test/java/com/dduru/gildongmu/participation/service/ParticipationCommandServiceTest.java
@@ -28,11 +28,12 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.util.Optional;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -43,6 +44,8 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 @DisplayName("ParticipationCommandService 테스트")
 class ParticipationCommandServiceTest {
+
+    private static final LocalDateTime NOW = LocalDateTime.of(2026, 7, 11, 12, 0);
 
     @Mock
     private PrivateChatRoomService privateChatRoomService;
@@ -95,6 +98,7 @@ class ParticipationCommandServiceTest {
 
             when(participationRepository.getByIdWithLockOrThrow(participationId)).thenReturn(participation);
             when(postRepository.getActiveByIdWithLockOrThrow(post.getId())).thenReturn(post);
+            when(timeProvider.now()).thenReturn(NOW);
             when(privateChatRoomService.createOrGetRoomWithLockedPost(ownerId, post, participantId))
                     .thenReturn(new PrivateChatRoomCreateResponse(roomId, true));
 
@@ -123,13 +127,14 @@ class ParticipationCommandServiceTest {
             Post post = createPost(100L, owner);
             Journey journey = createJourney(500L, post);
             Participation participation = createParticipation(participationId, post, participantId);
-            participation.contact();
+            participation.contact(NOW);
 
             Profile ownerProfile = mock(Profile.class);
             when(ownerProfile.getNickname()).thenReturn("호스트닉네임");
 
             when(participationRepository.getByIdWithLockOrThrow(participationId)).thenReturn(participation);
             when(postRepository.getActiveByIdWithLockOrThrow(post.getId())).thenReturn(post);
+            when(timeProvider.now()).thenReturn(NOW);
             when(journeyRepository.getByPostIdOrThrow(post.getId())).thenReturn(journey);
             when(profileRepository.findByUser_Id(ownerId)).thenReturn(Optional.of(ownerProfile));
             when(groupChatRoomService.inviteMemberOrGetRoom(ownerId, journey.getId(), participantId))

--- a/src/test/java/com/dduru/gildongmu/post/domain/PostTest.java
+++ b/src/test/java/com/dduru/gildongmu/post/domain/PostTest.java
@@ -16,12 +16,15 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @DisplayName("Post 테스트")
 class PostTest {
+
+    private static final LocalDateTime NOW = LocalDateTime.of(2026, 7, 11, 12, 0);
 
     @Nested
     @DisplayName("게시글 생성 검증")
@@ -123,7 +126,7 @@ class PostTest {
             Post post = createPost();
             Participation participation = createParticipation(post);
 
-            post.approveParticipation(participation);
+            post.approveParticipation(participation, NOW);
 
             assertThat(participation.isApproved()).isTrue();
             assertThat(post.getRecruitCount()).isEqualTo(2);
@@ -134,9 +137,9 @@ class PostTest {
         void contactingChangesStatusAndRecruitCount() {
             Post post = createPost();
             Participation participation = createParticipation(post);
-            participation.contact();
+            participation.contact(NOW);
 
-            post.approveParticipation(participation);
+            post.approveParticipation(participation, NOW);
 
             assertThat(participation.isApproved()).isTrue();
             assertThat(post.getRecruitCount()).isEqualTo(2);
@@ -147,9 +150,9 @@ class PostTest {
         void approvedThrowsAndKeepsRecruitCount() {
             Post post = createPost();
             Participation participation = createParticipation(post);
-            post.approveParticipation(participation);
+            post.approveParticipation(participation, NOW);
 
-            assertThatThrownBy(() -> post.approveParticipation(participation))
+            assertThatThrownBy(() -> post.approveParticipation(participation, NOW))
                     .isInstanceOf(BusinessException.class)
                     .extracting(e -> ((BusinessException) e).getErrorCode())
                     .isEqualTo(ErrorCode.PARTICIPATION_APPROVAL_NOT_ALLOWED);
@@ -161,9 +164,9 @@ class PostTest {
         void rejectedThrowsAndKeepsRecruitCount() {
             Post post = createPost();
             Participation participation = createParticipation(post);
-            participation.reject();
+            participation.reject(NOW);
 
-            assertThatThrownBy(() -> post.approveParticipation(participation))
+            assertThatThrownBy(() -> post.approveParticipation(participation, NOW))
                     .isInstanceOf(BusinessException.class)
                     .extracting(e -> ((BusinessException) e).getErrorCode())
                     .isEqualTo(ErrorCode.PARTICIPATION_APPROVAL_NOT_ALLOWED);
@@ -180,7 +183,7 @@ class PostTest {
         void approvedChangesStatusAndRecruitCount() {
             Post post = createPost();
             Participation participation = createParticipation(post);
-            post.approveParticipation(participation);
+            post.approveParticipation(participation, NOW);
 
             post.decrementRecruitCountIfApproved(participation);
 

--- a/src/test/java/com/dduru/gildongmu/post/service/PostServiceTest.java
+++ b/src/test/java/com/dduru/gildongmu/post/service/PostServiceTest.java
@@ -51,6 +51,7 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -68,6 +69,7 @@ import static org.mockito.Mockito.when;
 @DisplayName("PostService 테스트")
 class PostServiceTest {
     private static final LocalDate TODAY = LocalDate.of(2026, 5, 5);
+    private static final LocalDateTime NOW = TODAY.atTime(12, 0);
 
     @Mock private PostRepository postRepository;
     @Mock private UserRepository userRepository;
@@ -90,6 +92,7 @@ class PostServiceTest {
     @BeforeEach
     void setUpTimeProvider() {
         lenient().when(timeProvider.today()).thenReturn(TODAY);
+        lenient().when(timeProvider.now()).thenReturn(NOW);
         lenient().when(s3ImageUrlValidator.validateAndNormalize(anyString(), any(S3ImageDirectory.class)))
                 .thenAnswer(inv -> inv.getArgument(0));
     }

--- a/src/test/java/com/dduru/gildongmu/recommendation/service/PostRecommendationSelectionServiceTest.java
+++ b/src/test/java/com/dduru/gildongmu/recommendation/service/PostRecommendationSelectionServiceTest.java
@@ -62,6 +62,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 class PostRecommendationSelectionServiceTest {
 
     private static final LocalDate TODAY = LocalDate.of(2026, 7, 4);
+    private static final LocalDateTime NOW = TODAY.atTime(12, 0);
 
     @Autowired
     private UserRepository userRepository;
@@ -434,13 +435,13 @@ class PostRecommendationSelectionServiceTest {
 
     private void applyStatus(Participation participation, ParticipationStatus status) {
         if (status == ParticipationStatus.CONTACTING) {
-            participation.contact();
+            participation.contact(NOW);
         }
         if (status == ParticipationStatus.APPROVED) {
-            participation.approve();
+            participation.approve(NOW);
         }
         if (status == ParticipationStatus.REJECTED) {
-            participation.reject();
+            participation.reject(NOW);
         }
     }
 

--- a/src/test/java/com/dduru/gildongmu/user/service/UserServiceTest.java
+++ b/src/test/java/com/dduru/gildongmu/user/service/UserServiceTest.java
@@ -98,8 +98,7 @@ class UserServiceTest {
         // then
         assertThat(response.nickname()).startsWith("뚜비");
         verify(nicknameGenerator, times(10)).generateBaseNickname();
-        verify(nicknameGenerator, times(10)).generateRandomNumber();
+        verify(nicknameGenerator, times(11)).generateRandomNumber();
         verify(profileRepository, times(10)).existsByNickname(eq(duplicatedNickname));
     }
 }
-

--- a/src/test/java/com/dduru/gildongmu/verification/service/VerificationCodeServiceTest.java
+++ b/src/test/java/com/dduru/gildongmu/verification/service/VerificationCodeServiceTest.java
@@ -1,5 +1,6 @@
 package com.dduru.gildongmu.verification.service;
 
+import com.dduru.gildongmu.common.time.TimeProvider;
 import com.dduru.gildongmu.verification.dto.VerificationData;
 import com.dduru.gildongmu.verification.exception.*;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -27,6 +28,8 @@ class VerificationCodeServiceTest {
     private ValueOperations<String, String> valueOperations;
     @Spy
     private ObjectMapper objectMapper = new ObjectMapper();
+    @Mock
+    private TimeProvider timeProvider;
 
     @InjectMocks
     private VerificationCodeService verificationCodeService;


### PR DESCRIPTION
## 🔎 작업 내용
* 비즈니스 로직의 현재 날짜/시간 계산, JWT 발급/만료 시각 계산 을 `TimeProvider` 주입 기준으로 통일
* 참여 신청, 모집글, 신고, 인증번호, 관리자 조회 등 직접 `now()` 호출 제거
* 닉네임 fallback 생성 로직에서 현재 시간 의존성 제거
* 시간 고정 변경에 맞춰 도메인/서비스/JWT 테스트 기대값 보정

## ➕ 이슈 링크
* Closes #318

## 📸 스크린샷
없음

## 😎 리뷰 요구사항
> `TimeProvider`를 service에서 주입하고 domain에는 계산된 시간을 전달하는 방향이 일관적인지 확인 부탁드립니다.
> JWT 발급 시각을 `Clock` 기준으로 바꾼 부분이 기존 토큰 만료 정책과 동일하게 동작하는지 확인 부탁드립니다.

## 🧑‍💻 예정 작업
- 없음

## 📝 체크리스트
- [x] 브랜치 이름은 `feat/#이슈번호-개발내용` 형식으로 작성했는가?
- [x] 커밋 메시지는 `[#이슈번호] feat(scope): 커밋 내용` 형식으로 작성했는가?
- [x] PR 제목은 `feat(scope): PR 제목` 형식으로 작성했는가?
- [x] 작업 전 Issue를 작성했는가?
- [x] `dev` 브랜치로 병합을 요청했는가?
- [x] 불필요한 주석과 공백은 제거했는가?
- [x] 코드 리뷰어의 피드백을 반영했는가?
- [x] 테스트를 진행했는가?
- [x] 테스트 코드를 작성했는가?
